### PR TITLE
SYS-1777: Provide APACHE variable values for GA build

### DIFF
--- a/.github/workflows/build_docker_hub.yml
+++ b/.github/workflows/build_docker_hub.yml
@@ -36,3 +36,6 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.yaml-data.outputs.data }}
+          build-args: |
+            APACHE_RUN_USER="ca-www-data"
+            APACHE_RUN_GROUP="ca-www-data"


### PR DESCRIPTION
Fixes a bug where the Github Action to build the Docker image failed because the APACHE-related args had no values, because they normally come from docker-compose.

The GA `build-push-action` apparently does not support environment files, so environment variables must be supplied in-line.  I added the 2 values required and confirmed the action now succeeds.

During the pilot, this is fine.  If we move beyond pilot, I'll figure out a better way to do this, either skipping those custom values altogether for production builds (since they only exist to support permissions when mounting the code into the container in the dev environment) or pulling them from the YAML of the Helm chart we'll probably use.
