### PR TITLE
SYS-1777: Fix quoting problem for ca-www-data apache user in GA workflow

### DIFF
--- a/.github/workflows/build_docker_hub.yml
+++ b/.github/workflows/build_docker_hub.yml
@@ -37,5 +37,5 @@ jobs:
           push: true
           tags: ${{ steps.yaml-data.outputs.data }}
           build-args: |
-            APACHE_RUN_USER="ca-www-data"
-            APACHE_RUN_GROUP="ca-www-data"
+            APACHE_RUN_USER=ca-www-data
+            APACHE_RUN_GROUP=ca-www-data

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -2,7 +2,7 @@
 service: ucla-ca-providence
 
 # Name of the container image.
-image: uclalibrary/ucla-ca-providence:1.0.3
+image: uclalibrary/ucla-ca-providence:1.0.4
 
 # Deploy to these servers.
 servers:
@@ -42,7 +42,7 @@ ssh:
 
 accessories:
   providence: 
-    image: uclalibrary/ucla-ca-providence:1.0.3
+    image: uclalibrary/ucla-ca-providence:1.0.4
     host: t-u-kamalapp01.library.ucla.edu
     proxy:
       ssl: true


### PR DESCRIPTION
This fixes a problem in the Github Actions build and push workflow.  The quotes around environment variables are passed as part of the value into the image when built, resulting in a user `"ca-www-data"` (with quotes) instead of `ca-www-data`.

Version tag bumped to `1.0.4` for deployment to pilot environment.
