### PR TITLE
SYS-1774: Fix filename for PBCore 2.1 XML profile

### DIFF
--- a/install/profiles/xml/pbcore_2_1.xml
+++ b/install/profiles/xml/pbcore_2_1.xml
@@ -1,0 +1,7941 @@
+<?xml version="1.0" encoding="utf-8"?>
+<profile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="profile.xsd" useForConfiguration="1" base="base" infoUrl="http://providence.collectiveaccess.org/wiki/PBCoreInstallationProfile">
+  <profileName>[Standard] PBCore v2.1 REVISED 2019</profileName>
+  <profileDescription>Use this profile to set up a system implementing the PBCore v2.1 (http://www.pbcore.org) metadata standard</profileDescription>
+  <locales>
+    <locale lang="en" country="US">English</locale>
+  </locales>
+  <lists>
+    <list code="subjects_list" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Subject list</name>
+        </label>
+      </labels>
+      <items/>
+    </list>
+    <list code="object_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object Source</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="internal" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Our collection</name_singular>
+              <name_plural>Our collections</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="external" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>External collection</name_singular>
+              <name_plural>External collections</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_types" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Object Types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="audio" enabled="0" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio</name_singular>
+              <name_plural>Audio</name_plural>
+            </label>
+          </labels>
+          <items>
+            <item idno="audio_analog" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Analog Audio</name_singular>
+                  <name_plural>Analog Audio</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="audio_digital" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Digital Audio</name_singular>
+                  <name_plural>Digital Audio</name_plural>
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="moving_image" enabled="0" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Moving Image</name_singular>
+              <name_plural>Moving Images</name_plural>
+            </label>
+          </labels>
+          <items>
+            <item idno="moving_analog" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Analog Moving Image</name_singular>
+                  <name_plural>Analog Moving Images</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="moving_digital" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Digital Moving Image</name_singular>
+                  <name_plural>Digital Moving Images</name_plural>
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+      </items>
+    </list>
+    <list code="storage_location_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Storage location types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="campus" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>campus</name_singular>
+              <name_plural>campuses</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="building" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>building</name_singular>
+              <name_plural>buildings</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="floor" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>floor</name_singular>
+              <name_plural>floors</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="room" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>room</name_singular>
+              <name_plural>rooms</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="cabinet" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>cabinet</name_singular>
+              <name_plural>cabinets</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="drawer" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>drawer</name_singular>
+              <name_plural>drawers</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="shelf" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>shelf</name_singular>
+              <name_plural>shelves</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="occurrence_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Occurrence Types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="intellectual_content" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Intellectual Content</name_singular>
+              <name_plural>Intellectual Content</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="place_hierarchies" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Place hierarchies</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="pbcore" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>PBCore Coverage Authority</name_singular>
+              <name_plural>PBCore Coverage Authority</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="place_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Place sources</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="pbcore" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Coverage</name_singular>
+              <name_plural>Coverage</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="collection_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Collection types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="local" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Local collection</name_singular>
+              <name_plural>Local collections</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="external" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>External collection</name_singular>
+              <name_plural>External collections</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="entity_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Entity types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="individual" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>individual</name_singular>
+              <name_plural>individuals</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="organization" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>organization</name_singular>
+              <name_plural>organizations</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="family" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>family</name_singular>
+              <name_plural>families</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <!-- REVISED 2013 -->
+    <list code="pbcore_title_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Title Types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Album</name_singular>
+              <name_plural>Albums</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Collection</name_singular>
+              <name_plural>Collection</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Series</name_singular>
+              <name_plural>Series</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Episode</name_singular>
+              <name_plural>Episode</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Program</name_singular>
+              <name_plural>Program</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Segment</name_singular>
+              <name_plural>Segment</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option7" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Clip</name_singular>
+              <name_plural>Clip</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option8" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Miniseries</name_singular>
+              <name_plural>Miniseries</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option9" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Subseries</name_singular>
+              <name_plural>Subseries</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="pbcore_coverage_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Coverage Type</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="spatial" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Spatial</name_singular>
+              <name_plural>Spatial</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="temporal" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Temporal</name_singular>
+              <name_plural>Temporal</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="pbcore_description_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Description Type</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="none" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="abstract" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Abstract</name_singular>
+              <name_plural>Abstract</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="awards" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Awards</name_singular>
+              <name_plural>Awards</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="chapter" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Chapter</name_singular>
+              <name_plural>Chapter</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="collection" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Collection</name_singular>
+              <name_plural>Collection</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="comments" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Comments</name_singular>
+              <name_plural>Comments</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="description" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Description</name_singular>
+              <name_plural>Description</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="episode" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Episode Description</name_singular>
+              <name_plural>Episode Description</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="event" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Event</name_singular>
+              <name_plural>Event</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="excerpt" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Excerpt</name_singular>
+              <name_plural>Excerpt</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="item" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Item</name_singular>
+              <name_plural>Item</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="movement" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Movement</name_singular>
+              <name_plural>Movement</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="number" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Number</name_singular>
+              <name_plural>Number</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="playlist" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Playlist</name_singular>
+              <name_plural>Playlist</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="program" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Program</name_singular>
+              <name_plural>Program</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="reviews" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Reviews</name_singular>
+              <name_plural>Reviews</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="rundown" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Rundown</name_singular>
+              <name_plural>Rundown</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="script" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Script</name_singular>
+              <name_plural>Script</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="segment" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Segment</name_singular>
+              <name_plural>Segment</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="series" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Series</name_singular>
+              <name_plural>Series</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="shotlist" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Shot List</name_singular>
+              <name_plural>Shot List</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="song" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Song</name_singular>
+              <name_plural>Song</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="story" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Story</name_singular>
+              <name_plural>Story</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="summary" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Summary</name_singular>
+              <name_plural>Summary</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="transcript" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Transcript</name_singular>
+              <name_plural>Transcript</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="pbcore_relation_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Relation Type</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Has Format</name_singular>
+              <name_plural>Has Format</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Is Format Of</name_singular>
+              <name_plural>Is Format Of</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Has Part</name_singular>
+              <name_plural>Has Part</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Is Part Of</name_singular>
+              <name_plural>Is Part Of</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Has Version</name_singular>
+              <name_plural>Has Version</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Is Version Of</name_singular>
+              <name_plural>Is Version Of</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option7" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>References</name_singular>
+              <name_plural>References</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option8" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Is Referenced By</name_singular>
+              <name_plural>Is Referenced By</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="option9" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Has Derivative</name_singular>
+              <name_plural>Derived From</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="instantiation_physical_types_moving" hierarchical="0" system="0" vocabulary="0" defaultSort="1">
+      <labels>
+        <label locale="en_US">
+          <name>Physical Formats For Moving Images</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" rank="1" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="film_types" rank="2" enabled="0" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>FILM</name_singular>
+              <name_plural>FILM</name_plural>
+            </label>
+          </labels>
+          <items>
+            <item idno="option2"  rank="3" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Film</name_singular>
+                  <name_plural>Film</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="option3"  rank="4" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>8mm film</name_singular>
+                  <name_plural>8mm film</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="option4" rank="5" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>9.5mm film</name_singular>
+                  <name_plural>9.5mm film</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="option5" rank="6" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Super 8mm film</name_singular>
+                  <name_plural>Super 8mm film</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="option6" rank="7" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>16mm film</name_singular>
+                  <name_plural>16mm film</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="option7" rank="8" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Super 16mm film</name_singular>
+                  <name_plural>Super 16mm film</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="option8" rank="9" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>22mm film</name_singular>
+                  <name_plural>22mm film</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="option9" rank="10" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>28mm film</name_singular>
+                  <name_plural>28mm film</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="option10" rank="11" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>35mm film</name_singular>
+                  <name_plural>35mm film</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="option11" rank="12" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>70mm film</name_singular>
+                  <name_plural>70mm film</name_plural>
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="video_types" rank="13" enabled="0" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>VIDEO</name_singular>
+              <name_plural>VIDEO</name_plural>
+            </label>
+          </labels>
+          <items>
+            <item idno="videocassette" rank="14" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Videocassette</name_singular>
+                  <name_plural>Videocassette</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="open_reel_videotape" rank="15" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Open reel videotape</name_singular>
+                  <name_plural>Open reel videotape</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="optical_video_disc" rank="16" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Optical video disc</name_singular>
+                  <name_plural>Optical video disc</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape" rank="17" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape</name_singular>
+                  <name_plural>1 inch videotape</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_1" rank="18" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: MVC-10</name_singular>
+                  <name_plural>1 inch videotape: MVC-10</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_2" rank="19" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: PI-3V</name_singular>
+                  <name_plural>1 inch videotape: PI-3V</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_3" rank="20" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: EV-200</name_singular>
+                  <name_plural>1 inch videotape: EV-200</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_4" rank="21" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: EL-3400</name_singular>
+                  <name_plural>1 inch videotape: EL-3400</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_5" rank="22" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: IVC-700</name_singular>
+                  <name_plural>1 inch videotape: IVC-700</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_6" rank="23" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: IVC-800</name_singular>
+                  <name_plural>1 inch videotape: IVC-800</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_7" rank="24" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: IVC-900</name_singular>
+                  <name_plural>1 inch videotape: IVC-900</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_8" rank="25" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: UV-340</name_singular>
+                  <name_plural>1 inch videotape: UV-340</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_9" rank="26" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: EV-210</name_singular>
+                  <name_plural>1 inch videotape: EV-210</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_10" rank="27" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: SMPTE Type A</name_singular>
+                  <name_plural>1 inch videotape: SMPTE Type A</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_11" rank="28" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: SMPTE Type B</name_singular>
+                  <name_plural>1 inch videotape: SMPTE Type B</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_12" rank="29" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: SMPTE Type C</name_singular>
+                  <name_plural>1 inch videotape: SMPTE Type C</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_13" rank="30" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: BVH-1000</name_singular>
+                  <name_plural>1 inch videotape: BVH-100</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_14" rank="31" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: HDV-1000</name_singular>
+                  <name_plural>1 inch videotape: HDV-1000</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_15" rank="32" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: HDD-1000</name_singular>
+                  <name_plural>2 inch videotape: HDD-1000</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape" rank="33" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape</name_singular>
+                  <name_plural>1/2 inch videotape</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_1" rank="34" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: CV</name_singular>
+                  <name_plural>1/2 inch videotape: CV</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_2" rank="35" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: EIAJ Type 1</name_singular>
+                  <name_plural>1/2 inch videotape: EIAJ Type 1</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_3" rank="11" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: Hawkeye</name_singular>
+                  <name_plural>1/2 inch videotape: Hawkeye</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_4" rank="36" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: Recam</name_singular>
+                  <name_plural>1/2 inch videotape: Recam</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_5" rank="37" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: V200</name_singular>
+                  <name_plural>1/2 inch videotape: V200</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_6" rank="38" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: VCR</name_singular>
+                  <name_plural>1/2 inch videotape: VCR</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="quarter_inch_videotape" rank="39" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/4 inch videotape</name_singular>
+                  <name_plural>1/4 inch videotape</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape" rank="40" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape</name_singular>
+                  <name_plural>2 inch videotape</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_1" rank="41" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: Quadruplex</name_singular>
+                  <name_plural>2 inch videotape: Quadruplex</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_2" rank="42" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: Octaplex</name_singular>
+                  <name_plural>2 inch videotape: Octaplex</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_3" rank="43" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: VR-1500</name_singular>
+                  <name_plural>2 inch videotape: VR-1500</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_4" rank="44" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: VR-1600</name_singular>
+                  <name_plural>2 inch videotape: VR-1600</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_5" rank="45" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: IVC-9000</name_singular>
+                  <name_plural>2 inch videotape: IVC-9000</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_6" rank="46" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: Helical SV-201</name_singular>
+                  <name_plural>2 inch videotape: Helical SV-201</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_7" rank="47" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: ACR 25</name_singular>
+                  <name_plural>2 inch videotape: ACR 25</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="betacam" rank="48" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betacam</name_singular>
+                  <name_plural>Betacam</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="betacam_1" rank="49" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betacam: SP</name_singular>
+                  <name_plural>Betacam: SP</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="betamax" rank="50" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betamax</name_singular>
+                  <name_plural>Betamax</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="betamax_1" rank="51" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betamax: Hi-Fi</name_singular>
+                  <name_plural>Betamax: Hi-Fi</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="betamax_2" rank="52" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betamax: ED</name_singular>
+                  <name_plural>Betamax: ED</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="betamax_3" rank="53" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betamax: Super</name_singular>
+                  <name_plural>Betamax: Super</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="blu_ray_disc" rank="54" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Blu-ray disc</name_singular>
+                  <name_plural>Blu-ray disc</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="catrivision" rank="12" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Catrivision</name_singular>
+                  <name_plural>Catrivision</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="d1" rank="55" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D1</name_singular>
+                  <name_plural>D1</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="d2" rank="56" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D2</name_singular>
+                  <name_plural>D2</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="d3" rank="57" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D3</name_singular>
+                  <name_plural>D3</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="d5" rank="58" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D5</name_singular>
+                  <name_plural>D5</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="d5_1" rank="59" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D5: HD</name_singular>
+                  <name_plural>D5: HD</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="d6" rank="60" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D6</name_singular>
+                  <name_plural>D6</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="d9" rank="61" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D9</name_singular>
+                  <name_plural>D9</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="d9_1" rank="62" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D9: HD</name_singular>
+                  <name_plural>D9: HD</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="dct" rank="63" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DCT</name_singular>
+                  <name_plural>DCT</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="digital_betacam" rank="64" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Digital Betacam</name_singular>
+                  <name_plural>Digital Betacam</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="digital8" rank="65" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Digital8</name_singular>
+                  <name_plural>Digital8</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="dv" rank="66" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DV</name_singular>
+                  <name_plural>DV</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcam" rank="67" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCAM</name_singular>
+                  <name_plural>DVCAM</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcpro" rank="68" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCPRO</name_singular>
+                  <name_plural>DVCPRO</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcpro_1" rank="69" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCPRO: 25</name_singular>
+                  <name_plural>DVCPRO: 25</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcpro_2" rank="70" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCPRO: 50</name_singular>
+                  <name_plural>DVCPRO: 50</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcpro_3" rank="71" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCPRO: Progressive</name_singular>
+                  <name_plural>DVCPRO: Progressive</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcpro_4" rank="72" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCPRO: HD</name_singular>
+                  <name_plural>DVCPRO: HD</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd" rank="73" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD</name_singular>
+                  <name_plural>DVD</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd_1" rank="74" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD: DVD+R</name_singular>
+                  <name_plural>DVD: DVD+R</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd_2" rank="75" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD: DVD+R DL</name_singular>
+                  <name_plural>DVD: DVD+R DL</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd_3" rank="76" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD: DVD-R</name_singular>
+                  <name_plural>DVD: DVD-R</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd_4" rank="77" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD: DVD-RW</name_singular>
+                  <name_plural>DVD: DVD-RW</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd_5" rank="78" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD: DVD+RW</name_singular>
+                  <name_plural>DVD: DVD+RW</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="eiaj" rank="79" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>EIAJ</name_singular>
+                  <name_plural>EIAJ</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="evd" rank="80" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>EVD</name_singular>
+                  <name_plural>EVD</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="hdcam" rank="81" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>HDCAM</name_singular>
+                  <name_plural>HDCAM</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="hdcam_1" rank="82" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>HDCAM: SR</name_singular>
+                  <name_plural>HDCAM: SR</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="hdv" rank="83" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>HDV</name_singular>
+                  <name_plural>HDV</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="hi8" rank="84" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Hi8</name_singular>
+                  <name_plural>Hi8</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="laserdisc" rank="85" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>LaserDisc</name_singular>
+                  <name_plural>LaserDisc</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="laserdisc_1" rank="86" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>LaserDisc: CAV</name_singular>
+                  <name_plural>LaserDisc: CAV</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="laserdisc_2" rank="87" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>LaserDisc: CLV</name_singular>
+                  <name_plural>LaserDisc: CLV</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="laserdisc_3" rank="88" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>LaserDisc: CAA</name_singular>
+                  <name_plural>LaserDisc: CAA</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="mii" rank="89" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>MII</name_singular>
+                  <name_plural>MII</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="minidv" rank="90" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>MiniDV</name_singular>
+                  <name_plural>MiniDV</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="super_video_cd" rank="91" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Super Video CD</name_singular>
+                  <name_plural>Super Video CD</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="u_matic" rank="92" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>U-matic</name_singular>
+                  <name_plural>U-matic</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="u_matic_1" rank="93" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>U-matic: S</name_singular>
+                  <name_plural>U-matic: S</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="u_matic_2" rank="94" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>U-matic: SP</name_singular>
+                  <name_plural>U-matic: SP</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="universal_media_disc" rank="95" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Universal Media Disc</name_singular>
+                  <name_plural>Universal Media Disc</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="v_cord" rank="96" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>V-Cord</name_singular>
+                  <name_plural>V-Cord</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="v_cord_1" rank="97" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>V-Cord: I</name_singular>
+                  <name_plural>V-Cord: I</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="v_cord_2" rank="98" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>V-Cord: II</name_singular>
+                  <name_plural>V-Cord: II</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="vhs" rank="99" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>VHS</name_singular>
+                  <name_plural>VHS</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="vhs_1" rank="100" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>VHS: S-VHS</name_singular>
+                  <name_plural>VHS: S-VHS</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="vhs_2" rank="101" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>VHS: W-VHS</name_singular>
+                  <name_plural>VHS: W-VHS</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="vhs_3" rank="102" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>VHS: VHS-C</name_singular>
+                  <name_plural>VHS: VHS-C</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="video8" rank="103" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Video8</name_singular>
+                  <name_plural>Video8</name_plural>
+                </label>
+              </labels>
+            </item>
+            <item idno="vx" rank="104" enabled="1" default="0">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>VX</name_singular>
+                  <name_plural>VX</name_plural>
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+      </items>
+    </list>
+    <list code="instantiation_physical_types_audio" hierarchical="0" system="0" vocabulary="0" defaultSort="1">
+      <labels>
+        <label locale="en_US">
+          <name>Physical Formats For Audio</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" rank="1" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="open_reel_audiotape" rank="2" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Open reel audiotape</name_singular>
+              <name_plural>Open reel audiotape</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="grooved_analog_disc" rank="3" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Grooved analog disc</name_singular>
+              <name_plural>Grooved analog disc</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="one_inch_audio_tape" rank="4" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1 inch audio tape</name_singular>
+              <name_plural>1 inch audio tape</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="half_inch_audio_tape" rank="5" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1/2 inch audio tape</name_singular>
+              <name_plural>1/2 inch audio tape</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="quarter_inch_audio_cassette" rank="6" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1/4 inch audio cassette</name_singular>
+              <name_plural>1/4 inch audio cassette</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="quarter_inch_audio_tape" rank="7" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1/4 inch audio tape</name_singular>
+              <name_plural>1/4 inch audio tape</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="two_inch_audio_tape" rank="8" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>2 inch audio tape</name_singular>
+              <name_plural>2 inch audio tape</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="8_track" rank="9" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>8-track</name_singular>
+              <name_plural>8-track</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="aluminum_disc" rank="10" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Aluminum disc</name_singular>
+              <name_plural>Aluminum disc</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cassette" rank="11" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio cassette</name_singular>
+              <name_plural>Audio cassette</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cassette_1" rank="12" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio cassette: Type I</name_singular>
+              <name_plural>Audio cassette: Type I</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cassette_2" rank="13" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio cassette: Type II</name_singular>
+              <name_plural>Audio cassette: Type II</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cassette_3" rank="14" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio cassette: Type III</name_singular>
+              <name_plural>Audio cassette: Type III</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cassette_4" rank="15" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio cassette: Type IV</name_singular>
+              <name_plural>Audio cassette: Type IV</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cd" rank="16" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio CD</name_singular>
+              <name_plural>Audio CD</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="dat" rank="17" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DAT</name_singular>
+              <name_plural>DAT</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="dds" rank="18" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DDS</name_singular>
+              <name_plural>DDS</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="dtrs" rank="19" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DTRS</name_singular>
+              <name_plural>DTRS</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="dtrs_1" rank="20" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DTRS: DA-88</name_singular>
+              <name_plural>DTRS: DA-88</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="film_audio" rank="21" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Film</name_singular>
+              <name_plural>Film</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="flexi_disc" rank="21" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Flexi Disc</name_singular>
+              <name_plural>Flexi Disc</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="grooved_dictabelt" rank="22" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Grooved Dictabelt</name_singular>
+              <name_plural>Grooved Dictabelt</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="lacquer_disc" rank="23" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Lacquer disc</name_singular>
+              <name_plural>Lacquer disc</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="magnetic_dictabelt" rank="24" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Magnetic Dictabelt</name_singular>
+              <name_plural>Magnetic Dictabelt</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="mini_cassette" rank="25" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mini-cassette</name_singular>
+              <name_plural>Mini-cassette</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="pcm_betamax" rank="26" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>PCM Betamax</name_singular>
+              <name_plural>PCM Betamax</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="pcm_u_matic" rank="27" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>PCM U-matic</name_singular>
+              <name_plural>PCM U-matic</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="pcm_vhs" rank="28" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>PCM VHS</name_singular>
+              <name_plural>PCM VHS</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="piano_roll" rank="29" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Piano roll</name_singular>
+              <name_plural>Piano roll</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="plastic_cylinder" rank="30" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Plastic cylinder</name_singular>
+              <name_plural>Plastic cylinder</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="shellac_disc" rank="31" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Shellac disc</name_singular>
+              <name_plural>Shellac disc</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="super_audio_cd" rank="32" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Super Audio CD</name_singular>
+              <name_plural>Super Audio CD</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="vinyl_recording" rank="33" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Vinyl recording</name_singular>
+              <name_plural>Vinyl recording</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="vinyl_recording_1" rank="34" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Vinyl recording: EP</name_singular>
+              <name_plural>Vinyl recording: EP</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="vinyl_recording_2" rank="35" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Vinyl recording: LP</name_singular>
+              <name_plural>Vinyl recording: LP</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="vinyl_recording_3" rank="36" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Vinyl recording: 45</name_singular>
+              <name_plural>Vinyl recording: 45</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="vinyl_recording_4" rank="37" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Vinyl recording: 78</name_singular>
+              <name_plural>Vinyl recording: 78</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="wax_cylinder" rank="38" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Wax cylinder</name_singular>
+              <name_plural>Wax cylinder</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="wire_recording" rank="39" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Wire recording</name_singular>
+              <name_plural>Wire recording</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="instantiation_generations_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Generations Types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="a_b_rolls" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>A-B rolls</name_singular>
+              <name_plural>A-B rolls</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="answer_print" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Answer print</name_singular>
+              <name_plural>Answer print</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="composite" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Composite</name_singular>
+              <name_plural>Composite</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="copy" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Copy</name_singular>
+              <name_plural>Copy</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="copy_access" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Copy: Access</name_singular>
+              <name_plural>Copy: Access</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="dub" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Dub</name_singular>
+              <name_plural>Dub</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="duplicate" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Duplicate</name_singular>
+              <name_plural>Duplicate</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="fine_cut" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Fine cut</name_singular>
+              <name_plural>Fine cut</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="intermediate" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Intermediate</name_singular>
+              <name_plural>Intermediate</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="interpositive" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Interpositive</name_singular>
+              <name_plural>Interpositive</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="internegative" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Internegative</name_singular>
+              <name_plural>Internegative</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="color_reversal_intermediate" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Color reversal intermediate</name_singular>
+              <name_plural>Color reversal intermediate</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="kinescope" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Kinescope</name_singular>
+              <name_plural>Kinescope</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="line_cut" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Line cut</name_singular>
+              <name_plural>Line cut</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="magnetic_track" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Magnetic Track</name_singular>
+              <name_plural>Magnetic Track</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="master" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Master</name_singular>
+              <name_plural>Master</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="master_distribution" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Master: distribution</name_singular>
+              <name_plural>Master: distribution</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="master_production" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Master: production</name_singular>
+              <name_plural>Master: production</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="mezzanine" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mezzanine</name_singular>
+              <name_plural>Mezzanine</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="negative" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Negative</name_singular>
+              <name_plural>Negative</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="optical_track" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Optical Track</name_singular>
+              <name_plural>Optical Track</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="original" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Original</name_singular>
+              <name_plural>Original</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="original_footage" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Original footage</name_singular>
+              <name_plural>Original footage</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="original_recording" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Original recording</name_singular>
+              <name_plural>Original recording</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="outs_and_trims" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Outs and trims</name_singular>
+              <name_plural>Outs and trims</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="picture_lock" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Picture lock</name_singular>
+              <name_plural>Picture lock</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="positive" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Positive</name_singular>
+              <name_plural>Positive</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="preservation" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Preservation</name_singular>
+              <name_plural>Preservation</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="print" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Print</name_singular>
+              <name_plural>Print</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="proxy_file" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Proxy file</name_singular>
+              <name_plural>Proxy file</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="reversal" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Reversal</name_singular>
+              <name_plural>Reversal</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="rough_cut" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Rough cut</name_singular>
+              <name_plural>Rough cut</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="separation_master" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Separation master</name_singular>
+              <name_plural>Separation master</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="stock_footage" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Stock footage</name_singular>
+              <name_plural>Stock footage</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="submaster" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Submaster</name_singular>
+              <name_plural>Submaster</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="transcription_disc" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Transcription disc</name_singular>
+              <name_plural>Transcription disc</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="work_print" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Work print</name_singular>
+              <name_plural>Work print</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="work_tapes" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Work tapes</name_singular>
+              <name_plural>Work tapes</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="work_track" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Work track</name_singular>
+              <name_plural>Work track</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="pbcore_dates_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>PBCore Date types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="accepted" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>accepted</name_singular>
+              <name_plural>accepted</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="available" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>available</name_singular>
+              <name_plural>available</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="available_end" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>available end</name_singular>
+              <name_plural>available end</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="available_start" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>available start</name_singular>
+              <name_plural>available start</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="broadcast" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>broadcast</name_singular>
+              <name_plural>broadcast</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="captured" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>captured</name_singular>
+              <name_plural>captured</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="created" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>created</name_singular>
+              <name_plural>created</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="copyright" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>copyright</name_singular>
+              <name_plural>copyright</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="distributed" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>distributed</name_singular>
+              <name_plural>distributed</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="dubbed" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>dubbed</name_singular>
+              <name_plural>dubbed</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="edited" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>edited</name_singular>
+              <name_plural>edited</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="encoded" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>encoded</name_singular>
+              <name_plural>encoded</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="encrypted" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>encrypted</name_singular>
+              <name_plural>encrypted</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="event" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>event</name_singular>
+              <name_plural>event</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="ingested" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>ingested</name_singular>
+              <name_plural>ingested</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="issued" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>issued</name_singular>
+              <name_plural>issued</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="licensed" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>licensed</name_singular>
+              <name_plural>licensed</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="mastered" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>mastered</name_singular>
+              <name_plural>mastered</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="migrated" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>migrated</name_singular>
+              <name_plural>migrated</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="mixed" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>mixed</name_singular>
+              <name_plural>mixed</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="modified" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>modified</name_singular>
+              <name_plural>modified</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="normalized" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>normalized</name_singular>
+              <name_plural>normalized</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="performed" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>performed</name_singular>
+              <name_plural>performed</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="podcast" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>podcast</name_singular>
+              <name_plural>podcast</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="published" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>published</name_singular>
+              <name_plural>published</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="released" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>released</name_singular>
+              <name_plural>released</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="restored" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>restored</name_singular>
+              <name_plural>restored</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="revised" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>revised</name_singular>
+              <name_plural>revised</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="tranferred" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>transferred</name_singular>
+              <name_plural>transferred</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="valid" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>valid</name_singular>
+              <name_plural>valid</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="validated" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>validated</name_singular>
+              <name_plural>validated</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="webcast" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>webcast</name_singular>
+              <name_plural>webcast</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="instantiation_media_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Media Types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="audio" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio</name_singular>
+              <name_plural>Audio</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="moving_image" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Moving Image</name_singular>
+              <name_plural>Moving Image</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+        <list code="asset_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Asset Type</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="album_type" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Album</name_singular>
+              <name_plural>Album</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="animation_type" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Animation</name_singular>
+              <name_plural>Animation</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="clip_type" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Clip</name_singular>
+              <name_plural>Clip</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="collection_type" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Collection</name_singular>
+              <name_plural>Collection</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="compilation_type" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Compilation</name_singular>
+              <name_plural>Compilation</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="episode_type" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Episode</name_singular>
+              <name_plural>Episode</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="miniseries_type" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Miniseries</name_singular>
+              <name_plural>Miniseries</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="program_type" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Program</name_singular>
+              <name_plural>Program</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="promo_type" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Promo</name_singular>
+              <name_plural>Promo</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="raw_footage_type" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Raw Footage</name_singular>
+              <name_plural>Raw Footage</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="segment_clip" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Segment</name_singular>
+              <name_plural>Segment</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="series_clip" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Series</name_singular>
+              <name_plural>Series</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="season_clip" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Season</name_singular>
+              <name_plural>Season</name_plural>
+            </label>
+          </labels>
+        </item>
+        <item idno="subseries_clip" enabled="1" default="0">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Subseries</name_singular>
+              <name_plural>Subseries</name_plural>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+  </lists>
+  <elementSets>
+    <metadataElement code="lcshFull" datatype="LCSH">
+      <labels>
+        <label locale="en_US">
+          <name>Library of Congress Subject Headings</name>
+          <description>Library of Congress Subject headings describing this object. To add a new heading simply type the first few letters of the heading and choose the desired one from the displayed list of possible matches.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">60</setting>
+        <setting name="fieldHeight">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="ca_objects">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="ca_object_representations">
+          <table>ca_object_representations</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="ca_entities">
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="ca_places">
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="ca_occurrences">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="ca_collections">
+          <table>ca_collections</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="geonames" datatype="GeoNames">
+      <labels>
+        <label locale="en_US">
+          <name>GeoNames</name>
+          <description>A Geographic lookup that takes search text, passes it to the GeoNames search service and provides a dropdown with search results (ordered by score). Selected geoname is stored as both text (name, country, continent and ID) and the service URL identifier.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">1</setting>
+        <setting name="maxChars">65535</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="ca_objects">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="ca_places">
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="ca_occurrences">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="ca_collections">
+          <table>ca_collections</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="georeference" datatype="Geocode">
+      <labels>
+        <label locale="en_US">
+          <name>Georeference</name>
+          <description>Coordinates documenting the location of the item</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">80</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">1</setting>
+        <setting name="maxChars">65535</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="ca_objects">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="ca_places">
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="description" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Description</name>
+          <description>Narrative description. This is the primary text used to document the item.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="r2">
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="r3">
+          <table>ca_occurrences</table>
+          <type>event</type>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="r4">
+          <table>ca_collections</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="r5">
+          <table>ca_storage_locations</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="r6">
+          <table>ca_object_lots</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="caption" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Caption</name>
+          <description>Short descriptive caption for item.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">2</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_object_representations</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="r2">
+          <table>ca_representation_annotations</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="r3">
+          <table>ca_set_items</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="address" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Address</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <elements>
+        <metadataElement code="line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Address line 1</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="address1" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Address line 1</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">70</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Address line 1</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="address2" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Address line 2</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">70</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="line3" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Address line 3</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="city" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>City</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">20</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="stateprovince" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>State</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">15</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="postalcode" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Postal code</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">10</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="country" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Country</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">15</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="ca_entities">
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="ca_places">
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="telephone" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Telephone/fax</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">65535</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="ca_entities">
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="ca_places">
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="email" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Email address</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">65535</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="ca_entities">
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="ca_places">
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="biography" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Description</name>
+          <description>Narrative biography for entity. This is the primary text used to document the entity.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="biography_source" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Source of description</name>
+          <description>Source of entity biography. This should be a formal citation if possible. For informal sources a narrative description is acceptable.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">3</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="institution" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Institution</name>
+          <description>Name of the institution to which the collection belongs.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_collections</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <!-- REVISED 2013 -->
+    <metadataElement code="pbcoreExtension" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Extension</name>
+          <description>pbcoreExtension is an extension element. Use this element as a wrapper containing a specific element from another standard.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/pbcoreextension</documentationUrl>
+      <settings/>
+      <elements>
+        <metadataElement code="extension_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Extension element</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="extensionElement" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Extension element</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/extensionelement</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="extension_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Extension value</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="extensionValue" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Extension value</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/extensionvalue</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="extension_line3" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Extension authority used</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="extensionAuthority" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Extension authority used</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/extensionauthorityused</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="r2">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreCoverage" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Coverage</name>
+          <description>coverage refers to either the geographic location or the time period covered by the asset’s intellectual content. For geographic locations (‘spatial’ descriptors), it is expressed by keywords such as place names (e.g. ‘Alaska’ or ‘Washington, DC’), numeric coordinates or geo-spatial data. For time-based events (‘temporal’ descriptors), it is expressed by using a date, period, era, or time-based event that is portrayed or covered in the intellectual content (e.g. ‘2007’ or ‘Victorian Era’). The PBCore metadata element coverage houses the actual spatial or temporal keywords. The companion element coverageType is used to identify the type of keywords that are being used.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/pbcorecoverage</documentationUrl>
+      <elements>
+        <metadataElement code="pbCoverage_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Coverage</name>
+            </label>
+          </labels>
+          <documentationUrl>http://pbcore.org/elements/coverage</documentationUrl>
+          <settings/>
+          <elements>
+            <metadataElement code="pbCoverage_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Coverage</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/coverage</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+              </settings>
+            </metadataElement>
+          </elements> 
+        </metadataElement>
+        <metadataElement code="pbCoverage_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Coverage Details</name>
+            </label>
+          </labels>
+          <documentationUrl>http://pbcore.org/elements/coverage</documentationUrl>
+          <settings/>
+          <elements>
+            <metadataElement code="coverageType" datatype="List" list="pbcore_coverage_types">
+              <labels>
+                <label locale="en_US">
+                  <name>Coverage Type</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/coveragetype</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="coverageSource" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Coverage Source</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/coverage</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="coverageRef" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Coverage Ref</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/coverage</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r2">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreIdentifier" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Additional PBCore Identifiers</name>
+          <description>pbcoreIdentifier is an identifier that can apply to the asset. This identifier should not be limited to a specific instantiation, but rather all instantiations of an asset. It can also hold a URL or URI that points to the asset. </description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/pbcoreidentifier</documentationUrl>
+      <elements>
+        <metadataElement code="pbcore_id" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Identifier</name>
+            </label>
+          </labels>
+          <documentationUrl>http://pbcore.org/elements/pbcoreidentifier</documentationUrl>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="pbcore_id_source" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Identifier source</name>
+            </label>
+          </labels>
+          <documentationUrl>http://pbcore.org/elements/pbcoreidentifier</documentationUrl>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r2">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationIdentifier" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Additional Instantiation Identifiers</name>
+          <description>instantiationIdentifier contains an unambiguous reference or identifier for a particular instantiation of an asset.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationidentifier</documentationUrl>
+      <elements>
+        <metadataElement code="instantiation_id" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Identifier</name>
+            </label>
+          </labels>
+          <documentationUrl>http://pbcore.org/elements/instantiationidentifier</documentationUrl>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="instantiation_id_source" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Identifier source</name>
+            </label>
+          </labels>
+          <documentationUrl>http://pbcore.org/elements/instantiationidentifier</documentationUrl>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreTitle" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Additional Titles</name>
+          <description>pbcoreTitle is a name or label relevant to the asset. There may be many types of titles an asset may have, such as a series title, episode title, segment title, or project title, therefore the element is repeatable.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/pbcoretitle</documentationUrl>
+      <settings/>
+      <elements>
+        <metadataElement code="pbTitle_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Title</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="pbTitle_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Title</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/pbcoretitle</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="pbTitle_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Title Details</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="pbTitleType" datatype="List" list="pbcore_title_types">
+              <labels>
+                <label locale="en_US">
+                  <name>Title Type</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/pbcoretitle</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbTitleSource" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Title Source</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/pbcoretitle</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbTitleRef" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Title Ref</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/pbcoretitle</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreDescription" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Description</name>
+          <description>pbcoreDescription is an element that uses free-form text or a narrative to report general notes, abstracts, or summaries about the intellectual content of an asset. The information may be in the form of an individual program description, anecdotal interpretations, or brief content reviews. The description may also consist of outlines, lists, bullet points, rundowns, edit decision lists, indexes, or tables of content.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/pbcoredescription</documentationUrl>
+      <settings/>
+      <elements>
+        <metadataElement code="pBdescription_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Description</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="pBdescription_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Description</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/pbcoredescription</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">5</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="pBdescription_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Description Details</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="pbdescriptionType" datatype="List" list="pbcore_description_types">
+              <labels>
+                <label locale="en_US">
+                  <name>Description Type</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/pbcoredescription</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbdescriptionSource" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Description Source</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/pbcoredescription</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbdescriptionRef" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Description Ref</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/pbcoredescription</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="primary_inst_id_source" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Primary Identifier Source</name>
+          <description></description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationidentifier</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="primary_pbcore_id_source" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Primary Identifier Source</name>
+          <description></description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/pbcoreidentifier</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="primary_title_details" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Primary Title Details</name>
+          <description></description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/pbcoretitle</documentationUrl>
+      <settings/>
+      <elements>
+        <metadataElement code="pbPrimaryTitleType" datatype="List" list="pbcore_title_types">
+          <labels>
+            <label locale="en_US">
+              <name>Title Type</name>
+            </label>
+          </labels>
+          <documentationUrl>http://pbcore.org/elements/pbcoretitle</documentationUrl>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">255</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="pbPrimaryTitleSource" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Title Source</name>
+            </label>
+          </labels>
+          <documentationUrl>http://pbcore.org/elements/pbcoretitle</documentationUrl>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">255</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="pbPrimaryTitleRef" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Title Ref</name>
+            </label>
+          </labels>
+          <documentationUrl>http://pbcore.org/elements/pbcoretitle</documentationUrl>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">255</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreAssetType" datatype="List" list="asset_types">
+      <labels>
+        <label locale="en_US">
+          <name>Asset Type</name>
+          <description>pbcoreAssetType is a broad definition of the type of intellectual content being described. Asset types might include those without associated instantiations (a collection or series), or those with instantiations (programs, episodes, clips, etc.)</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/pbcoreassettype</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreGenre" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Genre</name>
+          <description>pbcoreGenre is an element that describes the Genre of the asset, which can be defined as a categorical description informed by the topical nature or a particular style or form of the content.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/pbcoregenre</documentationUrl>
+      <settings/>
+      <elements>
+        <metadataElement code="pbGenre_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Genre</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="pbGenre_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Genre</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/pbcoregenre</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="pbGenre_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Genre Details</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="pbGenreSource" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Genre Source</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/pbcoregenre</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbGenreRef" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Genre Ref</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/pbcoregenre</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements> 
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreAudienceLevel" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Audience Level</name>
+          <description>Identifies a type of audience, viewer, or listener for whom the media item is primarily designed or educationally useful.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/pbcoreaudiencelevel</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreAudienceRating" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Audience Rating</name>
+          <description>Designates the type of users for whom the intellectual content of a media item is intended or judged appropriate. This element differs from the element pbcoreAudienceLevel in that it utilizes standard ratings that have been crafted by the broadcast television and film industries and that are used as flags for audience or age-appropriate materials.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/pbcoreaudiencerating</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreRelation" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Relation</name>
+          <description>The descriptor relationType identifies the type of work bond between a media item you are cataloging and some other related media item.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/pbcorerelation</documentationUrl>
+      <elements>
+        <metadataElement code="relationType" datatype="List" list="pbcore_relation_types">
+          <labels>
+            <label locale="en_US">
+              <name>Relation Type</name>
+            </label>
+          </labels>
+          <documentationUrl>http://pbcore.org/elements/pbcorerelationtype</documentationUrl>
+          <settings>
+            <setting name="listWidth">40</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="relation" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Relation</name>
+            </label>
+          </labels>
+          <documentationUrl>http://pbcore.org/elements/pbcorerelationidentifier</documentationUrl>
+          <settings>
+            <setting name="fieldWidth">60</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">1</setting>
+            <setting name="maxChars">65535</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="rightsSummary_asset" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Rights Summary</name>
+          <description>rightsSummary is used as a general free-text element to identify information about copyrights and property rights held in and over an asset or instantiation, whether they are open access or restricted in some way. If dates, times and availability periods are associated with a right, include them. End user permissions, constraints and obligations may also be identified as needed</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/rightssummary</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">5</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="rightsLink_asset" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Rights Link</name>
+          <description>rightsLink is a URI pointing to a declaration of rights.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/rightslink</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+        <metadataElement code="rightsSummary_instantiation" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Rights Summary</name>
+          <description>rightsSummary is used as a general free-text element to identify information about copyrights and property rights held in and over an asset or instantiation, whether they are open access or restricted in some way. If dates, times and availability periods are associated with a right, include them. End user permissions, constraints and obligations may also be identified as needed</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/rightssummary</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">5</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="rightsLink_instantiation" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Rights Link</name>
+          <description>rightsLink is a URI pointing to a declaration of rights.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/rightslink</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationPhysAudio" datatype="List" list="instantiation_physical_types_audio">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Physical for Audio</name>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationphysical</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <type>audio_analog</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationPhysMovingImages" datatype="List" list="instantiation_physical_types_moving">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Physical for Moving Image</name>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationphysical</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <type>moving_analog</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDigMovingImages" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Digital for Moving Image</name>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationdigital</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <type>moving_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDigAudio" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Digital for Audio</name>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationdigital</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <type>audio_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationLocation" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Location</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">2</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationGenerations" datatype="List" list="instantiation_generations_types">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Generations</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationTimeStart" datatype="TimeCode">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Time Start</name>
+          <description>instantiationTimeStart describes the point at which playback begins for a time-based instantiation. It is likely that the content on a tape may begin an arbitrary amount of time after the beginning of the instantiation.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationtimestart</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">60</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <type>audio</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="r2">
+          <table>ca_objects</table>
+          <type>moving_image</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDuration" datatype="TimeCode">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Duration</name>
+          <description>The element instantiationDuration provides a timestamp for the overall length or duration of a time-based media item. It represents the playback time. Best practice is to use a timestamp format such as HH:MM:SS[:|;]FF or HH:MM:SS.mmm or S.mmm.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationduration</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">60</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <type>audio</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="r2">
+          <table>ca_objects</table>
+          <type>moving_image</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDataRate" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Data Rate</name>
+          <description>The amount of data in a digital media file that is encoded, delivered or distributed, for every second of time.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationdatarate</documentationUrl>
+      <settings/>
+      <elements>
+        <metadataElement code="instantiationDataRate_text" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Instantiation Data Rate</name>
+              <description></description>
+            </label>
+          </labels>
+          <documentationUrl>http://pbcore.org/elements/instantiationdatarate</documentationUrl>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="instantiationDataRate_units" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Units of Measure</name>
+              <description></description>
+            </label>
+          </labels>
+          <documentationUrl>http://pbcore.org/elements/instantiationchan</documentationUrl>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <type>audio_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="r2">
+          <table>ca_objects</table>
+          <type>moving_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationFileSize" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation File Size</name>
+          <description></description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationfilesize</documentationUrl>
+      <settings/>
+      <elements>
+        <metadataElement code="instantiationFileSize_text" datatype="Text">
+          <labels>
+          <label locale="en_US">
+            <name>Instantiation File Size</name>
+            <description></description>
+          </label>
+          </labels>
+          <documentationUrl>http://pbcore.org/elements/instantiationfilesize</documentationUrl>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="instantiationFileSize_units" datatype="Text">
+          <labels>
+          <label locale="en_US">
+            <name>Units of Measure</name>
+            <description></description>
+          </label>
+          </labels>
+          <documentationUrl>http://pbcore.org/elements/instantiationfilesize</documentationUrl>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <type>audio_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="r2">
+          <table>ca_objects</table>
+          <type>moving_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationColors" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Colors</name>
+          <description>Indicates the overall color, grayscale, or black and white nature of the presentation of an instantiation, as a single occurrence or combination of occurrences in or throughout the instantiation.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationcolors</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <type>moving_image</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationTracks" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Tracks</name>
+          <description>The element instantiationTracks is simply intended to indicate the number and type of tracks that are found in a media item, whether it is analog or digital. (e.g. 1 video track, 2 audio tracks, 1 text track, 1 sprite track, etc.) Other configuration information specific to these identified tracks should be described using instantiationChannelConfiguration.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationtracks</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <type>audio</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="r2">
+          <table>ca_objects</table>
+          <type>moving_image</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationChanConf" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Channel Configuration</name>
+          <description>The element instantiationChannelConfiguration is designed to indicate, at a general narrative level, the arrangement or configuration of specific channels or layers of information within an instantiation’s tracks. Examples are 2-track mono, 8- track stereo, or video track with alpha channel.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationchannelconfiguration</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <type>audio</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction code="r2">
+          <table>ca_objects</table>
+          <type>moving_image</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationLanguage" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Language</name>
+          <description>instantiationLanguage identifies the primary language of the tracks’ audio or text. Languages must be indicated using 3-letter codes standardized in ISO 639-2 or 639-3. If an instantiation includes more than one language, the element can be repeated. Alternately, both languages can be expressed in one element by separating two three-letter codes with a semicolon, i.e. eng;fre.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationlanguage</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationEssenceTrack" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Essence Track</name>
+          <description>instantiationEssenceTrack is an XML container element that allows for grouping of related essenceTrack elements and their repeated use. Use instantiationEssenceTrack element to describe the individual streams that comprise an instantiation, such as audio, video, timecode, etc.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationessencetrack</documentationUrl>
+      <settings/>
+      <elements>
+        <metadataElement code="essence_line01" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Type</name>
+              <description>essenceTrackType refers to the media type of the decoded data. Tracks may possibly be of these types: video, audio, caption, metadata, image, etc.</description>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="trackType" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Type</name>
+                  <description>essenceTrackType refers to the media type of the decoded data. Tracks may possibly be of these types: video, audio, caption, metadata, image, etc.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line02" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Identifier</name>
+              <description>essenceTrackIdentifier is an identifier of the track. Several audiovisual containers include such identifier schema to identify each track, such as MPEG2 PIDs or QuickTime Track ids</description>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="trackIdentifier" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Identifier</name>
+                  <description>essenceTrackIdentifier is an identifier of the track. Several audiovisual containers include such identifier schema to identify each track, such as MPEG2 PIDs or QuickTime Track ids</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line03" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Identifier Source</name>
+              <description>the name of the software or tool that provided the Track Identifier</description>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="trackIdentifierSource" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Identifier Source</name>
+                  <description>the name of the software or tool that provided the Track Identifier</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line04" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Standard</name>
+              <description>essenceTrackStandard should be be used with file-based instantiations to describe the broadcast standard of the video signal (e.g. NTSC, PAL) or to further clarify the standard of the essenceTrackEncoding format.</description>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="trackStandard" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Standard</name>
+                  <description>essenceTrackStandard should be be used with file-based instantiations to describe the broadcast standard of the video signal (e.g. NTSC, PAL) or to further clarify the standard of the essenceTrackEncoding format.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line05" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Encoding</name>
+              <description>essenceTrackEncoding identifies how the actual information in an instantiation is compressed, interpreted, or formulated using a particular scheme. Identifying the encoding used is beneficial for a number of reasons, including as a way to achieve reversible compression; for the construction of document indices to facilitate searching and access; or for efficient distribution of the information across data networks with differing bandwidths or pipeline capacities. Human-readable encoding value should be placed here.</description>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="trackEncoding" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Encoding</name>
+                  <description>essenceTrackEncoding identifies how the actual information in an instantiation is compressed, interpreted, or formulated using a particular scheme. Identifying the encoding used is beneficial for a number of reasons, including as a way to achieve reversible compression; for the construction of document indices to facilitate searching and access; or for efficient distribution of the information across data networks with differing bandwidths or pipeline capacities. Human-readable encoding value should be placed here.</description>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/essencetrackencoding</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line06" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Data Rate</name>
+              <description>essenceTrackDataRate measures the amount of data used per time interval for encoded data. The data rate can be calculated by dividing the total data size of the track's encoded data by a time unit.</description>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="trackDataRate_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Data Rate</name>
+                  <description>essenceTrackDataRate measures the amount of data used per time interval for encoded data. The data rate can be calculated by dividing the total data size of the track's encoded data by a time unit.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackDataRate_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                  <description></description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line07" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Time Start</name>
+              <description>essenceTrackTimeStart provides a time stamp for the beginning point of playback for a time-based essence track. It is likely that the content on a tape may begin an arbitrary amount of time after the beginning of the instantiation.</description>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="trackTimeStart" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Time Start</name>
+                  <description>essenceTrackTimeStart provides a time stamp for the beginning point of playback for a time-based essence track. It is likely that the content on a tape may begin an arbitrary amount of time after the beginning of the instantiation.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line08" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Duration</name>
+              <description>essenceTrackDuration provides a timestamp for the overall length or duration of a track. It represents the track playback time</description>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="trackDuration" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Duration</name>
+                  <description>essenceTrackDuration provides a timestamp for the overall length or duration of a track. It represents the track playback time</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line09" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Bit Depth</name>
+              <description>essenceTrackBitDepth specifies how much data is sampled when information is digitized, encoded, or converted for an instantiation (specifically, audio, video, or image). Bit depth is measured in bits and generally implies an arbitrary perception of quality during playback of an instantiation (the higher the bit depth, the greater the fidelity).</description>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="trackBitDepth_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Bit Depth</name>
+                  <description>essenceTrackBitDepth specifies how much data is sampled when information is digitized, encoded, or converted for an instantiation (specifically, audio, video, or image). Bit depth is measured in bits and generally implies an arbitrary perception of quality during playback of an instantiation (the higher the bit depth, the greater the fidelity).</description>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/essencetrackbitdepth</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackBitDepth_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                  <description></description>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/essencetrackbitdepth</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line10" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Sampling Rate</name>
+              <description>essenceTrackSamplingRate measures how often data is sampled when information from the audio portion from an instantiation is digitized. For a digital audio signal, the sampling rate is measured in kilohertz and is an indicator of the perceived playback quality of the media item (the higher the sampling rate, the greater the fidelity).</description>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="trackSamplingRate_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Sampling Rate</name>
+                  <description>essenceTrackSamplingRate measures how often data is sampled when information from the audio portion from an instantiation is digitized. For a digital audio signal, the sampling rate is measured in kilohertz and is an indicator of the perceived playback quality of the media item (the higher the sampling rate, the greater the fidelity).</description>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/essencetracksamplingrate</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackSamplingRate_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Sampling Rate</name>
+                  <description></description>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/essencetracksamplingrate</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line11" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Playback Speed</name>
+              <description>essenceTrackPlaybackSpeed specifies the rate of units against time at which the media track should be rendered for human consumption. e.g., 15ips (inches per second).</description>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="trackPlaybackSpeed_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Playback Speed</name>
+                  <description>essenceTrackPlaybackSpeed specifies the rate of units against time at which the media track should be rendered for human consumption. e.g., 15ips (inches per second).</description>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/essencetrackplaybackspeed</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackPlaybackSpeed_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                  <description></description>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/essencetrackplaybackspeed</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line12" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Frame Size</name>
+              <description>essenceTrackFrameSize measures the width and height of the encoded video or image track. The frame size refers to the size of the encoded pixels and not the size of the displayed image. It may be expressed as combination of pixels measured horizontally vs. the number of pixels of image/resolution data stacked vertically (interlaced and progressive scan).</description>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="trackFrameSize_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Frame Size</name>
+                  <description>essenceTrackFrameSize measures the width and height of the encoded video or image track. The frame size refers to the size of the encoded pixels and not the size of the displayed image. It may be expressed as combination of pixels measured horizontally vs. the number of pixels of image/resolution data stacked vertically (interlaced and progressive scan).</description>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/essencetrackframesize</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackFrameSize_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                  <description></description>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/essencetrackframesize</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line13" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Aspect Ratio</name>
+              <description>essenceTrackAspectRatio indicates the ratio of horizontal to vertical proportions in the display of a static image or moving image.</description>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="trackAspectRatio_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Aspect Ratio</name>
+                  <description>essenceTrackAspectRatio indicates the ratio of horizontal to vertical proportions in the display of a static image or moving image.</description>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/essencetrackaspectratio</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackAspectRatio_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                  <description></description>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/essencetrackaspectratio</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line14" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Frame Rate</name>
+              <description>essenceTrackFrameRate is relevant to tracks of video track type only. The frame rate is calculated by dividing the total number of frames by the duration of the video track. By default measure frame rate in frames per second expressed as fps as a unit of measure. e.g., 24 fps.</description>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="trackFrameRate_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Frame Rate</name>
+                  <description>essenceTrackFrameRate is relevant to tracks of video track type only. The frame rate is calculated by dividing the total number of frames by the duration of the video track. By default measure frame rate in frames per second expressed as fps as a unit of measure. e.g., 24 fps.</description>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/essencetrackframerate</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackFrameRate_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                  <description></description>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/essencetrackframerate</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line15" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Language</name>
+              <description>essenceTrackLanguage identifies the primary language of the tracks’ audio or text. Languages must be indicated using 3-letter codes standardized in ISO 639-2 or 639-3. If an instantiation includes more than one language, the element can be repeated. Alternately, both languages can be expressed in one element by separating two three-letter codes with a semicolon, i.e. eng;fre.</description>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="trackLanguage" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Language</name>
+                  <description>essenceTrackLanguage identifies the primary language of the tracks’ audio or text. Languages must be indicated using 3-letter codes standardized in ISO 639-2 or 639-3. If an instantiation includes more than one language, the element can be repeated. Alternately, both languages can be expressed in one element by separating two three-letter codes with a semicolon, i.e. eng;fre.</description>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/essencetracklanguage</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line16" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Annotation</name>
+              <description>essenceTrackAnnotation can store any supplementary information about a track or the metadata used to describe it. It clarifies element values, terms, descriptors, and vocabularies that may not be otherwise sufficiently understood.</description>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="trackAnnotation_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Annotation</name>
+                  <description>essenceTrackAnnotation can store any supplementary information about a track or the metadata used to describe it. It clarifies element values, terms, descriptors, and vocabularies that may not be otherwise sufficiently understood.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">3</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackAnnotation_type" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Annotation Type</name>
+                  <description></description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <type>audio</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">250</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+        <restriction code="r2">
+          <table>ca_objects</table>
+          <type>moving_image</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">250</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreSubject" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Subject</name>
+          <description>pbcoreSubject is used to assign topic headings or keywords that portray the intellectual content of the asset. A subject is expressed by keywords, key phrases, or even specific classification codes. Controlled vocabularies, authorities, formal classification codes, as well as folksonomies and user-generated tags, may be employed when assigning descriptive subject terms.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/pbcoresubject</documentationUrl>
+      <settings/>
+      <elements>
+        <metadataElement code="pbSubject_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Subject</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="pbSubject_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Subject</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/pbcoresubject</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="pbSubject_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Subject Details</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="pbSubjectType" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Subject Type</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/pbcoresubject</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbSubjectSource" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Subject Source</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/pbcoresubject</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbSubjectRef" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Subject Ref</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/pbcoresubject</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreAnnotation" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Annotation</name>
+          <description>pbcoreAnnotation allows the addition of any supplementary information about the metadata used to describe the PBCore record. pbcoreAnnotation clarifies element values, terms, descriptors, and vocabularies that may not be otherwise sufficiently understood.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/pbcoreannotation</documentationUrl>
+      <settings/>
+      <elements>
+        <metadataElement code="pbAnnotation_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Annotation</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="pbAnnotation_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Annotation</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/pbcoreannotation</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">5</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="pbAnnotation_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Annotation Type</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="pbAnnotationType" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Annotation Type</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/pbcoreannotation</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationAnnotation" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Annotation</name>
+          <description>instantiationAnnotation is used to add any supplementary information about an instantiation of the instantiation or the metadata used to describe it. It clarifies element values, terms, descriptors, and vocabularies that may not be otherwise sufficiently understood.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationannotation</documentationUrl>
+      <settings/>
+      <elements>
+        <metadataElement code="instAnnotation_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Annotation</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="instAnnotation_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Annotation</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/instantiationannotation</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">5</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="instAnnotation_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Annotation Type</name>
+            </label>
+          </labels>
+          <settings/>
+          <elements>
+            <metadataElement code="instAnnotationType" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Annotation Type</name>
+                </label>
+              </labels>
+              <documentationUrl>http://pbcore.org/elements/instantiationannotation</documentationUrl>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreDate" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Asset Date</name>
+          <description></description>
+        </label>
+      </labels>
+      <documentationUrl></documentationUrl>
+      <settings/>
+      <elements>
+        <metadataElement code="pbcoreDates_value" datatype="DateRange">
+          <labels>
+            <label locale="en_US">
+              <name>Date</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="pbCoreDates_types" datatype="List" list="pbCore_dates_types">
+          <labels>
+            <label locale="en_US">
+              <name>Type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDate" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Date</name>
+          <description></description>
+        </label>
+      </labels>
+      <documentationUrl></documentationUrl>
+      <settings/>
+      <elements>
+        <metadataElement code="instantiationDates_value" datatype="DateRange">
+          <labels>
+            <label locale="en_US">
+              <name>Date</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="instantiationDates_types" datatype="List" list="pbCore_dates_types">
+          <labels>
+            <label locale="en_US">
+              <name>Type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationMediaType" datatype="List" list="instantiation_media_types">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Media Type</name>
+          <description></description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationmediatype</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">80</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationStandard" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Standard</name>
+          <description>If the instantiation is a physical item, instantiationStandard can be used to refer to the broadcast standard of the video signal (e.g. NTSC, PAL), or the audio encoding (e.g. Dolby A, vertical cut). If the instantiation is a digital item, instantiationStandard should be used to express the container format of the digital file (e.g. MXF).</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationstandard</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationAlternativeModes" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Alternative Modes</name>
+          <description>instantiationAlternativeModes is a catch-all metadata element that identifies equivalent alternatives to the primary visual, sound or textual information that exists in an instantiation. These are modes that offer alternative ways to see, hear, and read the content of an instantiation. Examples include DVI (Descriptive Video Information), SAP (Supplementary Audio Program), ClosedCaptions, OpenCaptions, Subtitles, Language Dubs, and Transcripts. For each instance of available alternativeModes, the mode and its associated language should be identified together, if applicable. Examples include ‘SAP in English,’ ‘SAP in Spanish,’ ‘Subtitle in French,’ ‘OpenCaption in Arabic.’</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationalternativemodes</documentationUrl>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">1</setting>
+        <setting name="minChars">0</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDimensions" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Dimensions</name>
+          <description>instantiationDimensions is an element that specifies either the dimensions of a physical instantiation, or the high-level visual dimensions of a digital instantiation. For physical dimensions, usage examples might be 7″ for an audio reel. When describing visual dimensions, use this for high-level descriptors such as 1080p. Use the element frameSize to describe the pixel dimensions of a visual resource.</description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/elements/instantiationdimensions</documentationUrl>
+      <settings/>
+      <elements>
+        <metadataElement code="instantiationDimensions_text" datatype="Length">
+          <labels>
+            <label locale="en_US">
+              <name>Instantiation Dimensions</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="instantiationDimensions_units" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Units of Measure</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="entity_attributes" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Entity Attributes</name>
+          <description></description>
+        </label>
+      </labels>
+      <documentationUrl>http://pbcore.org/attributes</documentationUrl>
+      <settings/>
+      <elements>
+        <metadataElement code="entitySource" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Entity Source</name>
+            </label>
+          </labels>
+          <documentationUrl>http://pbcore.org/attributes</documentationUrl>
+          <settings>
+            <setting name="fieldWidth">50</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">255</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="entityRef" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Entity Ref</name>
+            </label>
+          </labels>
+          <documentationUrl>http://pbcore.org/attributes</documentationUrl>
+          <settings>
+            <setting name="fieldWidth">50</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">255</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction code="r1">
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+  </elementSets>
+  <userInterfaces>
+    <userInterface code="standard_object_ui" type="ca_objects">
+      <labels>
+        <label locale="en_US">
+          <name>Standard object editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic_pbcore" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="status">
+              <bundle>status</bundle>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Primary Identifier</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_containerID">
+              <bundle>ca_attribute_containerID</bundle>
+            </placement>
+            <placement code="ca_attribute_primary_inst_id_source">
+              <bundle>ca_attribute_primary_inst_id_source</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationIdentifier">
+              <bundle>ca_attribute_instantiationIdentifier</bundle>
+              <settings>
+                <setting name="add_label" locale="en_US">Add instantiation identifier</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Title</setting>
+                <setting name="add_label" locale="en_US">Add Title</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationDate">
+              <bundle>ca_attribute_instantiationDate</bundle>
+              <settings>
+                <setting name="add_label" locale="en_US">Add instantiation date</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationDimensions">
+              <bundle>ca_attribute_instantiationDimensions</bundle>
+              <settings>
+                <setting name="add_label" locale="en_US">Add instantiation dimensions</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationPhysAudio">
+              <bundle>ca_attribute_instantiationPhysAudio</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationPhysMovingImages">
+              <bundle>ca_attribute_instantiationPhysMovingImages</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationDigMovingImages">
+              <bundle>ca_attribute_instantiationDigMovingImages</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationDigAudio">
+              <bundle>ca_attribute_instantiationDigAudio</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationStandard">
+              <bundle>ca_attribute_instantiationStandard</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationLocation">
+              <bundle>ca_attribute_instantiationLocation</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationMediaType">
+              <bundle>ca_attribute_instantiationMediaType</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationGenerations">
+              <bundle>ca_attribute_instantiationGenerations</bundle>
+              <settings>
+                <setting name="add_label" locale="en_US">Add instantiation generations</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationFileSize">
+              <bundle>ca_attribute_instantiationFileSize</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationTimeStart">
+              <bundle>ca_attribute_instantiationTimeStart</bundle>
+              <settings>
+                <setting name="add_label" locale="en_US">Add starting time</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationDuration">
+              <bundle>ca_attribute_instantiationDuration</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationDataRate">
+              <bundle>ca_attribute_instantiationDataRate</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationColors">
+              <bundle>ca_attribute_instantiationColors</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationTracks">
+              <bundle>ca_attribute_instantiationTracks</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationChanConf">
+              <bundle>ca_attribute_instantiationChanConf</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationLanguage">
+              <bundle>ca_attribute_instantiationLanguage</bundle>
+              <settings>
+                <setting name="add_label" locale="en_US">Add language</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationAlternativeModes">
+              <bundle>ca_attribute_instantiationAlternativeModes</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationEssenceTrack">
+              <bundle>ca_attribute_instantiationEssenceTrack</bundle>
+              <settings>
+                <setting name="add_label" locale="en_US">Add essence track</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_rightsSummary_instantiation">
+              <bundle>ca_attribute_rightsSummary_instantiation</bundle>
+              <settings>
+                <setting name="add_label" locale="en_US">Add instantiation rights summary</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_rightsLink_instantiation">
+              <bundle>ca_attribute_rightsLink_instantiation</bundle>
+              <settings>
+                <setting name="add_label" locale="en_US">Add instantiation rights link</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationAnnotation">
+              <bundle>ca_attribute_instantiationAnnotation</bundle>
+              <settings>
+                <setting name="add_label" locale="en_US">Add instantiation annotation</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="media" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Media</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_object_representations">
+              <bundle>ca_object_representations</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="works" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Intellectual Content</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="restrict_to_type">intellectual_content</setting>
+                <setting name="label" locale="en_US">Related Intellectual Content</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="assets" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Instantiations</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Related Instantiations</setting>
+                <setting name="restrict_to_types">audio_analog</setting>
+                <setting name="restrict_to_types">audio_digital</setting>
+                <setting name="restrict_to_types">moving_analog</setting>
+                <setting name="restrict_to_types">moving_digital</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="extension" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Extensions</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_attribute_pbcoreExtension">
+              <bundle>ca_attribute_pbcoreExtension</bundle>
+              <settings>
+                <setting name="add_label" locale="en_US">Add extension</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_entity_ui" type="ca_entities">
+      <labels>
+        <label locale="en_US">
+          <name>Standard entity editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="idno">
+              <bundle>idno</bundle>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Name</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_entity_attributes">
+              <bundle>ca_attribute_entity_attributes</bundle>
+            </placement>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="contact" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Contact info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_attribute_address">
+              <bundle>ca_attribute_address</bundle>
+            </placement>
+            <placement code="ca_attribute_telephone">
+              <bundle>ca_attribute_telephone</bundle>
+            </placement>
+            <placement code="ca_attribute_email">
+              <bundle>ca_attribute_email</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Related instantiation</setting>
+                <setting name="add_label" locale="en_US">Add instantiation</setting>
+              </settings>
+            </placement>
+            <placement code="ca_occurrences">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Related intellectual content</setting>
+                <setting name="add_label" locale="en_US">Add intellectual content</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+            </placement>
+            <placement code="ca_collections">
+              <bundle>ca_collections</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="keywords" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Keywords</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_list_items">
+              <bundle>ca_list_items</bundle>
+              <settings>
+                <setting name="add_label" locale="en_US">Add term</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_lcshFull">
+              <bundle>ca_attribute_lcshFull</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_place_ui" type="ca_places">
+      <labels>
+        <label locale="en_US">
+          <name>Standard place editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="place" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Place</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="idno">
+              <bundle>idno</bundle>
+            </placement>
+            <placement code="source_id">
+              <bundle>source_id</bundle>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Name</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="location" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Location</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_location">
+              <bundle>hierarchy_location</bundle>
+            </placement>
+            <placement code="ca_attribute_georeference">
+              <bundle>ca_attribute_georeference</bundle>
+            </placement>
+            <placement code="ca_attribute_geonames">
+              <bundle>ca_attribute_geonames</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Related instantiation</setting>
+              </settings>
+            </placement>
+            <placement code="ca_assets">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Related intellectual content</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+            </placement>
+            <placement code="ca_collections">
+              <bundle>ca_collections</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="keywords" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Keywords</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_list_items">
+              <bundle>ca_list_items</bundle>
+              <settings>
+                <setting name="add_label" locale="en_US">Add term</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_lcshFull">
+              <bundle>ca_attribute_lcshFull</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_occurrences_ui" type="ca_occurrences">
+      <labels>
+        <label locale="en_US">
+          <name>Standard occurrences editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="content" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="status">
+              <bundle>status</bundle>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+            </placement>
+            <placement code="ca_attribute_pbcoreAssetType">
+              <bundle>ca_attribute_pbcoreAssetType</bundle>
+            </placement>
+            <placement code="ca_attribute_pbcoreDate">
+              <bundle>ca_attribute_pbcoreDate</bundle>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Primary Identifier</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_primary_pbcore_id_source">
+              <bundle>ca_attribute_primary_pbcore_id_source</bundle>
+            </placement>
+            <placement code="ca_attribute_pbcoreIdentifier">
+              <bundle>ca_attribute_pbcoreIdentifier</bundle>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Primary Title</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_primary_title_details">
+              <bundle>ca_attribute_primary_title_details</bundle>
+            </placement>
+            <placement code="ca_attribute_pbcoreTitle">
+              <bundle>ca_attribute_pbcoreTitle</bundle>
+              <settings>
+                <setting name="add_label" locale="en_US">Add Title</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_pbcoreSubject">
+              <bundle>ca_attribute_pbcoreSubject</bundle>
+            </placement>
+            <placement code="ca_attribute_pbcoreDescription">
+              <bundle>ca_attribute_pbcoreDescription</bundle>
+            </placement>
+            <placement code="ca_attribute_pbcoreGenre">
+              <bundle>ca_attribute_pbcoreGenre</bundle>
+            </placement>
+            <placement code="ca_attribute_pbcoreCoverage">
+              <bundle>ca_attribute_pbcoreCoverage</bundle>
+            </placement>
+            <placement code="ca_attribute_pbcoreAudienceLevel">
+              <bundle>ca_attribute_pbcoreAudienceLevel</bundle>
+            </placement>
+            <placement code="ca_attribute_pbcoreAudienceRating">
+              <bundle>ca_attribute_pbcoreAudienceRating</bundle>
+            </placement>
+            <placement code="ca_attribute_pbcoreAnnotation">
+              <bundle>ca_attribute_pbcoreAnnotation</bundle>
+              <settings>
+                <setting name="add_label" locale="en_US">Add annotation</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="intellectual" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Intellectual Property</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_contributors">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="restrict_to_relationship_types">actor</setting>
+                <setting name="restrict_to_relationship_types">artist</setting>
+                <setting name="restrict_to_relationship_types">artistic_director</setting>
+                <setting name="restrict_to_relationship_types">associate_producer</setting>
+                <setting name="restrict_to_relationship_types">author</setting>
+                <setting name="restrict_to_relationship_types">broadcast_engineer</setting>
+                <setting name="restrict_to_relationship_types">camera_operator</setting>
+                <setting name="restrict_to_relationship_types">caption_writer</setting>
+                <setting name="restrict_to_relationship_types">casting_director</setting>
+                <setting name="restrict_to_relationship_types">choreographer</setting>
+                <setting name="restrict_to_relationship_types">cinematographer</setting>
+                <setting name="restrict_to_relationship_types">co_producer</setting>
+                <setting name="restrict_to_relationship_types">commenator</setting>
+                <setting name="restrict_to_relationship_types">composer</setting>
+                <setting name="restrict_to_relationship_types">costume_designer</setting>
+                <setting name="restrict_to_relationship_types">creator</setting>
+                <setting name="restrict_to_relationship_types">describer</setting>
+                <setting name="restrict_to_relationship_types">director</setting>
+                <setting name="restrict_to_relationship_types">director_of_photography</setting>
+                <setting name="restrict_to_relationship_types">editor</setting>
+                <setting name="restrict_to_relationship_types">executive_producer</setting>
+                <setting name="restrict_to_relationship_types">filmmaker</setting>
+                <setting name="restrict_to_relationship_types">foley_artist</setting>
+                <setting name="restrict_to_relationship_types">graphic_designer</setting>
+                <setting name="restrict_to_relationship_types">graphic_editor</setting>
+                <setting name="restrict_to_relationship_types">guest</setting>
+                <setting name="restrict_to_relationship_types">host</setting>
+                <setting name="restrict_to_relationship_types">interviewee</setting>
+                <setting name="restrict_to_relationship_types">interviewer</setting>
+                <setting name="restrict_to_relationship_types">lighting_technician</setting>
+                <setting name="restrict_to_relationship_types">make_up_artist</setting>
+                <setting name="restrict_to_relationship_types">moderator</setting>
+                <setting name="restrict_to_relationship_types">music_supervisor</setting>
+                <setting name="restrict_to_relationship_types">musician</setting>
+                <setting name="restrict_to_relationship_types">narrator</setting>
+                <setting name="restrict_to_relationship_types">panelist</setting>
+                <setting name="restrict_to_relationship_types">performer</setting>
+                <setting name="restrict_to_relationship_types">performing_group</setting>
+                <setting name="restrict_to_relationship_types">photographer</setting>
+                <setting name="restrict_to_relationship_types">producer</setting>
+                <setting name="restrict_to_relationship_types">production_unit</setting>
+                <setting name="restrict_to_relationship_types">recording_engineer</setting>
+                <setting name="restrict_to_relationship_types">reporter</setting>
+                <setting name="restrict_to_relationship_types">set_designer</setting>
+                <setting name="restrict_to_relationship_types">sound_designer</setting>
+                <setting name="restrict_to_relationship_types">sound_editor</setting>
+                <setting name="restrict_to_relationship_types">speaker</setting>
+                <setting name="restrict_to_relationship_types">technical_director</setting>
+                <setting name="restrict_to_relationship_types">video_engineer</setting>
+                <setting name="restrict_to_relationship_types">vocalist</setting>
+                <setting name="restrict_to_relationship_types">voiceover_artist</setting>
+                <setting name="restrict_to_relationship_types">writer</setting>
+                <setting name="label" locale="en_US">Creators and Contributors</setting>
+                <setting name="add_label" locale="en_US">Add creators</setting>
+              </settings>
+            </placement>
+            <placement code="ca_publishers">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="restrict_to_relationship_types">publisher</setting>
+                <setting name="restrict_to_relationship_types">distributor</setting>
+                <setting name="restrict_to_relationship_types">presenter</setting>
+                <setting name="label" locale="en_US">Publishers</setting>
+                <setting name="add_label" locale="en_US">Add publishers</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_rightsSummary_asset">
+              <bundle>ca_attribute_rightsSummary_asset</bundle>
+            </placement>
+            <placement code="ca_attribute_rightsLink_asset">
+              <bundle>ca_attribute_rightsLink_asset</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="assets" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Instantiations</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="restrict_to_type"> </setting>
+                <setting name="label" locale="en_US">Related Instantiations</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="extension" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Extensions</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_attribute_pbcoreExtension">
+              <bundle>ca_attribute_pbcoreExtension</bundle>
+              <settings>
+                <setting name="add_label" locale="en_US">Add extension</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="related_assets" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Intellectual Content</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_occurrences">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Related Intellectual Content</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_collection_ui" type="ca_collections">
+      <labels>
+        <label locale="en_US">
+          <name>Collection editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_location">
+              <bundle>hierarchy_location</bundle>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Title</setting>
+                <setting name="add_label" locale="en_US">Add Title</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+            </placement>
+            <placement code="ca_attribute_institution">
+              <bundle>ca_attribute_institution</bundle>
+            </placement>
+            <placement code="ca_attribute_description">
+              <bundle>ca_attribute_description</bundle>
+            </placement>
+            <placement code="ca_attribute_internal_notes">
+              <bundle>ca_attribute_internal_notes</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Related Instantiations</setting>
+              </settings>
+            </placement>
+            <placement code="ca_occurrences">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Related Intellectual Content</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+            </placement>
+            <placement code="ca_collections">
+              <bundle>ca_collections</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="keywords" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Keywords</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_list_items">
+              <bundle>ca_list_items</bundle>
+              <settings>
+                <setting name="add_label" locale="en_US">Add term</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_storage_locations_ui" type="ca_storage_locations">
+      <labels>
+        <label locale="en_US">
+          <name>Storage locations editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_navigation">
+              <bundle>hierarchy_navigation</bundle>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Name</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+            </placement>
+            <placement code="ca_attribute_description">
+              <bundle>ca_attribute_description</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="location" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Location</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_location">
+              <bundle>hierarchy_navigation</bundle>
+            </placement>
+            <placement code="ca_attribute_georeference">
+              <bundle>ca_attribute_georeference</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="contents" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Contents</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_navigation">
+              <bundle>hierarchy_navigation</bundle>
+            </placement>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_navigation">
+              <bundle>hierarchy_navigation</bundle>
+            </placement>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_object_lots_ui" type="ca_object_lots">
+      <labels>
+        <label locale="en_US">
+          <name>Object lots editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Lot title</setting>
+                <setting name="add_label" locale="en_US">Add lot title</setting>
+              </settings>
+            </placement>
+            <placement code="idno_stub">
+              <bundle>idno_stub</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Lot number</setting>
+              </settings>
+            </placement>
+            <placement code="lot_status_id">
+              <bundle>lot_status_id</bundle>
+            </placement>
+            <placement code="ca_attribute_description">
+              <bundle>ca_attribute_description</bundle>
+            </placement>
+            <placement code="extent">
+              <bundle>extent</bundle>
+            </placement>
+            <placement code="extent_units">
+              <bundle>extent_units</bundle>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+            </placement>
+            <placement code="ca_collections">
+              <bundle>ca_collections</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="contents" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Contents</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Alternate lot titles</setting>
+                <setting name="add_label" locale="en_US">Add lot title</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_representation_ui" type="ca_object_representations">
+      <labels>
+        <label locale="en_US">
+          <name>Object representation editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Title</setting>
+                <setting name="add_label" locale="en_US">Add Title</setting>
+              </settings>
+            </placement>
+            <placement code="media">
+              <bundle>media</bundle>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+            </placement>
+            <placement code="ca_attribute_caption">
+              <bundle>ca_attribute_caption</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="annotations" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Annotations</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_representation_annotations">
+              <bundle>ca_representation_annotations</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_places</bundle>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_representation_annotation_ui" type="ca_representation_annotations">
+      <labels>
+        <label locale="en_US">
+          <name>Representation annotation editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Title</setting>
+                <setting name="add_label" locale="en_US">Add Title</setting>
+              </settings>
+            </placement>
+            <placement code="ca_representation_annotation_properties">
+              <bundle>ca_representation_annotation_properties</bundle>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+            </placement>
+            <placement code="ca_attribute_description">
+              <bundle>ca_attribute_description</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="keywords" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Keywords</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_list_items">
+              <bundle>ca_list_items</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+  </userInterfaces>
+  <relationshipTypes>
+    <relationshipTable name="ca_objects_x_entities">
+      <types>
+        <type code="creator" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>created by</typename>
+              <typename_reverse>is creator</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="publisher" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>published by</typename>
+              <typename_reverse>is publisher</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="contributor" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>contributed by</typename>
+              <typename_reverse>is contributor</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_occurrences">
+      <types>
+        <type code="manifestation" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has as intellectual content</typename>
+              <typename_reverse>is instantiation of</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight>event</subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_collections">
+      <types>
+        <type code="part_of" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is part of</typename>
+              <typename_reverse>contains</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_objects">
+      <types>
+        <type code="clone" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Clone Of</typename>
+              <typename_reverse>Cloned To</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="dub" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Dub Of</typename>
+              <typename_reverse>Dubbed To</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="format" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Format Of</typename>
+              <typename_reverse>Has Format</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="part_of" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Part Of</typename>
+              <typename_reverse>Has Part</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="replaced" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Replaced By</typename>
+              <typename_reverse>Replaces</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_occurrences_x_occurrences">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Related To</typename>
+              <typename_reverse>Is Related To</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="derived" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>Has Derivative</typename>
+              <typename_reverse>Derived From</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="reference" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>References</typename>
+              <typename_reverse>Is Referenced By</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="part_of" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Part Of</typename>
+              <typename_reverse>Has Part</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="version" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>Has Version</typename>
+              <typename_reverse>Is Version Of</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_places">
+      <types>
+        <type code="created" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>was created at</typename>
+              <typename_reverse>was creation location of</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="located" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>was located at</typename>
+              <typename_reverse>was location of</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft>image</subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="depicts" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="describes" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>describes</typename>
+              <typename_reverse>is described by</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_vocabulary_terms">
+      <types>
+        <type code="described" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="depicts" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_entities_x_entities">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="child" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is child of</typename>
+              <typename_reverse>is parent of</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft>individual</subTypeLeft>
+          <subTypeRight>individual</subTypeRight>
+        </type>
+        <type code="spouse" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is spouse of</typename>
+              <typename_reverse>is spouse of</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft>individual</subTypeLeft>
+          <subTypeRight>individual</subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_entities_x_places">
+      <types>
+        <type code="birthplace" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>was born at</typename>
+              <typename_reverse>was birthplace of</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="residence" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>resided at</typename>
+              <typename_reverse>was residence of</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="workplace" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>worked at</typename>
+              <typename_reverse>was workplace of</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="ownership" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>owned</typename>
+              <typename_reverse>was owned by</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="built_by" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>built</typename>
+              <typename_reverse>was built by</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_entities_x_occurrences">
+      <types>
+        <type code="actor" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is actor in</typename>
+              <typename_reverse>has as actor</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="artist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is artist of</typename>
+              <typename_reverse>has as artist</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="artistic_director" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is artistic director of</typename>
+              <typename_reverse>has as artistic director</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="assoicate_producer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is associate producer of</typename>
+              <typename_reverse>has as assoicate producer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="author" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is author of</typename>
+              <typename_reverse>has as author</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="broadcast_engineer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is broadcast engineer of</typename>
+              <typename_reverse>has as broadcast engineer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="camera_operator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is camera operator of</typename>
+              <typename_reverse>has as camera operator</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="caption_writer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is caption writer of</typename>
+              <typename_reverse>has as caption writer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="casting_director" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is casting director of</typename>
+              <typename_reverse>has as casting director</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="choreographer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is choreographer of</typename>
+              <typename_reverse>has as choreographer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="cinematographer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is cinematographer of</typename>
+              <typename_reverse>has as cinematographer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="co_producer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is co-producer of</typename>
+              <typename_reverse>has as co-producer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="commentator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is commentator of</typename>
+              <typename_reverse>has as commentator</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="composer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is composer of</typename>
+              <typename_reverse>has as composer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="concept_artist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is concept artist of</typename>
+              <typename_reverse>has as concept artist</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="conductor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is conductor of</typename>
+              <typename_reverse>has as conductor</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="costume_designer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is costume designer of</typename>
+              <typename_reverse>has as costume designer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="creator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is creator of</typename>
+              <typename_reverse>has as creator</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="describer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is describer of</typename>
+              <typename_reverse>has as describer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="director" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is director of</typename>
+              <typename_reverse>has as director</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="director_of_photography" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is director of photography of</typename>
+              <typename_reverse>has as director of photography</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="editor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is editor of</typename>
+              <typename_reverse>has as editor</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="executive_producer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is executive producer of</typename>
+              <typename_reverse>has as executive producer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="filmmaker" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is filmmaker of</typename>
+              <typename_reverse>has as filmmaker</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="foley_artist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is foley artist of</typename>
+              <typename_reverse>has as foley artist</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="graphic_designer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is graphic designer of</typename>
+              <typename_reverse>has as graphic designer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="graphic_editor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is graphic editor of</typename>
+              <typename_reverse>has as graphic editor</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="guest" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is guest of</typename>
+              <typename_reverse>has as guest</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="host" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is host of</typename>
+              <typename_reverse>has as host</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="interviewee" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is interviewee of</typename>
+              <typename_reverse>has as interviewee</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="interviewer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is interviewer of</typename>
+              <typename_reverse>has as interviewer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="lighting_technician" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is lighting technican of</typename>
+              <typename_reverse>has as lighting technician</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="make_up_artist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is make-up artist of</typename>
+              <typename_reverse>has as make-up artist</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="moderator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is moderator of</typename>
+              <typename_reverse>has as moderator</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="music_supervisor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is music supervisor of</typename>
+              <typename_reverse>has as music supervisor</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="musician" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is musician of</typename>
+              <typename_reverse>has as musician</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="narrator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is narrator of</typename>
+              <typename_reverse>has as narrator</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="panelist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is panelist of</typename>
+              <typename_reverse>has as panelist</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="performer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is performer of</typename>
+              <typename_reverse>has as performer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="performing_group" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is performing group of</typename>
+              <typename_reverse>has as performing group</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="photographer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is photographer of</typename>
+              <typename_reverse>has as photographer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="producer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is producer of</typename>
+              <typename_reverse>has as producer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="production_unit" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is production unit of</typename>
+              <typename_reverse>has as production unit</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="recording_engineer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is recording engineer of</typename>
+              <typename_reverse>has as recording engineer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="reporter" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is reporter of</typename>
+              <typename_reverse>has as reporter</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="set_designer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is set designer of</typename>
+              <typename_reverse>has as set designer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="sound_designer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is sound designer of</typename>
+              <typename_reverse>has as sound designer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="sound_editor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is sound editor of</typename>
+              <typename_reverse>has as sound editor</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="speaker" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is speaker of</typename>
+              <typename_reverse>has as speaker</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="technical_director" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is technical director of</typename>
+              <typename_reverse>has as technical director</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="video_engineer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is video engineer of</typename>
+              <typename_reverse>has as video engineer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="vocalist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is vocalist of</typename>
+              <typename_reverse>has as vocalist</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="voiceover_artist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is voiceover artist of</typename>
+              <typename_reverse>has as voiceover artist</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="writer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is writer of</typename>
+              <typename_reverse>has as writer</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <!-- Publisher -->
+        <type code="publisher" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is publisher of</typename>
+              <typename_reverse>has as publisher</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="distributor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is distributor of</typename>
+              <typename_reverse>has as distributor</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+        <type code="presenter" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is presenter of</typename>
+              <typename_reverse>has presenter by</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight/>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_entities">
+      <types>
+        <type code="donor" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>was donated by</typename>
+              <typename_reverse>is donor of</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="provider" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>was provided by</typename>
+              <typename_reverse>is provider of</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_places">
+      <types>
+        <type code="originates" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>originates from</typename>
+              <typename_reverse>is origination location of</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_collections">
+      <types>
+        <type code="part_of" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is part of</typename>
+              <typename_reverse>contains</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_entities_x_collections">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_entities_x_vocabulary_terms">
+      <types>
+        <type code="described" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_places_x_places">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_places_x_vocabulary_terms">
+      <types>
+        <type code="describes" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_occurrences_x_collections">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft>event</subTypeLeft>
+          <subTypeRight>event</subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_occurrences_x_vocabulary_terms">
+      <types>
+        <type code="describes" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="subject" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has subject</typename>
+              <typename_reverse>is subject</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_places_x_occurrences">
+      <types>
+        <type code="site" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>was site of</typename>
+              <typename_reverse>occurred at</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight>event</subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_collections_x_collections">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_collections_x_vocabulary_terms">
+      <types>
+        <type code="described" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_places_x_collections">
+      <types>
+        <type code="location" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is location of</typename>
+              <typename_reverse>is located in</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_list_items_x_list_items">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_representation_annotations_x_objects">
+      <types>
+        <type code="depicts" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="illustrated" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is illustrated by</typename>
+              <typename_reverse>illustrates</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_representation_annotations_x_entities">
+      <types>
+        <type code="depicts" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="describes" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>describes</typename>
+              <typename_reverse>is described by</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_representation_annotations_x_places">
+      <types>
+        <type code="depicts" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+        <type code="describes" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>describes</typename>
+              <typename_reverse>is described by</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_representation_annotations_x_occurrences">
+      <types>
+        <type code="depicts" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight>event</subTypeRight>
+        </type>
+        <type code="describes" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>describes</typename>
+              <typename_reverse>is described by</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight>event</subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_representation_annotations_x_vocabulary_terms">
+      <types>
+        <type code="describes" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+          <subTypeLeft> </subTypeLeft>
+          <subTypeRight></subTypeRight>
+        </type>
+      </types>
+    </relationshipTable>
+  </relationshipTypes>
+</profile>


### PR DESCRIPTION
Amendment for [SYS-1774](https://uclalibrary.atlassian.net/browse/SYS-1774)

- Filename for PBCore 2.1 XML profile was originally committed as `pbcore_2.1.xml`, but this caused an issue with install
- Updated the filename to `pbcore_2_1.xml`

[SYS-1774]: https://uclalibrary.atlassian.net/browse/SYS-1774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ