### PR TITLE
SYS-1810: Update app.conf to enable movements, and use local subfolder

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -2,7 +2,7 @@
 service: ucla-ca-providence
 
 # Name of the container image.
-image: uclalibrary/ucla-ca-providence:1.0.5
+image: uclalibrary/ucla-ca-providence:1.0.6
 
 # Deploy to these servers.
 servers:
@@ -42,7 +42,7 @@ ssh:
 
 accessories:
   providence: 
-    image: uclalibrary/ucla-ca-providence:1.0.5
+    image: uclalibrary/ucla-ca-providence:1.0.6
     host: t-u-kamalapp01.library.ucla.edu
     proxy:
       ssl: true

--- a/ucla_customizations/app/conf/local/app.conf
+++ b/ucla_customizations/app/conf/local/app.conf
@@ -3412,7 +3412,8 @@ history_tracking_policies = {
 						useDatePicker = 0,
 						template = "<l>^ca_storage_locations.hierarchy.preferred_labels.name%delimiter=_➜_</l>  <ifdef code='ca_objects_x_storage_locations.movement_by'> <br>MOVED BY: ^ca_objects_x_storage_locations.movement_by</ifdef>  <ifdef code='ca_objects_x_storage_locations.movement_comments'> <br>COMMENTS: ^ca_objects_x_storage_locations.movement_comments</ifdef>",
 						trackingRelationshipType = related,
-						restrictToRelationshipTypes = [related]
+						restrictToRelationshipTypes = [related],
+						useHierarchicalBrowser = 1,
 					}
 				},
 				ca_occurrences = {

--- a/ucla_customizations/app/conf/local/app.conf
+++ b/ucla_customizations/app/conf/local/app.conf
@@ -2840,7 +2840,7 @@ configuration_export_exclude_lists = []
 # Object lot inheritance
 # -----------------------------------
 # Controls whether a newly created object will inherit its lot relationship from its parent object
-ca_objects_dont_inherit_lot_from_parent = 1
+ca_objects_dont_inherit_lot_from_parent = 0
 
 # Controls whether a newly created object will inherit its default idno from the lot set at creation time
 ca_objects_dont_inherit_idno_from_lot = 0

--- a/ucla_customizations/app/conf/local/app.conf
+++ b/ucla_customizations/app/conf/local/app.conf
@@ -326,7 +326,7 @@ ca_collections_disable = 0
 ca_object_lots_disable = 0
 ca_storage_locations_disable = 0
 ca_loans_disable = 0
-ca_movements_disable = 1
+ca_movements_disable = 0
 ca_tours_disable = 1
 ca_object_representations_disable = 1
 
@@ -2840,7 +2840,7 @@ configuration_export_exclude_lists = []
 # Object lot inheritance
 # -----------------------------------
 # Controls whether a newly created object will inherit its lot relationship from its parent object
-ca_objects_dont_inherit_lot_from_parent = 0
+ca_objects_dont_inherit_lot_from_parent = 1
 
 # Controls whether a newly created object will inherit its default idno from the lot set at creation time
 ca_objects_dont_inherit_idno_from_lot = 0
@@ -3393,3 +3393,72 @@ idno_element_display_format_without_label = <div class='formLabel'>^ELEMENT <spa
 
 # Log directory for external export activity
 external_export_log_directory = <ca_base_dir>/app/log
+
+# New configuration for history tracking
+# Uses example configuration supporting combined workflow- and movement-based history tracking
+history_tracking_policies = {
+	defaults = { 
+		ca_objects = current_location
+	},
+	policies = {
+		current_location = {
+			name = _(Current location),
+			table = ca_objects,
+			elements = {
+				ca_storage_locations = {
+					__default__ = {
+						date = ca_objects_x_storage_locations.effective_date,
+						setInterstitialElementsOnAdd = [effective_date],
+						useDatePicker = 0,
+						template = "<l>^ca_storage_locations.hierarchy.preferred_labels.name%delimiter=_➜_</l>  <ifdef code='ca_objects_x_storage_locations.movement_by'> <br>MOVED BY: ^ca_objects_x_storage_locations.movement_by</ifdef>  <ifdef code='ca_objects_x_storage_locations.movement_comments'> <br>COMMENTS: ^ca_objects_x_storage_locations.movement_comments</ifdef>",
+						trackingRelationshipType = related,
+						restrictToRelationshipTypes = [related]
+					}
+				},
+				ca_occurrences = {
+					exhibition = {
+						date = ca_occurrences.exhibition_date,
+						setInterstitialElementsOnAdd = [effective_date],
+						template = "<l>^ca_occurrences.preferred_labels.name</l>",
+					},
+					__default__ = {
+						date = ca_objects_x_occurrences.effective_date,
+						setInterstitialElementsOnAdd = [effective_date],
+						template = "<l>^ca_occurrences.idno</l> ^ca_occurrences.preferred_labels.name",
+					}
+				},
+				ca_loans = {
+					__default__  = { 
+						date = ca_loans_x_objects.effective_date,
+						setInterstitialElementsOnAdd = [effective_date],
+						color = F78B8B,
+						template = <l>^ca_loans.idno</l> ^ca_loans.preferred_labels (^ca_loans.institution ^ca_loans.date) <ifdef code='ca_loans_x_objects.movement_comments'> <br>COMMENTS: ^ca_loans_x_objects.movement_comments</ifdef>,
+						restrictToRelationshipTypes = [loan]
+					  }   
+				},
+				ca_movements = {
+					__default__ = {
+						date = ca_movements.placementDate,
+						setInterstitialElementsOnAdd = [effective_date],
+						template ="<unit relativeTo='ca_movements'>[^ca_movements.idno] <l>^ca_movements.preferred_labels.name</l>,  ^ca_movements.purposeNotes<br/>
+								<unit relativeTo='ca_storage_locations' restrictToRelationshipTypes='location'>Moved to <l>^ca_storage_locations.hierarchy.preferred_labels.name%delimiter=_➜_</l></unit>
+							</unit>",
+						trackingRelationshipType = location,
+
+						# useRelated = for browsing purposes log the current value as the first related item in this table
+						useRelated = ca_storage_locations,
+
+						# useRelatedRelationshipType = relationship type used when logging current value against related table
+						useRelatedRelationshipType = location_tracking,
+
+						# ca_movements_x_storage_locations relationship types for old and new parent locations 
+						# (used when tracking movements of storage locations within the location hierarchy)
+						originalLocationTrackingRelationshipType = original_location,
+						newLocationTrackingRelationshipType = new_location,
+						subLocationTrackingRelationshipType = sub_location
+					}
+				}
+			}
+		}
+	}
+ }

--- a/ucla_providence/app/conf/app.conf
+++ b/ucla_providence/app/conf/app.conf
@@ -412,7 +412,7 @@ ca_tour_stops_show_related_counts_in_inspector_for = []
 # Show "add child record" control in editor inspector?
 # -----------------------------------
 #
-ca_objects_show_add_child_control_in_inspector = 1
+ca_objects_show_add_child_control_in_inspector = 0
 ca_entities_show_add_child_control_in_inspector = 0
 ca_places_show_add_child_control_in_inspector = 1
 ca_occurrences_show_add_child_control_in_inspector = 0
@@ -478,7 +478,7 @@ set_editor_default_table = ca_objects
 # The type hierarchy behavior can be independently for each type of hierarchical record.
 # Set to 1 to fully enable, 0 to disable and ~ (tilde character) to partially enable restrictions.
 #
-ca_objects_enforce_strict_type_hierarchy = 1
+ca_objects_enforce_strict_type_hierarchy = 0
 ca_entities_enforce_strict_type_hierarchy = 0
 ca_places_enforce_strict_type_hierarchy = 0
 ca_occurrences_enforce_strict_type_hierarchy = 0
@@ -2259,10 +2259,10 @@ delete_reference_handling_default = remove
 # ca_objects_component_container_template, ca_objects_component_display_template and ca_objects_component_num_columns directives.
 # 
 # List of object types to which components may be attached
-ca_objects_container_types = [moving_digital, moving_analog]
+ca_objects_container_types = []
 
 # List of object types used for components
-ca_objects_component_types = [moving_component]
+ca_objects_component_types = []
 
 # Display inspector tools for merging and unmerging of component media. Merging will take all media attached to components, attach
 # it to the parent as object representations and delete the components. Unmerging will take all object representation media 
@@ -2270,16 +2270,16 @@ ca_objects_component_types = [moving_component]
 ca_objects_component_allow_merge_unmerge = 0
 
 # In ca_objects_components_list bundle, the number of columns used when listing components
-ca_objects_component_num_columns = 1
+ca_objects_component_num_columns = 3
 
 # Template used got overall formatting of component list in ca_objects_components_list bundle
 # The ^COMPONENT_LIST tag will contain a full list of attached components, with each component formatted using
 # the template defined in the ca_objects_component_display_template directive.
-ca_objects_component_container_template = "<div class='componentGrid' style='display: flex; flex-direction: column; gap: 0.5rem;'>
-	<div class='componentHeader' style='display: flex; justify-content: space-between;'>
-		<div class='componentHeaderItem' style='width: 33%'>Name</div>
-		<div class='componentHeaderItem' style='width: 33%'>Accession Number</div>
-		<div class='componentHeaderItem' style='width: 33%'>Location</div>
+ca_objects_component_container_template = "<div class='componentGrid'>
+	<div class='componentHeader'>
+		<div class='componentHeaderItem'>Name</div>
+		<div class='componentHeaderItem'>Accession Number</div>
+		<div class='componentHeaderItem'>Location</div>
 	</div>
 	^COMPONENT_LIST
 </div>"
@@ -2287,9 +2287,9 @@ ca_objects_component_container_template = "<div class='componentGrid' style='dis
 # Template used to format each attached component for display
 ca_objects_component_display_template = "
 <case>
-	<if rule='^ca_objects.element_inactive = \"Yes\"'><div class='componentRowDisabled'><div class='componentItem' style='width: 33%'><l>^ca_objects.preferred_labels.name</l> (inactive)</div><div class='componentItem' style='width: 33%'>^ca_objects.idno</div><div class='componentItem' style='width: 33%'>^ca_objects.history_tracking_current_value%policy=current_location</div></div></if>
-	<div class='componentRow' style='display: flex; justify-content: space-between;'><div class='componentItem' style='width: 33%'><l>^ca_objects.preferred_labels.name</l></div><div class='componentItem' style='width: 33%'>^ca_objects.idno</div><div class='componentItem' style='width: 33%'>^ca_objects.history_tracking_current_value%policy=current_location</div></div>"
-ca_objects_component_current_display_template = "<div class='componentRow' style='display: flex; justify-content: space-between;'><div class='componentItem componentItemSelected'>^ca_objects.preferred_labels.name</div><div class='componentItem' style='width: 33%'>^ca_objects.idno</div><div class='componentItem' style='width: 33%'>^ca_objects.history_tracking_current_value%policy=current_location</div></div>
+	<if rule='^ca_objects.element_inactive = \"Yes\"'><div class='componentRowDisabled'><div class='componentItem'><l>^ca_objects.preferred_labels.name</l> (inactive)</div><div class='componentItem'>^ca_objects.idno</div><div class='componentItem'>^ca_objects.history_tracking_current_value%policy=current_location</div></div></if>
+	<div class='componentRow'><div class='componentItem'><l>^ca_objects.preferred_labels.name</l></div><div class='componentItem'>^ca_objects.idno</div><div class='componentItem'>^ca_objects.history_tracking_current_value%policy=current_location</div></div>"
+ca_objects_component_current_display_template = "<div class='componentRow'><div class='componentItem componentItemSelected'>^ca_objects.preferred_labels.name</div><div class='componentItem'>^ca_objects.idno</div><div class='componentItem'>^ca_objects.history_tracking_current_value%policy=current_location</div></div>
 </case>"
                                                                     
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ucla_providence/app/conf/local/app.conf
+++ b/ucla_providence/app/conf/local/app.conf
@@ -3412,7 +3412,8 @@ history_tracking_policies = {
 						useDatePicker = 0,
 						template = "<l>^ca_storage_locations.hierarchy.preferred_labels.name%delimiter=_➜_</l>  <ifdef code='ca_objects_x_storage_locations.movement_by'> <br>MOVED BY: ^ca_objects_x_storage_locations.movement_by</ifdef>  <ifdef code='ca_objects_x_storage_locations.movement_comments'> <br>COMMENTS: ^ca_objects_x_storage_locations.movement_comments</ifdef>",
 						trackingRelationshipType = related,
-						restrictToRelationshipTypes = [related]
+						restrictToRelationshipTypes = [related],
+						useHierarchicalBrowser = 1,
 					}
 				},
 				ca_occurrences = {

--- a/ucla_providence/app/conf/local/app.conf
+++ b/ucla_providence/app/conf/local/app.conf
@@ -2840,7 +2840,7 @@ configuration_export_exclude_lists = []
 # Object lot inheritance
 # -----------------------------------
 # Controls whether a newly created object will inherit its lot relationship from its parent object
-ca_objects_dont_inherit_lot_from_parent = 1
+ca_objects_dont_inherit_lot_from_parent = 0
 
 # Controls whether a newly created object will inherit its default idno from the lot set at creation time
 ca_objects_dont_inherit_idno_from_lot = 0

--- a/ucla_providence/app/conf/local/app.conf
+++ b/ucla_providence/app/conf/local/app.conf
@@ -1,0 +1,3464 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#                                     __
+#                                   / _|
+#   __ _ _ __  _ __   ___ ___  _ __ | |_
+#  / _` | '_ \| '_ \ / __/ _ \| '_ \|  _|
+# | (_| | |_) | |_) | (_| (_) | | | | |
+#  \__,_| .__/| .__(_)___\___/|_| |_|_|
+#       | |   | |
+#       |_|   |_|
+# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+# Providence 
+# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+#
+# Info @ https://docs.collectiveaccess.org/providence/user/configuration/configuringProvidence/mainConfiguration/app
+# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+# 
+#    WHAT: This is the main application configuration file for Providence, designed so that users can easy manage various 
+#          system-wide settings in one convenient location.
+#
+#    WHEN TO CUSTOMIZE:  App.conf handles most customizations that are not controlled through the UI or profile (with
+#          the notable exceptions of: browse, id number configurations, and additional settings for dates, media and search).
+#          This document is broken into the following sections: Disable, Hierarchies, Titles & Ids, Search, 
+#		   Feature Settings, Access Control, Styling, Mapping, System Defaults, Media, Admin Configuration and Export 
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   __  __                      
+#  |  \/  |                     
+#  | \  / | ___ _ __  _   _ ___ 
+#  | |\/| |/ _ \ '_ \| | | / __|
+#  | |  | |  __/ | | | |_| \__ \
+#  |_|  |_|\___|_| |_|\__,_|___/
+#                              
+#  Control the "New" and "Find" menus in Providence                           
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# -----------------------------------
+# Menu bar preferences
+# -----------------------------------
+#
+# By default each of the follow record types has a sub-menu in the top-level "New" menu
+# list out the configured types. When you choose a type the creation of new record of that type
+# is initiated. If you have several types configured sub-menus make sense, but if your setup only
+# has one or two types, or is deeply nested then you may want to push the first level of types
+# directly onto the menu. Setting the directives below will force the first level of the sub-menu onto
+# the "new" menu itself.
+#
+ca_object_lots_no_new_submenu = 0
+ca_objects_no_new_submenu = 0
+ca_entities_no_new_submenu = 0
+ca_collections_no_new_submenu = 0
+ca_occurrences_no_new_submenu = 1
+ca_loans_no_new_submenu = 0
+ca_movements_no_new_submenu = 0
+ca_tours_no_new_submenu = 0
+ca_object_representations_no_new_submenu = 0
+
+
+# -----------------------------------
+# Find menu formatting
+# -----------------------------------
+#
+# By default only the top-level item classes ("objects", "entities", "collections") appear in the find menu
+# Set the following to a non-zero value to break out each top-level item into a submenu with types
+# This allows you do to type-specific searches and browses
+#
+ca_objects_breakout_find_by_type_in_submenu = 0
+ca_object_lots_breakout_find_by_type_in_submenu = 0
+ca_object_representations_breakout_find_by_type_in_submenu = 0
+ca_entities_breakout_find_by_type_in_submenu = 0
+ca_places_breakout_find_by_type_in_submenu = 0
+ca_occurrences_breakout_find_by_type_in_submenu = 0
+ca_collections_breakout_find_by_type_in_submenu = 0
+ca_loans_breakout_find_by_type_in_submenu = 0
+ca_movements_breakout_find_by_type_in_submenu = 0
+ca_sets_breakout_find_by_type_in_submenu = 1
+
+# Set the following to a non-zero value to put types directly into the find menu, replacing the top-level item class
+# This allows you do to type-specific searches and browses where the types are treated as generic top-level items
+#
+ca_objects_breakout_find_by_type_in_menu = 0
+ca_object_lots_breakout_find_by_type_in_menu = 0
+ca_object_representations_breakout_find_by_type_in_menu = 0
+ca_entities_breakout_find_by_type_in_menu = 0
+ca_places_breakout_find_by_type_in_menu = 0
+ca_occurrences_breakout_find_by_type_in_menu = 1
+ca_collections_breakout_find_by_type_in_menu = 0
+ca_loans_breakout_find_by_type_in_menu = 0
+ca_movements_breakout_find_by_type_in_menu = 0
+ca_sets_breakout_find_by_type_in_menu = 0
+
+# -----------------------------------
+# Navigation options
+# -----------------------------------
+#
+# If you only want to allow users to create new records with top-level types for
+# a give item type, set the appropriate directive below to 1; if set users will still be able
+# to create records for sub-types, but only from within an existing record with a top-level types
+# This can be useful if you have a system where sub-types need to be subsidiary to top-level records -
+# eg. sub-type records need to have a top-level parent and cannot exist on their own
+#
+ca_objects_navigation_new_menu_shows_top_level_types_only = 0
+ca_entities_navigation_new_menu_shows_top_level_types_only = 0
+ca_places_navigation_new_menu_shows_top_level_types_only = 0
+ca_occurrences_navigation_new_menu_shows_top_level_types_only = 0
+ca_collections_navigation_new_menu_shows_top_level_types_only = 0
+ca_object_lots_navigation_new_menu_shows_top_level_types_only = 0
+ca_storage_locations_navigation_new_menu_shows_top_level_types_only = 0
+ca_loans_navigation_new_menu_shows_top_level_types_only = 0
+ca_movements_navigation_new_menu_shows_top_level_types_only = 0
+ca_object_representations_navigation_new_menu_shows_top_level_types_only = 0
+
+
+# If <table>_breakout_find_by_type_in_menu is set and you want to allow users to only 
+# search for records through top-level types, without displaying sub-types in the "find" 
+# menu, set the appropriate directive below to 1; if set users will give only options for 
+# search/advanced search/browse for top-level types of the relevant table. A sub-menu for
+# each top-level type will contain options for search/advanced search/browse
+ca_objects_navigation_find_menu_shows_top_level_types_only = 0
+ca_entities_navigation_find_menu_shows_top_level_types_only = 0
+ca_places_navigation_find_menu_shows_top_level_types_only = 0
+ca_occurrences_navigation_find_menu_shows_top_level_types_only = 0
+ca_collections_navigation_find_menu_shows_top_level_types_only = 0
+ca_object_lots_navigation_find_menu_shows_top_level_types_only = 0
+ca_storage_locations_navigation_find_menu_shows_top_level_types_only = 0
+ca_loans_navigation_find_menu_shows_top_level_types_only = 0
+ca_movements_navigation_find_menu_shows_top_level_types_only = 0
+ca_object_representations_navigation_find_menu_shows_top_level_types_only = 0
+
+# Nested (hierarchical) types may be listed in a series of nested menus or as a single
+# menu of indented options. For larger type hierarchies using nested menus (the default)
+# will usually be easier to use by only showing a portion of the hierarchy at a time. For
+# snall, deeply nested hierarchies (such as typical collection type hierarchies where 
+# may be are 5+ levels, but each level contains only a single type) using an indented list
+# where the entire hierarchy is shown at once with nesting indicated by indenting may be
+# preferrable.
+ca_objects_navigation_new_menu_use_indented_type_lists = 0
+ca_entities_navigation_new_menu_use_indented_type_lists = 0
+ca_places_navigation_new_menu_use_indented_type_lists = 0
+ca_occurrences_navigation_new_menu_use_indented_type_lists = 0
+ca_collections_navigation_new_menu_use_indented_type_lists = 1
+ca_object_lots_navigation_new_menu_use_indented_type_lists = 0
+ca_storage_locations_navigation_new_menu_use_indented_type_lists = 0
+ca_loans_navigation_new_menu_use_indented_type_lists = 0
+ca_movements_navigation_new_menu_use_indented_type_lists = 0
+ca_object_representations_navigation_new_menu_use_indented_type_lists = 0
+
+
+# You can enumerate the types and sub-types shown in the new menu below...
+# ... by limiting the types to be shown
+ca_objects_navigation_new_menu_limit_types_to = []
+ca_entities_navigation_new_menu_limit_types_to = []
+ca_places_navigation_new_menu_limit_types_to = []
+ca_occurrences_navigation_new_menu_limit_types_to = []
+ca_collections_navigation_new_menu_limit_types_to = []
+ca_object_lots_navigation_new_menu_limit_types_to = []
+ca_storage_locations_navigation_new_menu_limit_types_to = []
+ca_loans_navigation_new_menu_limit_types_to = []
+ca_movements_navigation_new_menu_limit_types_to = []
+ca_object_representations_navigation_new_menu_limit_types_to = []
+
+# ... or by excluding specific types
+ca_objects_navigation_new_menu_exclude_types = []
+ca_entities_navigation_new_menu_exclude_types = []
+ca_places_navigation_new_menu_exclude_types = []
+ca_occurrences_navigation_new_menu_exclude_types = []
+ca_collections_navigation_new_menu_exclude_types = []
+ca_object_lots_navigation_new_menu_exclude_types = []
+ca_loans_navigation_new_menu_exclude_types = []
+ca_movements_navigation_new_menu_exclude_types = []
+ca_object_representations_navigation_new_menu_exclude_types = []
+
+# You can enumerate the types and sub-types shown in the find menu below...
+# ... by limiting the types to be shown
+ca_objects_navigation_find_menu_limit_types_to = []
+ca_entities_navigation_find_menu_limit_types_to = []
+ca_places_navigation_find_menu_limit_types_to = []
+ca_occurrences_navigation_find_menu_limit_types_to = []
+ca_collections_navigation_find_menu_limit_types_to = []
+ca_object_lots_navigation_find_menu_limit_types_to = []
+ca_loans_navigation_find_menu_limit_types_to = []
+ca_movements_navigation_find_menu_limit_types_to = []
+ca_object_representations_navigation_find_menu_limit_types_to = []
+
+# ... or by excluding specific types
+ca_objects_navigation_find_menu_exclude_types = []
+ca_entities_navigation_find_menu_exclude_types = []
+ca_places_navigation_find_menu_exclude_types = []
+ca_occurrences_navigation_find_menu_exclude_types = []
+ca_collections_navigation_find_menu_exclude_types = []
+ca_object_lots_navigation_find_menu_exclude_types = []
+ca_loans_navigation_find_menu_exclude_types = []
+ca_movements_navigation_find_menu_exclude_types = []
+ca_object_representations_navigation_find_menu_exclude_types = []
+
+# By default searches restricted to a specific type will implicitly include
+# sub-types. You can disable this behavior on a per-type basis for tables below
+ca_objects_find_dont_expand_hierarchically = []
+ca_entities_find_dont_expand_hierarchically = []
+ca_places_find_dont_expand_hierarchically = []
+ca_occurrences_find_dont_expand_hierarchically = []
+ca_collections_find_dont_expand_hierarchically = []
+ca_object_lots_find_dont_expand_hierarchically = []
+ca_loans_find_dont_expand_hierarchically = []
+ca_movements_find_dont_expand_hierarchically = []
+ca_object_representations_find_dont_expand_hierarchically = []
+
+# By default searches can be executed across all types in the "find" menu
+# by selecting the non-type specific menu entry for a table (Eg. "entities")
+# You can disable the ability to do un-restricted searches on a per-table
+# basis below
+ca_objects_find_dont_allow_non_type_restricted = 0
+ca_entities_find_dont_allow_non_type_restricted = 0
+ca_places_find_dont_allow_non_type_restricted = 0
+ca_occurrences_find_dont_allow_non_type_restricted = 0
+ca_collections_find_dont_allow_non_type_restricted = 0
+ca_object_lots_find_dont_allow_non_type_restricted = 0
+ca_movements_find_dont_allow_non_type_restricted = 0
+ca_object_representations_find_dont_allow_non_type_restricted = 0
+
+# You can disable the search, browse and/or advanced search options for specific types in tables
+# using the directives below. List types to _not_ allow search/browse/advanced search.
+ca_objects_no_search_for_types = []
+ca_entities_no_search_for_types = []
+ca_places_no_search_for_types = []
+ca_occurrences_no_search_for_types = []
+ca_collections_no_search_for_types = []
+ca_object_lots_no_search_for_types = []
+ca_object_representations_no_search_for_types = []
+ca_loans_no_search_for_types = []
+ca_movements_no_search_for_types = []
+ca_tours_no_search_for_types = []
+ca_storage_locations_no_search_for_types = []
+
+ca_objects_no_adv_search_for_types = []
+ca_entities_no_adv_search_for_types = []
+ca_places_no_adv_search_for_types = []
+ca_occurrences_no_adv_search_for_types = []
+ca_collections_no_adv_search_for_types = []
+ca_object_lots_no_adv_search_for_types = []
+ca_object_representations_no_adv_search_for_types = []
+ca_loans_no_adv_search_for_types = []
+ca_movements_no_adv_search_for_types = []
+ca_tours_no_adv_search_for_types = []
+ca_storage_locations_no_adv_search_for_types = []
+
+ca_objects_no_browse_for_types = []
+ca_entities_no_browse_for_types = []
+ca_places_no_browse_for_types = []
+ca_occurrences_no_browse_for_types = []
+ca_collections_no_browse_for_types = []
+ca_object_lots_no_browse_for_types = []
+ca_object_representations_no_browse_for_types = []
+ca_loans_no_browse_for_types = []
+ca_movements_no_browse_for_types = []
+
+
+# -----------------------------------
+# Show/Hide Representations
+# -----------------------------------
+#
+# Sometimes you want representations enabled for relationship purposes but don't want
+# to have the option to create or edit them as free-standing records. You can control
+# whether the object representations, when enabled in general above, show up in the "new"
+# and "find" menus using the directives below. Set them to a non-zero value to remove
+# object representations from the specified menu.
+#
+ca_object_representations_dont_show_in_new_menu = 0
+ca_object_representations_dont_show_in_find_menu = 0
+
+# -----------------------------------
+# Show/Hide Tables
+# -----------------------------------
+#
+# If you don't want certain modules to show up in the "New" menu, you can disable them
+# here. They will still be searchable and can be created using QuickAdd or direct links
+# (e.g. in the editor inspector of a related record, like an Object created from a Lot)
+#
+ca_objects_dont_show_in_new_menu = 0
+ca_entities_dont_show_in_new_menu = 0
+ca_places_dont_show_in_new_menu = 0
+ca_occurrences_dont_show_in_new_menu = 0
+ca_collections_dont_show_in_new_menu = 0
+ca_object_lots_dont_show_in_new_menu = 0
+ca_storage_locations_dont_show_in_new_menu = 0
+ca_loans_dont_show_in_new_menu = 0
+ca_movements_dont_show_in_new_menu = 0
+
+
+# -----------------------------------
+# Menu bar caching
+# -----------------------------------
+#
+# Caching the menu bar can significantly increase performance
+# If you are developing a profile. caching can prevent you from seeing profile
+# changes in real-time, however. So you can disable it here if need be. When using
+# the system "in production" it is usually best to leave this enabled
+#
+do_menu_bar_caching = 0
+
+                                      
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   _____  _           _     _      
+#  |  __ \(_)         | |   | |     
+#  | |  | |_ ___  __ _| |__ | | ___ 
+#  | |  | | / __|/ _` | '_ \| |/ _ \
+#  | |__| | \__ \ (_| | |_) | |  __/
+#  |_____/|_|___/\__,_|_.__/|_|\___|
+#                                  
+#  Turn off (or on) various features and database areas.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                              
+# -----------------------------------
+# Editor "disable" switches
+# -----------------------------------
+#
+# If you're not using certain editors in your system (you don't catalogue places for example)
+# you can disable the menu items for them by setting the various *_disable directives below to a non-zero value
+#
+ca_objects_disable = 0
+ca_entities_disable = 0
+ca_places_disable = 0
+ca_occurrences_disable = 0
+ca_collections_disable = 0
+ca_object_lots_disable = 0
+ca_storage_locations_disable = 0
+ca_loans_disable = 0
+ca_movements_disable = 0
+ca_tours_disable = 1
+ca_object_representations_disable = 1
+
+
+# -----------------------------------
+# QuickAdd disable switches
+# -----------------------------------
+#
+ca_objects_disable_quickadd = 0
+ca_entities_disable_quickadd = 0
+ca_places_disable_quickadd = 0
+ca_occurrences_disable_quickadd = 0
+ca_collections_disable_quickadd = 0
+ca_object_lots_disable_quickadd = 0
+ca_storage_locations_disable_quickadd = 0
+ca_loans_disable_quickadd = 0
+ca_movements_disable_quickadd = 0
+
+# Split name on initial load of quickadd editor?
+# If set to 0 only displayname will be populated initially with
+# forename and surname fields are left left blank
+ca_entities_split_name_on_quickadd_load = 0
+
+# -----------------------------------
+# Disable "Add new <object> to lot" 
+# -----------------------------------
+# (in the object lot editor inspector)
+#
+disable_add_object_to_lot_inspector_controls = 0
+
+# -----------------------------------
+# Inspector options 
+# (all can be set on a per-table basis)
+# -----------------------------------
+
+# Show next/previous navigation by idno sequence?
+ca_objects_inspector_display_idno_sequence_navigation = 0
+
+# Flags to display in inspector. Keys are expressions, values are display text for flag.
+# If expression evaluates to true, flag is displayed. Expressions may include references to 
+# bundles in the current record, using standard display template syntax (Eg. ^ca_objects.idno)
+ca_objects_inspector_display_flags = {
+#	"^ca_objects.preferred_labels.name !~ /concrete is fluid/i" = "IS NOT CONCRETE!"
+}
+
+# Delimiter to separate multiple flags with
+ca_objects_inspector_display_flags_delimiter = ";"
+
+# Display template used to format title of current record. If not set preferred label is used.
+# Template is evaluated relative to current record
+#ca_objects_inspector_display_title = 
+
+# Display template, evaluated relative to current record, output below media in inspector.
+# Typically used for customized display of additional information
+#ca_objects_inspector_display_below_media = 
+
+# Display template, evaluated relative to current record, output in "more info" area below creation/modification dates.
+#ca_objects_inspector_display_more_info = 
+
+# -----------------------------------
+# Show related counts in the inspector?
+# -----------------------------------
+# Display link in inspector to search for related items. Links can be
+# set for all records in a related table, or for specific types in a related table.
+# Separate types from the table name using a "/" character. Separate multiple types with 
+# commas or semicolons. To break out counts for all types use "*". For example:
+#
+#   ca_objects/artworks;videos  => links for related artwork and video objects
+#   ca_objects/*   => links for each type of related object
+#   ca_objects     => a single like to all related objects of any type 
+#
+ca_objects_show_related_counts_in_inspector_for = []
+ca_entities_show_related_counts_in_inspector_for = [ca_objects]
+ca_places_show_related_counts_in_inspector_for = []
+ca_occurrences_show_related_counts_in_inspector_for = [ca_objects]
+ca_collections_show_related_counts_in_inspector_for = [ca_objects]
+ca_storage_locations_show_related_counts_in_inspector_for = []
+ca_loans_show_related_counts_in_inspector_for = []
+ca_movements_show_related_counts_in_inspector_for = []
+ca_tour_stops_show_related_counts_in_inspector_for = []
+
+# -----------------------------------
+# Show "add child record" control in editor inspector?
+# -----------------------------------
+#
+ca_objects_show_add_child_control_in_inspector = 1
+ca_entities_show_add_child_control_in_inspector = 0
+ca_places_show_add_child_control_in_inspector = 1
+ca_occurrences_show_add_child_control_in_inspector = 0
+ca_collections_show_add_child_control_in_inspector = 1
+ca_storage_locations_show_add_child_control_in_inspector = 1
+ca_loans_show_add_child_control_in_inspector = 0
+ca_movements_show_add_child_control_in_inspector = 0
+ca_tour_stops_show_add_child_control_in_inspector = 0
+
+# -----------------------------------
+# Set duplication disable
+# ----------------------------------- 
+# If you want to disable the ability to duplicate all items in a set across the board set this
+#
+ca_sets_disable_duplication_of_items = 0
+
+# -----------------------------------
+# Set type controls
+# -----------------------------------
+#
+enable_set_type_controls = 0
+
+# -----------------------------------
+# Default table in set editor set list
+# -----------------------------------
+#
+set_editor_default_table = ca_objects
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   _    _ _                         _     _           
+#  | |  | (_)                       | |   (_)          
+#  | |__| |_  ___ _ __ __ _ _ __ ___| |__  _  ___  ___ 
+#  |  __  | |/ _ \ '__/ _` | '__/ __| '_ \| |/ _ \/ __|
+#  | |  | | |  __/ | | (_| | | | (__| | | | |  __/\__ \
+#  |_|  |_|_|\___|_|  \__,_|_|  \___|_| |_|_|\___||___/
+#
+#  Settings for hierarchical properties and display.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# -----------------------------------
+# Strict type hierarchies
+# -----------------------------------
+#
+# When fully enabled, top-level records may only be created with top-level types, and sub-records may only be created
+# with types that are direct sub-types of the parent's type. This ensures conformance with the type hierarchy. So
+# if you have an object type hierarchy like this:
+#
+# Book
+# -- Page
+# ---- Figure
+# -- Frontspiece
+#
+# ... then top-level records can only be of type "Book." Sub-records of books may only be "Page" or "Frontspiece";
+# and sub-records of "Page" can be "Figure." "Frontspiece" may not take sub-records.
+#
+# We partially enabled, top-level records may only be created with top-level types, but sub-records may be of *any*
+# type below the top-level type, not just direct sub-types. In the example above, the sub-records of a "book" can be
+# of type "Page", "Figure" or Frontspiece; sub-records of a "Page" may be only of type "Figure."
+#
+# When disabled, all types are allowed anywhere.
+#
+# The type hierarchy behavior can be independently for each type of hierarchical record.
+# Set to 1 to fully enable, 0 to disable and ~ (tilde character) to partially enable restrictions.
+#
+ca_objects_enforce_strict_type_hierarchy = 1
+ca_entities_enforce_strict_type_hierarchy = 0
+ca_places_enforce_strict_type_hierarchy = 0
+ca_occurrences_enforce_strict_type_hierarchy = 0
+ca_collections_enforce_strict_type_hierarchy = 0
+ca_storage_locations_enforce_strict_type_hierarchy = 0
+ca_loans_enforce_strict_type_hierarchy = 0
+ca_tour_stops_enforce_strict_type_hierarchy = 0
+ca_list_items_enforce_strict_type_hierarchy = 0
+
+
+# -----------------------------------
+# Hierarchy browser items
+# -----------------------------------
+#
+
+# Template for display of each level in the hierarchy browser
+ca_objects_hierarchy_browser_display_settings = ^ca_objects.preferred_labels.name (^ca_objects.idno)
+ca_object_lots_hierarchy_browser_display_settings = ^ca_object_lots.preferred_labels (^ca_object_lots.idno_stub)
+ca_entities_hierarchy_browser_display_settings = ^ca_entities.preferred_labels (^ca_entities.idno)
+ca_places_hierarchy_browser_display_settings = ^ca_places.preferred_labels (^ca_places.idno)
+ca_occurrences_hierarchy_browser_display_settings = ^ca_occurrences.preferred_labels (^ca_occurrences.idno)
+ca_collections_hierarchy_browser_display_settings = ^ca_collections.preferred_labels (^ca_collections.idno)
+ca_list_hierarchy_browser_display_settings = ^ca_lists.preferred_labels.name (^ca_lists.list_code)
+ca_list_items_hierarchy_browser_display_settings = ^ca_list_items.preferred_labels.name_plural (^ca_list_items.idno)
+ca_storage_locations_hierarchy_browser_display_settings = ^ca_storage_locations.preferred_labels (^ca_storage_locations.idno)
+ca_tour_stops_hierarchy_browser_display_settings = ^ca_tour_stops.preferred_labels (^ca_tour_stops.idno)
+ca_relationship_types_hierarchy_browser_display_settings = ^ca_relationship_types.preferred_labels (^ca_relationship_types.type_code)
+ca_loans_hierarchy_browser_display_settings = ^ca_loans.preferred_labels (^ca_loans.idno)
+ca_movements_hierarchy_browser_display_settings = ^ca_movements.preferred_labels (^ca_movements.idno)
+ca_sets_hierarchy_browser_display_settings = ^ca_sets.preferred_labels (^ca_sets.idno)
+
+# Sort and disabled item settings for hierarchy browsers
+ca_objects_hierarchy_browser_sort_values = [ca_objects.idno_sort]
+ca_objects_hierarchy_browser_sort_direction = asc
+ca_object_lots_hierarchy_browser_sort_values = [ca_object_lots.idno_stub_sort]
+ca_object_lots_hierarchy_browser_sort_direction = asc
+ca_entities_hierarchy_browser_sort_values = [ca_entities.preferred_labels.surname, ca_entities.preferred_labels.forename]
+ca_entities_hierarchy_browser_sort_direction = asc
+ca_places_hierarchy_browser_sort_values = [ca_places.rank, ca_places.preferred_labels.name_sort]
+ca_places_hierarchy_browser_sort_direction = asc
+ca_occurrences_hierarchy_browser_sort_values = [ca_occurrences.preferred_labels.name_sort]
+ca_occurrences_hierarchy_browser_sort_direction = asc
+ca_collections_hierarchy_browser_sort_values = [ca_collections.rank, ca_collections.preferred_labels.name_sort]
+ca_collections_hierarchy_browser_sort_direction = asc
+ca_list_items_hierarchy_browser_sort_values = [ca_list_items.preferred_labels.name_sort_plural]
+ca_list_items_hierarchy_browser_sort_direction = asc
+ca_list_items_hierarchy_browser_disabled_items_mode = full
+ca_storage_locations_hierarchy_browser_sort_values = [ca_storage_locations.rank, ca_storage_locations.preferred_labels.name_sort]
+ca_storage_locations_hierarchy_browser_sort_direction = asc
+ca_storage_locations_hierarchy_browser_disabled_items_mode = disabled
+ca_tour_stops_hierarchy_browser_sort_values = [ca_tour_stops.preferred_labels.name_sort]
+ca_tour_stops_hierarchy_browser_sort_direction = asc
+ca_relationship_types_hierarchy_browser_sort_values = [ca_relationship_types.preferred_labels.typename]
+ca_relationship_types_hierarchy_browser_sort_direction = asc
+ca_loans_hierarchy_browser_sort_values = [ca_loans.preferred_labels.name_sort]
+ca_loans_hierarchy_browser_sort_direction = asc
+ca_movements_hierarchy_browser_sort_values = [ca_movements.preferred_labels.name_sort]
+ca_movements_hierarchy_browser_sort_direction = asc
+ca_sets_hierarchy_browser_sort_values = [ca_sets.preferred_labels.name]
+ca_sets_hierarchy_browser_sort_direction = asc
+
+# Optional templates to format header in "Location in Hierarchy" (hierarchy_location) hierarchy browsing bundle
+# If not set, preferred labels are used for each level in the hierarchy when displayed in the browser navigation header
+#ca_objects_hierarchy_browser_header_settings = ^ca_objects.preferred_labels.name (^ca_objects.idno)
+#ca_object_lots_hierarchy_browser_header_settings = ^ca_object_lots.preferred_labels (^ca_object_lots.idno_stub)
+#ca_entities_hierarchy_browser_header_settings = ^ca_entities.preferred_labels (^ca_entities.idno)
+#ca_places_hierarchy_browser_header_settings = ^ca_places.preferred_labels (^ca_places.idno)
+#ca_occurrences_hierarchy_browser_header_settings = ^ca_occurrences.preferred_labels (^ca_occurrences.idno)
+#ca_collections_hierarchy_browser_header_settings = ^ca_collections.preferred_labels (^ca_collections.idno)
+#ca_list_hierarchy_browser_header_settings = ^ca_lists.preferred_labels.name (^ca_lists.list_code)
+#ca_list_items_hierarchy_browser_header_settings = ^ca_list_items.preferred_labels.name_plural (^ca_list_items.idno)
+#ca_storage_locations_hierarchy_browser_header_settings = ^ca_storage_locations.preferred_labels (^ca_storage_locations.idno)
+#ca_tour_stops_hierarchy_browser_header_settings = ^ca_tour_stops.preferred_labels (^ca_tour_stops.idno)
+#ca_relationship_types_hierarchy_browser_header_settings = ^ca_relationship_types.preferred_labels (^ca_relationship_types.type_code)
+#ca_loans_hierarchy_browser_header_settings = ^ca_loans.preferred_labels (^ca_loans.idno)
+#ca_movements_hierarchy_browser_header_settings = ^ca_movements.preferred_labels (^ca_movements.idno)
+#ca_sets_hierarchy_browser_header_settings = ^ca_sets.preferred_labels (^ca_sets.idno)
+
+# -----------------------------------
+#  Collection hierarchies on the Summary screen 
+# -----------------------------------
+#
+# The summary screen includes a visual hierarchy by default for hierarchical collections. 
+# Use these directives to set the sort value for the hierarchical display, as well as the display
+# template used for format data. If nothing is set below the system will default to the settings
+# outlined in ca_collections_hierarchy_browser_sort_values.
+#                                                   
+ca_collections_hierarchy_summary_display_settings =
+ca_collections_hierarchy_summary_sort_values =
+ca_objects_hierarchy_summary_display_settings =
+ca_collections_hierarchy_summary_show_full_object_hierarachy = 0
+
+
+# -----------------------------------
+# Show/Hide hierarchy root (Storage Locations & Places)
+# -----------------------------------
+#
+# Hide hierarchy root for storage locations or places in New and Find screens
+# Note that if you haven't added any items to the hierarchies yet, enabling
+# this might prevent you from doing so (because you can't select a parent).
+#
+ca_storage_locations_hierarchy_browser_hide_root = 0
+ca_places_hierarchy_browser_hide_root = 0
+                          
+                          
+# -----------------------------------
+# Show/Hide child records in search/browse results
+# -----------------------------------
+#
+# Normally all results, regardless of their position in a hierarchy, are displayed
+# in search/browse results. Set this option for alternative policies. Possible
+# settings are:
+#		show			= 	show all results by default; allow user to filter children if they wish
+#		hide			=   hide all child records (those that are not at the top of their hierarchy) by default; allow user to remove filtering if desired
+#		alwaysShow 		=	show all results; do not allow filtering
+#		alwaysHide		=	hide all child records; do not allow the user to disable filtering
+#
+# "alwaysShow" is the default.
+#
+# While this option may be set for any table, it is typically used only for objects.
+#
+ca_objects_children_display_mode_in_results = alwaysShow
+
+
+# -----------------------------------
+# Show/Hide deaccessioned records in search/browse results
+# -----------------------------------
+#
+# Normally all results, regardless of deaccession status, are displayed
+# in search/browse results. Set this option for alternative policies. Possible
+# settings are:
+#		show			= 	show all results by default; allow user to filter deaccessioned records if they wish
+#		hide			=   hide all deaccessioned records by default; allow user to remove filtering if desired
+#		alwaysShow 		=	show all results; do not allow filtering
+#		alwaysHide		=	hide all deaccessioned records; do not allow the user to disable filtering
+#
+# "alwaysShow" is the default.
+#
+# While this option may be set for any table, it is typically used only for objects.
+#
+ca_objects_deaccession_display_mode_in_results = show
+
+# -----------------------------------
+# Enable display of collections and objects as a single hierarchy
+# -----------------------------------
+# ca_objects_x_collections_hierarchy_enabled = 1
+# ca_objects_x_collections_hierarchy_relationship_type =
+# ca_objects_x_collections_hierarchy_disable_object_collection_idno_inheritance = 
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   _______ _ _   _                     _____    _     
+#  |__   __(_) | | |              _    |_   _|  | |    
+#     | |   _| |_| | ___  ___   _| |_    | |  __| |___ 
+#     | |  | | __| |/ _ \/ __| |_   _|   | | / _` / __|
+#     | |  | | |_| |  __/\__ \   |_|    _| || (_| \__ \
+#     |_|  |_|\__|_|\___||___/         |_____\__,_|___/
+#                                                     
+#   Set whether or not titles and identifiers are required and unique.                                                      
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# -----------------------------------
+# Require input id number value to conform to format? (0=no, 1=yes)
+# -----------------------------------
+#
+require_valid_id_number_for_ca_objects = 0
+require_valid_id_number_for_ca_object_lots = 0
+require_valid_id_number_for_ca_entities = 1
+require_valid_id_number_for_ca_places = 1
+require_valid_id_number_for_ca_collections = 1
+require_valid_id_number_for_ca_occurrences = 1
+require_valid_id_number_for_ca_loans = 0
+require_valid_id_number_for_ca_movements = 0
+require_valid_id_number_for_ca_tours = 0
+require_valid_id_number_for_ca_tour_stops = 0
+require_valid_id_number_for_ca_object_representations = 0
+require_valid_id_number_for_ca_storage_locations = 0
+
+# -----------------------------------
+# Allow dupe id numbers? (0=no, 1=yes)
+# -----------------------------------
+#
+allow_duplicate_id_number_for_ca_objects = 1
+allow_duplicate_id_number_for_ca_object_lots = 1
+allow_duplicate_id_number_for_ca_entities = 1
+allow_duplicate_id_number_for_ca_places = 1
+allow_duplicate_id_number_for_ca_collections= 1
+allow_duplicate_id_number_for_ca_occurrences= 1
+allow_duplicate_id_number_for_ca_list_items= 1
+allow_duplicate_id_number_for_ca_loans= 0
+allow_duplicate_id_number_for_ca_movements= 0
+allow_duplicate_id_number_for_ca_tours= 0
+allow_duplicate_id_number_for_ca_tour_stops= 0
+allow_duplicate_id_number_for_ca_object_representations = 1
+allow_duplicate_id_number_for_ca_storage_locations = 1
+allow_duplicate_id_number_for_ca_site_pages = 1
+allow_duplicate_id_number_for_ca_metadata_dictionary_entries = 1
+
+# -----------------------------------
+# Allow dupe labels? (0=no, 1=yes)
+# -----------------------------------
+# If set to no, then atttempting to save records with a label already
+# in use by another record will fail
+#
+allow_duplicate_labels_for_ca_objects = 1
+allow_duplicate_labels_for_ca_object_lots = 1
+allow_duplicate_labels_for_ca_entities = 0
+allow_duplicate_labels_for_ca_places = 1
+allow_duplicate_labels_for_ca_collections= 0
+allow_duplicate_labels_for_ca_occurrences= 0
+allow_duplicate_labels_for_ca_storage_locations= 1
+allow_duplicate_labels_for_ca_list_items= 1
+allow_duplicate_labels_for_ca_loans = 1
+allow_duplicate_labels_for_ca_movements= 1
+allow_duplicate_labels_for_ca_object_representations= 1
+allow_duplicate_labels_for_ca_relationship_types= 1
+allow_duplicate_labels_for_ca_sets= 1
+allow_duplicate_labels_for_ca_set_items= 1
+allow_duplicate_labels_for_ca_search_forms= 1
+allow_duplicate_labels_for_ca_bundle_displays= 1
+allow_duplicate_labels_for_ca_metadata_alert_rules = 1
+allow_duplicate_labels_for_ca_editor_uis= 1
+allow_duplicate_labels_for_ca_editor_ui_screens= 1
+allow_duplicate_labels_for_ca_tours= 1
+allow_duplicate_labels_for_ca_tour_stops= 1
+allow_duplicate_labels_for_ca_metadata_dictionary_entries = 1
+allow_duplicate_labels_for_ca_representation_annotations = 1
+
+# -----------------------------------
+# Entity dupe name?
+# -----------------------------------
+# Set this to 1 if you want to display a warning when a new entity with
+# a name that already exists (preferred or nonpreferred) is about to be created
+#
+ca_entities_warn_when_preferred_label_exists = 0
+
+# -----------------------------------
+# Require preferred label? (0=no, 1=yes)
+# -----------------------------------
+# If set to yes, then attempting to save records without a preferred label
+# will fail. If set to no (default) then attempting to save a record without
+# a preferred label will automatically set the preferred label to "[BLANK]"
+#
+require_preferred_label_for_ca_objects = 0
+require_preferred_label_for_ca_object_lots = 0
+require_preferred_label_for_ca_entities = 0
+require_preferred_label_for_ca_places = 0
+require_preferred_label_for_ca_collections = 0
+require_preferred_label_for_ca_occurrences = 0
+require_preferred_label_for_ca_storage_locations = 0
+require_preferred_label_for_ca_list_items = 0
+require_preferred_label_for_ca_loans = 0
+require_preferred_label_for_ca_movements = 0
+require_preferred_label_for_ca_object_representations = 0
+require_preferred_label_for_ca_relationship_types = 0
+require_preferred_label_for_ca_set_items = 0
+require_preferred_label_for_ca_search_forms = 0
+require_preferred_label_for_ca_bundle_displays = 0
+require_preferred_label_for_ca_editor_uis = 0
+require_preferred_label_for_ca_editor_ui_screens = 0
+require_preferred_label_for_ca_tours = 0
+require_preferred_label_for_ca_tour_stops = 0
+
+#
+# Set blank label text placeholder to something other than "BLANK"
+# The text will always be enclosed in square brackets. For example,
+# if this option is set to "No label" blank preferred labels will be 
+# automatically set to [No label]
+#
+# The "blank_label_text" directive will set text for all records
+# You can set blank label text for a specific table in the form <table name>_blank_label_text
+# Ex. ca_objects_blank_label_text = BLANK TITLE
+#
+# Omit or leave blank this option to use the default placeholder of "BLANK"
+#
+#blank_label_text = No label
+#ca_objects_blank_label_text  = No label
+
+
+# -----------------------------------
+# Require preferred label value be present in a list
+# -----------------------------------
+# If set to a valid list code then any entered label value must match
+# a preferred label for an item in that list.
+#
+preferred_label_for_ca_objects_must_be_in_list =
+preferred_label_for_ca_object_lots_must_be_in_list = 
+preferred_label_for_ca_entities_must_be_in_list = 
+preferred_label_for_ca_places_must_be_in_list = 
+preferred_label_for_ca_collections_must_be_in_list = 
+preferred_label_for_ca_occurrences_must_be_in_list = 
+preferred_label_for_ca_storage_locations_must_be_in_list = 
+preferred_label_for_ca_list_items_must_be_in_list = 
+preferred_label_for_ca_loans_must_be_in_list = 
+preferred_label_for_ca_movements_must_be_in_list = 
+preferred_label_for_ca_object_representations_must_be_in_list = 
+preferred_label_for_ca_relationship_types_must_be_in_list = 
+preferred_label_for_ca_set_items_must_be_in_list = 
+preferred_label_for_ca_search_forms_must_be_in_list = 
+preferred_label_for_ca_bundle_displays_must_be_in_list = 
+preferred_label_for_ca_editor_uis_must_be_in_list = 
+preferred_label_for_ca_editor_ui_screens_must_be_in_list = 
+preferred_label_for_ca_tours_must_be_in_list = 
+preferred_label_for_ca_tour_stops_must_be_in_list = 
+
+# -----------------------------------
+# Allow automated renumbering objects with lot idno + sequence number?
+# -----------------------------------
+# (when object number don't conform to that format)
+#
+# If you're managing lots with related object-level records and the lot and
+# object numbering get out of sync (because you change the lot number after
+# the fact, for example) then this can be useful. But it can also be dangerous in the
+# sense that letting cataloguers renumber sets of objects at a click may not be the
+# idea. Only enable this if you need it. Keep in mind that the automated renumbering format
+# is fixed at lot <lot identifier> + <separator> + <sequential number starting from one>. So if
+# your lot number is 2010.10 and your separator is '.', then objects will be numbered 2010.10.1,
+# 2010.10.2, 2010.10.3, etc.
+#
+allow_automated_renumbering_of_objects_in_a_lot = 0
+
+# -----------------------------------
+# Label-less objects
+# -----------------------------------
+# If you don't want to specify preferred labels for objects set this to a non-zero value
+# This can be useful for collections where individual items lack working names, such as in
+# paleontology.
+ca_objects_dont_use_labels = 0
+
+# -----------------------------------
+# Label-specific sort
+# -----------------------------------
+# Set to assume a specific language when generating sortable titles regardless of the locale set for the title. This can be useful when content 
+# has been entered specific (or accurate) locale settings. The value can be a specific locale (Ex. "en_US") or a language code (Ex. "en") 
+#
+use_locale_for_sortable_titles =
+
+
+# Check access values in labels?
+dont_check_label_access = 1
+
+# Override label locale options? By default only locales marked as "for cataloguing" are 
+# displayed. You can override the default behavior for preferred and nonpreferred labels here 
+# by specifying one or more valid locale codes. The codes must be present in the system locale 
+# list, but do not need to be marked as for cataloguing. Locale options can be set on a global (all tables)
+# basis using the preferred_label_locales setting, on a per-table basis using the <table name>_preferred_label_locales
+# setting (Eg. ca_occurrences_preferred_label_locales = [en_US, en_CA]) or by specific table and type using the
+# <table name>_<table code>_preferred_label_locales setting (Eg. ca_occurrences_film_work_preferred_label_locales = [en_US, en_CA]
+#
+# Locales for nonpreferred labels may be set with similarly formatted "nonpreferred_label_locales" settings.
+#ca_occurrences_work_preferred_label_locales = [en_US, de_DE]
+
+# -----------------------------------
+# Label sort values
+# -----------------------------------
+# Set to on a per-table basis to control whether sortable values are automatically generated (the default)
+# or may be set directly by the user. The setting is in the form <table name>_user_settable_sortable_value
+#
+ca_objects_user_settable_sortable_value = 0
+ca_entities_user_settable_sortable_value = 0
+ca_collections_user_settable_sortable_value = 0
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#    _____                     _     
+#   / ____|                   | |    
+#  | (___   ___  __ _ _ __ ___| |__  
+#   \___ \ / _ \/ _` | '__/ __| '_ \ 
+#   ____) |  __/ (_| | | | (__| | | |
+#  |_____/ \___|\__,_|_|  \___|_| |_|
+#                                   
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                           
+
+# -----------------------------------
+# Search engine configuration
+# -----------------------------------
+#
+# Three search engines are implemented, each with different installation requirements 
+# and performance characteristics. Core functionality is the same across all 
+# engines with some engines supporting additional indexing options and wildcard and boolean operators.
+#
+# Available engines:
+#   SqlSearch = Search engine using SQL tables within the CA database to index content. This engine has no additional 
+#               dependencies outside of CA and always available without additional configuration. SqlSearch was the standard 
+#               engine through version 1.7. It is supplanted in version 1.8 by SqlSearch2 and will be removed in a future CA release.
+#
+#   SqlSearch2 = A reimplementation of SqlSearch that supports additional boolean operators and wildcard options. Its use is required 
+#                if you are using the SearchBuilder query interface available in CA version 1.8. This is the default search engine for 
+#                CollectiveAccess from version 1.8.
+#
+#   ElasticSearch = Search engine using ElasticSearch versions 5, 6 or 7 for indexing and query. To use this engine you must have a functioning 
+#                   ElasticSearch installation, a version-appropriate PHP-Elastic client installed, and the correct version set in the 
+#                   search.conf configuration file.  (See https://www.elastic.co for more information on ElasticSearch). By default the version 7
+#                   PHP-Elastic client is installed. To install a different version modify the composer.json file and re-run composer.
+search_engine_plugin = SqlSearch2
+
+# -----------------------------------
+# Quicksearch - order and results ("live" search in search box in header)
+# -----------------------------------
+#
+# What sorts of results does Quicksearch return?
+# List table names here to include them in the search, in the order they should appear. This is only the default 
+# display configuration, which can be overriden by user preferences. Syntax is ca_table/type, i.e ca_objects/video
+#
+quicksearch_default_results = [ca_objects, ca_entities, ca_places, ca_occurrences, ca_collections, ca_object_lots, ca_storage_locations, ca_loans, ca_movements, ca_tours, ca_tour_stops]
+
+# -----------------------------------
+# Quicksearch - break out by type?
+# -----------------------------------
+#
+# What table types are broken out in the result list? Syntax is list within square brackets, i.e [ca_objects, ca_entities]
+#
+quicksearch_breakout_by_type = 
+
+# By default quicksearches open the first panel with results for viewing. Set this option to disable that behavior
+# and return quicksearch results with all panels initially closed
+#
+quicksearch_dont_open_results_panel_automatically = 0
+    
+# -----------------------------------
+# Restrict facets shown to specific facet groups?
+# 	<table_name>_browse_facet_group limits facets on the main browse landing page
+#	<table_name>_refine_facet_group limits facets in the "refine" browse on detail pages
+#	<table_name>_search_refine_facet_group limits facets in the "refine" browse on search results
+# -----------------------------------
+#
+# ca_objects_browse_facet_group = main
+# ca_objects_refine_facet_group = refine
+# ca_objects_search_refine_facet_group = refine
+          
+# -----------------------------------
+# One table search 
+# -----------------------------------
+# If set to a controller in the "find" module, will use that for quicksearch rather
+# than the regular "Quicksearch" controller. This is useful for having the Quicksearch
+# operate on a single table
+#
+# one_table_search =
+                       
+# -----------------------------------
+# Background processing for media and search indexing
+# -----------------------------------
+
+# Method to use for invoking background processes. Options are:
+#   process = use Symphony process module to run background processes. Best choice, but may not be available on all systems.
+#   socket = trigger processing via web request using local socket. A Rube Goldberg-y method, but may be the only option on some systems.
+#
+# If left blank, process will be used by default. The socket method will only be used if explicitly configured to do so.
+# Note that on Windows servers the process module cannot run background processes outside of the current request, and return of output 
+# will not occur until all processing is complete. Use of the socket method is recommended on Windows if true background processing is 
+# required. Alternatively, Windows scheduled tasks may be used to periodically run the CollectiveAccess task queue.
+background_process_mode = process
+
+# Disable all background processing?
+disable_background_processing = 0
+
+# Disable background search indexing?
+disable_out_of_process_search_indexing = 0
+
+# Attempt to automatically trigger background search indexing?
+# Use this to disable triggering if processing of search indexing queue via cron job is preferred
+run_search_indexing_queue = 1
+
+# Attempt to automatically trigger ?
+# Use this to disable triggering if processing of search indexing queue via cron job is preferred
+run_task_queue = 1
+
+# Hostname to use when triggering background processing via socket
+# By default the site hostname configured in setup.php is used but you can override it
+# here if the hostname resolvable on the server differs from that used for incoming requests
+background_processing_trigger_socket_hostname = 
+
+# Socket protocol to use when triggering background processing via socket. Maybe set to tcp or tls
+# By default tcp is used when the incoming request is http and tls is used when https is employed.
+# You can override it here to use a constant protocol.
+background_processing_trigger_socket_protocol =
+
+# Port to use when triggering o background processing via socket.
+# By default the port used is 80 when the incoming request is http or 443 when https is used. 
+# You can override it here to use a constant port.
+background_processing_trigger_socket_port =
+
+# Disable verification of SSL certificate when connection uses https.
+# With some server/network configurations it may not be possible to validate the certificate
+# when connecting internally to trigger background processing. You can disable certificate checks here if
+# you need to. No data is transferred over the connection used to trigger indexing, but disabling
+# certificate checks is never a great idea. It is recommended that disabling be done only as a 
+# last resort.
+background_processing_trigger_dont_verify_socket_ssl_cert = 0
+
+# Append caUtils --hostname option when invoking caUtils to perform background search indexing 
+# or media processing. The value of the __CA_SITE_HOSTNAME__ configuration constant will be used.
+# For single-tenant systems there is no need to specify a hostname and it is preferable to omit the option.
+# For multi-tenant systems this option must be set to ensure background processing is triggered 
+# for the correct tennant.
+background_include_hostname_for_cautils = 0
+
+# -----------------------------------
+# Caption formatting for search/browse "thumbnail" results
+# -----------------------------------
+# Set a display template here to customize display of captions under thumbnails in the thumbnail result view. The 
+# template will be evaluated relative to each record in the result set.
+#
+ca_objects_results_thumbnail_caption_template = ^ca_objects.preferred_labels.name%truncate=27&ellipsis=1<br/><l>^ca_objects.idno</l>
+ca_occurrences_results_thumbnail_caption_template = ^ca_occurrences.preferred_labels.name%truncate=27&ellipsis=1<br/><l>^ca_occurrences.idno</l>
+ca_entities_results_thumbnail_caption_template = ^ca_entities.preferred_labels.name%truncate=27&ellipsis=1<br/><l>^ca_entities.idno</l>
+ca_collections_results_thumbnail_caption_template = ^ca_collections.preferred_labels.name%truncate=27&ellipsis=1<br/><l>^ca_collections.idno</l>
+                                 
+# -----------------------------------
+# Search/browse result set sorting
+# -----------------------------------
+# Restrict available sort options to those fields present in the currently selected display.
+# If set to zero all sort options are shown, including those for data that may not be currently displayed.
+#
+restrict_find_result_sort_options_to_current_display = 1
+
+#
+# Sorts for specific tables can be configured to show in all cases using <table>_include_result_sorts
+# The value is a list of sorts with the sort specification on the left and display name of the sort on the right
+#
+ca_objects_include_result_sorts = {
+#    ca_entities.preferred_labels.surname/artist = _(Artist)
+}
+
+#
+# The last selected sort is preserved across search and browses by default. If you prefer to reset the
+# sort to a default value on every new search or browse set the sort default below. The settings are table-specific
+# allowing a different default for each search or browse. Note that the search sort default is applied to all three
+# interfaces: basic, advanced and builder
+#
+#ca_objects_reset_sort_on_new_search = ca_objects.idno_sort
+#ca_objects_reset_sort_on_new_browse = ca_objects.idno_sort
+
+# -----------------------------------
+# Caching of sort field lists
+# -----------------------------------
+# If set lists of sort field are aggressively cached. Generating of sort lists
+# is resource intensive. Enabling caching will significantly improve performance
+# in some areas of the user interface, but may result in sort lists not reflecting 
+# recent configuration changed. 
+#
+do_available_sort_list_caching = 1
+
+# -----------------------------------
+# Hierarchy browser in storage location and list item search interfaces
+# -----------------------------------
+# Control whether the last browsed item is used as the initially selected item
+# in the hierarchy browser. Set to 0 to remember the last browsed item, 1 to always
+# start the hierarchy browser at the top of the hierarchy
+#  
+ca_storage_locations_dont_remember_last_browse_item = 0    
+ca_list_items_dont_remember_last_browse_item = 0     
+
+
+# -----------------------------------
+# Search/browse functionality availability
+# -----------------------------------
+# Control whether basic or advanced search, browse or search builder
+# interfaces are available on a per-table basis. Set to non-zero value
+# to disable an interface. By default, all interfaces are available.
+# When disabled, the interface is unavailable to all users, regardless of privileges.
+#
+ca_objects_disable_basic_search = 0
+ca_objects_disable_advanced_search = 0
+ca_objects_disable_search_builder = 0
+ca_objects_disable_browse = 0
+
+ca_object_lots_disable_basic_search = 0
+ca_object_lots_disable_advanced_search = 0
+ca_object_lots_disable_search_builder = 0
+ca_object_lots_disable_browse = 0
+
+ca_object_representations_disable_basic_search = 0
+ca_object_representations_disable_advanced_search = 0
+ca_object_representations_disable_search_builder = 0
+ca_object_representations_disable_browse = 0
+
+ca_entities_disable_basic_search = 0
+ca_entities_disable_advanced_search = 0
+ca_entities_disable_search_builder = 0
+ca_entities_disable_browse = 0
+
+ca_places_disable_basic_search = 0
+ca_places_disable_advanced_search = 0
+ca_places_disable_search_builder = 0
+ca_places_disable_browse = 0
+
+ca_occurrences_disable_basic_search = 0
+ca_occurrences_disable_advanced_search = 0
+ca_occurrences_disable_search_builder = 0
+ca_occurrences_disable_browse = 0
+
+ca_collections_disable_basic_search = 0
+ca_collections_disable_advanced_search = 0
+ca_collections_disable_search_builder = 0
+ca_collections_disable_browse = 0
+
+ca_storage_locations_disable_basic_search = 0
+ca_storage_locations_disable_advanced_search = 0
+ca_storage_locations_disable_search_builder = 0
+ca_storage_locations_disable_browse = 0
+
+ca_loans_disable_basic_search = 0
+ca_loans_disable_advanced_search = 0
+ca_loans_disable_search_builder = 0
+ca_loans_disable_browse = 0
+
+ca_movements_disable_basic_search = 0
+ca_movements_disable_advanced_search = 0
+ca_movements_disable_search_builder = 0
+ca_movements_disable_browse = 0
+
+# -----------------------------------
+# Browse panel styles 
+# -----------------------------------
+# (for best results, choose a number between 1 and 5)
+#
+browse_row_size = 4
+
+# -----------------------------------
+# Relationship autocomplete minimum search lengths
+# -----------------------------------
+# 
+#
+ca_storage_locations_autocomplete_minimum_search_length = 1
+autocomplete_minimum_search_length = 2
+
+                                   
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   ______         _                       
+#  |  ____|       | |                      
+#  | |__ ___  __ _| |_ _   _ _ __ ___  ___ 
+#  |  __/ _ \/ _` | __| | | | '__/ _ \/ __|
+#  | | |  __/ (_| | |_| |_| | | |  __/\__ \
+#  |_|  \___|\__,_|\__|\__,_|_|  \___||___/
+#                                         
+#  Settings related to various features such as: location tracking, deaccessioning, 
+#  WorldCat, check in/check out and more.                                       
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                           
+
+# -----------------------------------
+# Deaccession options
+# -----------------------------------
+deaccession_force_access_private = 1
+deaccession_dont_allow_editing = 0
+deaccession_use_disposal_date = 1
+
+
+# -----------------------------------
+# Library-style check-out of objects
+# -----------------------------------
+enable_library_services = 0
+enable_object_checkout = 0
+
+
+# -----------------------------------
+# User generated content
+# -----------------------------------
+enable_user_generated_content = 1
+
+# -----------------------------------
+# ResourceSpace import
+# -----------------------------------
+# The ResourceSpace data importer allows records and media to be imported from a ResourceSpace installation
+# The importer connects using a username and API Key that is unique to that user and can be found in the
+# edit user page under the Admin > Manage Users tab in ResourceSapce
+# 
+# Also required is the base URL for your ResourceSpace installation which all API calls are based on
+# This should be your root url + /api/
+#
+resourcespace_apis = {
+	EXAMPLE_RS_SYSTEM = {
+		resourcespace_label = ,
+		resourcespace_base_api_url = ,
+		resourcespace_user = 
+	
+	}
+}
+# -----------------------------------
+# Legistar import
+# -----------------------------------
+# Settings for API access to Legistar service (https://granicus.com/solution/govmeetings/legistar/)
+#
+#legistar_api_key = 
+#legistar_client_code = 
+
+# -----------------------------------
+# Home locations
+# -----------------------------------
+# If set options to set home locations (and return to home location) will be displayed.
+# Home location functionality can be enabled on a per-table or per-table-and-type basis by using
+# these options in the format <table>_enable_home_location or <table>_<type>_home_location.
+#
+# Note that only ca_objects, ca_object_lots, ca_collections, ca_object_representations and ca_storage_locations support home locations.
+ca_objects_enable_home_location = 1
+ca_object_lots_enable_home_location = 0
+ca_object_representations_enable_home_location = 0
+ca_collections_enable_home_location = 0
+ca_storage_locations_enable_home_location = 0
+
+# -----------------------------------
+# WorldCat import
+# -----------------------------------
+# The data importer can access OCLC WorldCat via either their web service API or Z39.50 service.
+# Using the web service API requires that PHP be installed with libCURL support. Using Z39.50
+# requires that PHP be built with libyaz support (http://www.indexdata.com/yaz). Many PHP installations
+# have libCURL installed by default; most do not have libyaz installed.
+#
+# The importer will connect ia Z39.50 if a username and password are configured below and libyaz is available, otherwise
+# the web service API will be used as a fallback, assuming a valid API key is configured below and libCURL is available.
+#
+worldcat_api_key = MY_WORLDCAT_API_KEY
+worldcat_z39.50_user =
+worldcat_z39.50_password =
+
+# Optionally mark WorldCat items already present in system using ISBN
+# To enable set "worlcat_isbn_element_code" to the ca_objects metadata element code containing the ISBN code for the book.
+worlcat_isbn_element_code =
+
+# Display template used to format "ISBN present" message. Evaluated relative to the existing object. 
+# You can use standard display template codes (eg. ^ca_objects.idno) to display details about the match.
+worlcat_isbn_exists_template = "<span class='caWorldCatExistingObjectIcon'><l><i class='fa fa-external-link' aria-hidden='true'></i></span></l>"
+
+# Template formatting the "key" displayed below WorldCat query results. Use this to define any icons used  in the "worlcat_isbn_exists_template"
+worlcat_isbn_exists_key = "<div class='caWorldCatExistingObjectKey'><i class='fa fa-external-link' aria-hidden='true'></i> = Previously imported</div>"
+
+# -----------------------------------
+# "Rich text" (aka. wysiwyg) editor options
+# -----------------------------------
+# In versions prior to 2.0 CKEditor v4 was used as the rich-text editor. 
+# As of version 2.0 two editors are supported: CKEditor v5 and QuillJS v2. CKEditor is still the 
+# default editor on the assumption existing users will prefer its familiar interface. QuillJS is a lighterweight editor
+# and may be preferable for new installations.  Note that while the CKEditor v5 interface is similar to that of v4, it 
+# is not identical. CKEditor v4 is no longer supported by its developers and cannot be used.
+wysiwyg_editor = ckeditor
+
+# 
+# Defines options available in the toolbar
+wysiwyg_editor_toolbar = {
+	formatting = [Bold, Italic, Underline, Strike, -, Subscript, Superscript, Font, FontSize, NumberedList, BulletedList, Outdent, Indent, Blockquote],
+	links = [Link, Unlink, Anchor],
+	misc = [SelectAll, Undo, Redo, -, Source, Maximize, Image, RemoveFormat]
+}
+
+# Defines options available in the toolbar
+wysiwyg_content_editor_toolbar = {
+	formatting = [Bold, Italic, Underline, Strike, -, Subscript, Superscript, Font, FontSize],
+	lists = [-, NumberedList, BulletedList, Outdent, Indent, Blockquote],
+	links = [Link, Unlink, Anchor],
+	misc = [SelectAll, Undo, Redo, -, Source, Maximize, Media]
+}
+
+
+# -----------------------------------
+# Enable dependent field visibility feature
+# -----------------------------------
+# See here for more information: https://docs.collectiveaccess.org
+#
+enable_dependent_field_visibility = 0
+
+                                                                  
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  ____                _              _        _   
+# |  _ \ __ ___      _| |_ _   _  ___| | _____| |_ 
+# | |_) / _` \ \ /\ / / __| | | |/ __| |/ / _ \ __|
+# |  __/ (_| |\ V  V /| |_| |_| | (__|   <  __/ |_ 
+# |_|   \__,_| \_/\_/  \__|\__,_|\___|_|\_\___|\__|                                                  
+#                                                                    
+# Settings supported integration with public-facing web interface
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~       
+
+# List of Pawtucket installations, used to generate URLs in Providence
+# The "base_url" value for an installation should be an absolute URL to the root of the installation.
+# The "version" value should be "2" or "2x". If you are using the Pawtucket 2.0 release use "2"
+pawtucket_installations = {
+#	frontend = {
+#		name = My Pawtucket Site,
+#		version = 2,
+#		base_url = https://mypawtuketsite.com
+#	}
+}
+
+# List of Pawtucket2x lightbox options; used to generate settings in Providence to
+# support anonymous access links to Pawtucket-hosted lightboxes. The list
+# should be key'ed on lightbox type (Eg. ca_objects for object lightboxes)
+# Currently only the "downloads" option is used, to generate Pawtucket2x lightbox
+# anonymous sharing links
+pawtucket_lightbox_options = {
+#	ca_objects = {
+#		downloads = {
+#			full = {
+#				type = media,
+#				version = original,
+#				label = _("Media (full resolution)")
+#			},
+#			medium = {
+#				type = media,
+#				version = medium,
+#				label = _("Media (medium)")
+#			},
+#		},
+#	}
+}
+
+# Global template values (Pawtucket content management)
+#
+# Globals are text values that may be set in the Pawtucket web UI and substituted
+# into any view template, including headers and footers. Values defined here 
+# will be editable in the "Global Values Editor" (available to users with the can_edit_theme_global_values priv)
+# and usable in templates under their name (Eg. {{{operating_hours}}} in the example below).
+#
+# Options controlling how the editor displays the value may be set for each global. Width and height control the size 
+# of the element; usewysiwygeditor enables a "wysiwyg" rich text editor for formatted text.
+#
+global_template_values = {
+	#hours_of_operation = {
+	#	name = Hours of operation,
+	#	description = List current operating hours here,
+	#	width = 600px,
+	#	height = 150px,
+	#	usewysiwygeditor = 0
+	#}
+}
+
+# Site page templates (Pawtucket content management)
+#
+# Allow PHP code in content-managed site pages
+#
+# By default only value tags in the form {{{tag-name}}} are allowed in Pawtucket site page templates. 
+# If you need the flexibility and power afforded by direct embedding of PHP code in your templates
+# set this option to a non-zero value. Note that enabling this option will allow execution of ANY
+# code embedded in the template on EVERY page load. Depending upon your point of view this is either a
+# feature or a security hole. It doesn't have to be a problem, but keep it in mind...
+#
+# Note that this setting only affects page previews in Providence. To allow PHP code execution in Pawtucket
+# you must also set this option in your theme.
+#
+allow_php_in_site_page_templates = 0
+
+                                                                  
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#                                    _____            _             _ 
+#      /\                           / ____|          | |           | |
+#     /  \   ___ ___ ___  ___ ___  | |     ___  _ __ | |_ _ __ ___ | |
+#    / /\ \ / __/ __/ _ \/ __/ __| | |    / _ \| '_ \| __| '__/ _ \| |
+#   / ____ \ (_| (_|  __/\__ \__ \ | |___| (_) | | | | |_| | | (_) | |
+#  /_/    \_\___\___\___||___/___/  \_____\___/|_| |_|\__|_|  \___/|_|
+#                                                                    
+#  Structural mechanisms that control who can see what, and how (optional).
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                           
+                                                                    
+# -----------------------------------
+# Bundle-level access control
+# -----------------------------------
+default_bundle_access_level = __CA_BUNDLE_ACCESS_EDIT__
+
+# -----------------------------------
+# Type-level access control
+# -----------------------------------
+perform_type_access_checking = 0
+default_type_access_level = __CA_BUNDLE_ACCESS_EDIT__
+
+# -----------------------------------
+# Source-level access control
+# -----------------------------------
+perform_source_access_checking = 0
+default_source_access_level = __CA_BUNDLE_ACCESS_EDIT__
+
+# -----------------------------------
+# Item-level access control
+# -----------------------------------
+perform_item_level_access_checking = 0
+default_item_access_level = __CA_ACL_EDIT_DELETE_ACCESS__
+
+# You can control item-level access control support
+# for each type of item using these directives
+ca_objects_dont_do_item_level_access_control = 0
+ca_object_lots_dont_do_item_level_access_control = 0
+ca_entities_dont_do_item_level_access_control = 0
+ca_places_dont_do_item_level_access_control = 0
+ca_occurrences_dont_do_item_level_access_control = 0
+ca_collections_dont_do_item_level_access_control = 0
+ca_lists_dont_do_item_level_access_control = 0
+ca_list_items_dont_do_item_level_access_control = 0
+ca_loans_dont_do_item_level_access_control = 0
+ca_movements_dont_do_item_level_access_control = 0
+ca_object_representations_dont_do_item_level_access_control = 0
+ca_representation_annotations_dont_do_item_level_access_control = 0
+ca_storage_locations_dont_do_item_level_access_control = 0
+ca_tours_dont_do_item_level_access_control = 0
+ca_tour_stops_dont_do_item_level_access_control = 0
+
+# Defaults for collection-to-object ACL inheritance settings
+#	Set to 1 to make default to inherit; 0 for default to be no inheritance
+ca_collections_acl_inherit_from_parent_default = 0
+ca_objects_acl_inherit_from_ca_collections_default = 0
+ca_objects_acl_inherit_from_parent_default = 0
+
+# -----------------------------------
+# Administrator
+# -----------------------------------
+# User_id to consider "administrator" - not subject to access control measures.
+# By default, user_id=1 is considered administrator for convenience and compatbility with older
+# installations. You can make any user_id "administrator" if you want, however, if disable this completely
+# by setting it to a blank value.
+#
+administrator_user_id = 1
+
+# email user when account is activated in Manage > Access control?
+email_user_when_account_activated = 0
+
+# -----------------------------------
+# Set Access
+# -----------------------------------
+# If you want all users to see all sets regardless of ownership or access control set this to one
+# (Yes, some people apparently want to do this)
+#
+ca_sets_all_users_see_all_sets = 0
+
+# -----------------------------------
+# "Access" inheritance
+# -----------------------------------
+# Allows child records to receive the "access" field value of their immediate parent. This can be useful when
+# you generally want child record access to mirror that of the parent, but with occasional cataloguer-defined exceptions
+#
+# Currently only supported for ca_objects
+ca_objects_allow_access_inheritance = 0
+
+# Default inheritance status for newly created ca_objects records
+ca_objects_access_inheritance_default = 1
+
+# list of values for 'access' field in objects, entities, places, etc. that allow public (unrestricted) viewing in Pawtucket
+public_access_settings = [1]
+
+# Common headers container request IP include:
+#	HTTP_CF_CONNECTING_IP (Actual user IP when CloudFlare proxy is used)
+# 	HTTP_X_REAL_IP (Actual user IP when  proxy is used)
+#	HTTP_X_FORWARDED_FOR (Actual user IP when  proxy is used)
+request_ip_headers = [HTTP_X_REAL_IP, HTTP_X_FORWARDED_FOR]
+
+# The "access" intrinsic field available on all primary tables determines whether a record
+# is displayed in public user interfaces, and to what groups of users it may be displayed.
+# The "access_statuses" list determines the values may be set for the "access" intrinsic. 
+# Typically it's two values (public, not-public), with additional entries optionally added to 
+# cover specific groups or categories of user. 
+#
+# Configured access values are shared across all types of records. The "omit_access_statuses" 
+# option allows you to hide specific values on specific table and type combinations. The
+# __default__ metatype is used for any type not specifically configured. You may use both list item
+# codes and list item values to reference to the entries to be omitted. 
+#
+# By default no entries are omitted, and all types of records use the same list of access values.
+# Uncomment the configuration below to omit values for specific tables/types.
+#
+#omit_access_statuses = {
+#	ca_objects = {
+#		# Set omit list + new list default
+#		__default__ = {
+#			omit = [restricted_public_access],
+#			default = not_publish
+#		},
+#		# Just set omit list
+#		a_type_code = [1,2]
+#	}
+#}
+
+# Disable delete for specific records for all users (including admins) no matter what access the user has
+#
+# Can be set on a per-table and per-type basis. Use the format <table>_<type_code>_disable_delete 
+# for type-specific settings
+#
+ca_objects_disable_delete = 0
+ca_entities_disable_delete = 0
+ca_places_disable_delete = 0
+ca_occurrences_disable_delete = 0
+ca_collections_disable_delete = 0
+ca_object_lots_disable_delete = 0
+ca_object_representations_disable_delete = 0
+ca_lists_disable_delete = 0
+ca_list_items_disable_delete = 0
+ca_storage_locations_disable_delete = 0
+ca_loans_disable_delete = 0
+ca_movements_disable_delete = 0
+ca_tours_disable_delete = 0
+ca_tour_stops_disable_delete = 0
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#    _____ _         _ _             
+#   / ____| |       | (_)            
+#  | (___ | |_ _   _| |_ _ __   __ _ 
+#   \___ \| __| | | | | | '_ \ / _` |
+#   ____) | |_| |_| | | | | | | (_| |
+#  |_____/ \__|\__, |_|_|_| |_|\__, |
+#               __/ |           __/ |
+#              |___/           |___/ 
+#   
+#  Controls for visual elements such as logos, colors, etc. within the application and exported reports and labels       
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# -----------------------------------
+# Theme configuration
+# -----------------------------------
+# To display your logo in the menu bar, upload it to the graphics/logos/ folder in the Default theme
+# directory and enter the filename below.  For the best results, your logo must not exceed
+# 45 pixels in height.  To change the menu color, enter the six digit HTML color code below
+# and omit the leading '#' sign.
+#
+menu_color = ffffff
+footer_color = ffffff
+
+branding = {
+	menuBar = {
+		src = themes/default/graphics/logos/logo.svg,
+		width = 210px,
+		height = 20px,
+		alt = _(CollectiveAccess logo),
+		style = "margin-top:10px;"
+	},
+	login = {
+		src = themes/default/graphics/logos/logo.svg,
+		width = 327px,
+		height = 45px,
+		alt = _(CollectiveAccess logo)
+	},
+	report = {
+		src = themes/default/graphics/logos/logo.png,
+		width = 197px,
+		height = 19px,
+		alt = _(CollectiveAccess logo)
+	}
+}
+
+# -----------------------------------
+# Search Result Reporting configuration
+# -----------------------------------
+# To display your logo at the top of a PDF report, upload it to the graphics/logos/ folder in all themes
+# directory and enter the filename below.  To change the header color (report_color) and header text color (report_text_color), enter the six digit HTML color code below
+# and omit the leading '#' sign.
+#
+report_header_enabled = 1
+report_color = FFFFFF
+report_text_color = 000000
+
+# For Microsoft Word output of results set this
+# to include labels next to field values
+report_include_labels_in_docx_output = 1
+
+#
+# The following options control what additional information can be printed on PDF bundle reports. 
+# Enter a non-zero value to include the following information.
+#
+report_show_timestamp = 1
+report_show_number_results = 1
+report_show_search_term = 1
+
+report_representation_version = preview
+
+#
+# The following options control what information appears in header and footer for excel (only appears in View > Page Layout mode)
+#
+excel_report_header_enabled = 0
+excel_report_show_search_term = 0
+excel_report_footer_enabled = 0
+
+/* Image path for icon to display when no image is available in thumbnail view */
+/* Image must be uploaded to graphics/buttons in your theme folder */
+
+no_image_icon = glyphicons_138_picture.png
+
+#
+# For PDF reports HTML tags, except for those enumerated below, are stripped to avoid unexpected formatting issues
+# Additional tags may be added by specifying the tag name without <>. For self-closing tags omit the trailing "/"
+#
+report_allowed_text_tags = ["b", "strong", "i", "em", "u", "strike", "sub", "sup", "p", "div", "br", "span", "img"]
+
+
+# -----------------------------------
+# Print labels (ie. stickers)
+# -----------------------------------
+# As of CollectiveAccess version 1.5 a new label generator is available that is easier to
+# configure and customize. The new generator uses HTML/CSS to specify the layout of label formats,
+# unlike the old system which uses a set of complex configuration files. Any existing
+# label formats you wish to use with the new generator must be completely reimplemented. There is
+# no automated conversion process.
+
+# Set this if you want a dashed border around all printed labels
+add_print_label_borders = 0
+
+# -----------------------------------
+# Annotation options
+# -----------------------------------
+# element code of ca_representation_annotation list metadata element that should be used to classify and color code annotations
+#
+annotation_class_element =
+
+# -----------------------------------
+# Additional theme
+# -----------------------------------
+# theme to use when user is not logged in (when they're logged in their preferred theme is used)
+#
+theme = default
+themes_directory = <ca_base_dir>/themes
+themes_url = <ca_url_root>/themes
+views_directory = <themes_directory>/<theme>/views
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   __  __                   _             
+#  |  \/  |                 (_)            
+#  | \  / | __ _ _ __  _ __  _ _ __   __ _ 
+#  | |\/| |/ _` | '_ \| '_ \| | '_ \ / _` |
+#  | |  | | (_| | |_) | |_) | | | | | (_| |
+#  |_|  |_|\__,_| .__/| .__/|_|_| |_|\__, |
+#               | |   | |             __/ |
+#               |_|   |_|            |___/ 
+# 
+#  Settings for GeoNames and Mapping plugins (Google Maps/Open Layers)
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# -----------------------------------
+# GeoNames web services
+# -----------------------------------
+# To access the GeoNames services for geographic names
+# via a 'GeoNames' attribute you must enter your GeoNames username and password
+# here. You can get a free account at http://www.geonames.org/login. After
+# you confirmed your registration you have to enable your account for web
+# service usage at http://www.geonames.org/manageaccount, otherwise the search
+# won't return any results.
+# If you don't care about GeoNames (or even know what is it) then leave this as-is
+#
+geonames_user = enter_your_username_here
+
+# The api.geonames.org URL should not be changed if you're using the free GeoNames
+# web service. The free offering should be sufficient for most users. If you have
+# a paid/premium account, geonames provides you with a list of additional hostnames
+# available for use over https here: http://www.geonames.org/account
+# Enter one of those hostnames to make use of your premium subscription
+#
+geonames_api_base_url = http://api.geonames.org
+
+# -----------------------------------
+# Mapping plugins
+# -----------------------------------
+#
+# Name of plugin class to use for mapping
+# 	Currently supported values: OpenLayers, Leaflet
+#
+# OpenLayers is deprecated. Use Leaflet unless you have a reason to do otherwise.
+mapping_plugin = Leaflet
+
+# --- Leaflet options
+# Show zoom in/out control
+leaflet_maps_show_scale_controls = 1
+
+# Path color for polygons and circles
+leaflet_maps_path_color = "#0000cc"
+
+# Path weight (in pixels) for polygons and circles
+leaflet_maps_path_weight = 2
+
+# Path opacity for polygons and circles (0 is transparent, 1 is opaque)
+leaflet_maps_path_opacity = 0.6
+
+# Fill color for polygons and circles
+leaflet_maps_fill_color = "#ff0000"
+
+# Fill opacity for polygons and circles (0 is transparent, 1 is opaque)
+leaflet_maps_fill_opacity = 0.1
+
+# URL for base layer when using Leaflet mapping plugin
+# See https://leaflet-extras.github.io/leaflet-providers/preview/ for previews of various base maps
+leaflet_base_layer = https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
+
+# --- OpenLayers options
+# Tile to use for base layer; Ex. OpenLayers.Layer.OSM() [OpenStreetMaps] or OpenLayers.Layer.Stamen('toner') [Stamen 'Toner' theme]
+openlayers_base_layer = OpenLayers.Layer.OSM()
+
+# Radius, in pixels, of plotted points
+openlayers_point_radius = 5
+
+# Fill color (hex) for points and regions
+openlayers_fill_color = #ffcc66
+
+# Stroke width, in pixels, for points, regions and paths
+openlayers_stroke_width = 2
+
+# Stroke color (hex) for points, regions and paths
+openlayers_stroke_color = #ff9933
+
+#  Fill color (hex) for points and regions when selected
+openlayers_fill_color_selected = #66ccff
+
+#  Stroke color (hex) for points regions and paths when selected
+openlayers_stroke_color_selected = #3399ff
+
+# --- Generic mapping options
+# Attribute object records to use to map search results
+#
+ca_objects_map_attribute = georeference
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   _____        __            _ _       
+#  |  __ \      / _|          | | |      
+#  | |  | | ___| |_ __ _ _   _| | |_ ___ 
+#  | |  | |/ _ \  _/ _` | | | | | __/ __|
+#  | |__| |  __/ || (_| | |_| | | |_\__ \
+#  |_____/ \___|_| \__,_|\__,_|_|\__|___/
+#                                       
+#                                  
+#  System defaults to control layouts, displays, templates and more.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# -----------------------------------
+# Related item lookup settings
+# -----------------------------------
+ca_objects_lookup_settings = [^ca_object_representations.media.icon (^ca_objects.idno) ^ca_objects.preferred_labels]
+ca_objects_lookup_delimiter =
+ca_objects_lookup_relationship_type_position = right
+ca_objects_lookup_sort = _natural;ca_objects.idno_sort
+ca_objects_lookup_relationship_type_editable = 0
+
+ca_object_lots_lookup_settings = [^ca_object_lots.preferred_labels (^ca_object_lots.idno_stub)]
+ca_object_lots_lookup_delimiter = ➔
+ca_object_lots_lookup_relationship_type_position = right
+ca_object_lots_lookup_sort = _natural;ca_object_lots.idno_stub_sort
+ca_object_lots_lookup_relationship_type_editable = 0
+
+ca_entities_lookup_settings = [^ca_entities.preferred_labels]
+ca_entities_lookup_delimiter = ➔
+ca_entities_lookup_relationship_type_position = right
+ca_entities_lookup_sort = _natural;ca_entity_labels.name_sort
+ca_entities_lookup_relationship_type_editable = 0
+
+ca_places_lookup_settings =  [^ca_places.hierarchy.preferred_labels.name%maxLevelsFromBottom=4]
+ca_places_lookup_delimiter =  ➔
+ca_places_lookup_relationship_type_position = right
+ca_places_lookup_sort = _natural;ca_places.idno_sort
+ca_places_lookup_relationship_type_editable = 0
+
+ca_occurrences_lookup_settings = [^ca_occurrences.preferred_labels]
+ca_occurrences_lookup_delimiter = ➔
+ca_occurrences_lookup_relationship_type_position = right
+ca_occurrences_lookup_sort = _natural;ca_occurrences.idno_sort
+ca_occurrences_lookup_relationship_type_editable = 0
+
+ca_collections_lookup_settings = [^ca_collections.preferred_labels (^ca_collections.idno)]
+ca_collections_lookup_delimiter = ➔
+ca_collections_lookup_relationship_type_position = right
+ca_collections_lookup_sort = _natural;ca_collections.idno_sort
+ca_collections_lookup_relationship_type_editable = 0
+
+ca_storage_locations_lookup_settings = [^ca_storage_locations.hierarchy.preferred_labels.name]
+ca_storage_locations_lookup_delimiter = ➔
+ca_storage_locations_lookup_relationship_type_position = right
+ca_storage_locations_lookup_sort = _natural;ca_storage_locations.idno_sort
+ca_storage_locations_lookup_relationship_type_editable = 0
+
+ca_list_items_lookup_settings = ["[^ca_lists.preferred_labels.name] ^ca_list_items.hierarchy.preferred_labels.name_plural%delimiter=_➜_"]
+ca_list_items_lookup_delimiter = ➔
+ca_list_items_lookup_relationship_type_position = right
+ca_list_items_lookup_sort = _natural;ca_list_items.idno_sort
+ca_list_items_lookup_relationship_type_editable = 0
+
+ca_relationship_types_lookup_settings = [^ca_relationship_types.parent.preferred_labels ➔ ^ca_relationship_types.preferred_labels (^ca_relationship_types.type_code)]
+ca_relationship_types_lookup_delimiter = ➔
+ca_relationship_types_lookup_sort = _natural;ca_relationship_types.type_code
+
+ca_loans_lookup_settings = [^ca_loans.preferred_labels]
+ca_loans_lookup_delimiter = ➔
+ca_loans_lookup_relationship_type_position = right
+ca_loans_lookup_sort = _natural;ca_loans.idno_sort
+ca_loans_lookup_relationship_type_editable = 0
+
+ca_movements_lookup_settings = [^ca_movements.preferred_labels]
+ca_movements_lookup_delimiter = ➔
+ca_movements_lookup_relationship_type_position = right
+ca_movements_lookup_sort = _natural;ca_movements.idno_sort
+ca_movements_lookup_relationship_type_editable = 0
+
+ca_users_lookup_settings = [^ca_users.fname ^ca_users.lname (^ca_users.email)]
+ca_users_lookup_delimiter = ➔
+ca_users_lookup_sort = _natural;ca_users.user_name
+
+ca_user_groups_lookup_settings= [^ca_user_groups.name]
+ca_user_groups_lookup_delimiter = ➔
+ca_user_groups_lookup_sort = _natural;ca_user_groups.code
+
+ca_tours_lookup_settings = [^ca_tours.preferred_labels]
+ca_tours_lookup_delimiter = ➔
+ca_tours_lookup_sort = _natural;ca_tours.tour_code
+
+ca_tour_stops_lookup_settings = [^ca_tour_stops.preferred_labels]
+ca_tour_stops_lookup_delimiter = ➔
+ca_tour_stops_lookup_sort = _natural;ca_tour_stops.idno_sort
+ca_tour_stops_lookup_relationship_type_editable = 0
+
+ca_object_representations_lookup_settings = [^ca_object_representations.media.icon ^ca_object_representations.preferred_labels]
+ca_object_representations_lookup_delimiter = ➔
+ca_object_representations_lookup_sort = _natural;ca_object_representations.idno_sort
+ca_object_representations_lookup_relationship_type_editable = 0
+
+ca_representation_annotations_lookup_settings = [^ca_representation_annotations.preferred_labels.name]
+ca_representation_annotations_lookup_delimiter = ➔
+ca_representation_annotations_lookup_sort = _natural
+
+ca_sets_lookup_settings = [^ca_sets.preferred_labels.name (^ca_sets.set_code)]
+ca_sets_lookup_delimiter = ➔
+ca_sets_lookup_sort = _natural
+
+ca_object_checkouts_lookup_settings = [^ca_objects.preferred_labels.name (^ca_objects.idno) <i>Borrowed on ^ca_object_checkouts.checkout_date%timeOmit=1 by ^ca_users.fname ^ca_users.lname</i>]
+ca_object_checkouts_lookup_delimiter = ➔
+
+ca_item_tags_lookup_settings = [^ca_item_tags.tag]
+ca_item_tags_lookup_delimiter =
+ca_item_tags_lookup_sort = _natural
+
+
+# -----------------------------------
+# Default display templates for related bundles (Eg. ca_entities, ca_occurrences, etc.) ** in displays **
+# -----------------------------------
+ca_objects_default_bundle_display_template = "<ifdef code='ca_objects.preferred_labels.name'><unit relativeTo='ca_objects'><l>^ca_objects.preferred_labels.name</l></unit> (^relationship_typename)</ifdef>"
+ca_entities_default_bundle_display_template = "<ifdef code='ca_entities.preferred_labels.displayname'><unit relativeTo='ca_entities'><l>^ca_entities.preferred_labels.displayname</l></unit> (^relationship_typename)</ifdef>"
+ca_collections_default_bundle_display_template = "<ifdef code='ca_collections.preferred_labels.name'><unit relativeTo='ca_collections'><l>^ca_collections.preferred_labels.name</l></unit> (^relationship_typename)</ifdef>"
+ca_places_default_bundle_display_template = "<ifdef code='ca_places.preferred_labels.name'><unit relativeTo='ca_places'><l>^ca_places.preferred_labels.name</l></unit> (^relationship_typename)</ifdef>"
+ca_occurrences_default_bundle_display_template = "<ifdef code='ca_occurrences.preferred_labels.name'><unit relativeTo='ca_occurrences'><l>^ca_occurrences.preferred_labels.name</l></unit> (^relationship_typename)</ifdef>"
+ca_object_lots_default_bundle_display_template = "<ifdef code='ca_object_lots.preferred_labels.name'><unit relativeTo='ca_object_lots'><l>^ca_object_lots.preferred_labels.name</l> [^ca_object_lots.idno_stub]</unit><ifdef code='relationship_typename'> (^relationship_typename)</ifdef></ifdef>"
+ca_storage_locations_default_bundle_display_template = "<ifdef code='ca_storage_locations.preferred_labels.name'><unit relativeTo='ca_storage_locations'><l>^ca_storage_locations.preferred_labels.name</l></unit> (^relationship_typename)</ifdef>"
+ca_loans_default_bundle_display_template = "<ifdef code='ca_loans.preferred_labels.name'><unit relativeTo='ca_loans'><l>^ca_loans.preferred_labels.name</l></unit> (^relationship_typename)</ifdef>"
+ca_movements_default_bundle_display_template = "<ifdef code='ca_movements.preferred_labels.name'><unit relativeTo='ca_movements'><l>^ca_movements.preferred_labels.name</l> (^relationship_typename)</unit></ifdef>"
+ca_object_representations_default_bundle_display_template = "<ifdef code='ca_object_representations.preferred_labels.name'><unit relativeTo='ca_object_representations'><l>^ca_object_representations.media.thumbnail</l><br/><l>^ca_object_representations.preferred_labels.name</l></unit><ifdef code='relationship_typename'> (^relationship_typename)</ifdef></ifdef>"
+ca_list_items_default_bundle_display_template = "<ifdef code='ca_list_items.preferred_labels.name'><unit relativeTo='ca_list_items'><l>^ca_list_items.preferred_labels.name_plural</l></unit> (^relationship_typename)</ifdef>"
+
+# -----------------------------------
+# Default display templates for related bundles (Eg. ca_entities, ca_occurrences, etc.) ** in user interfaces **
+# -----------------------------------
+ca_objects_default_editor_display_template = <ifdef code='ca_objects.preferred_labels.name'><l>^ca_objects.preferred_labels.name</l></ifdef>
+ca_entities_default_editor_display_template = <ifdef code='ca_entities.preferred_labels.displayname'><l>^ca_entities.preferred_labels.displayname</l></ifdef>
+ca_places_default_editor_display_template = <l>^ca_places.preferred_labels.name</l>
+ca_collections_default_editor_display_template = <l>^ca_collections.preferred_labels.name</l>
+ca_occurrences_default_editor_display_template = <l>^ca_occurrences.preferred_labels.name</l>
+ca_object_lots_default_editor_display_template = <l>^ca_object_lots.preferred_labels.name</l>
+ca_storage_locations_default_editor_display_template = <l>^ca_storage_locations.hierarchy.preferred_labels.name</l>
+ca_loans_default_editor_display_template = <l>^ca_loans.preferred_labels.name</l>
+ca_movements_default_editor_display_template = <l>^ca_movements.preferred_labels.name</l>
+ca_list_items_default_editor_display_template = <l>^ca_list_items.preferred_labels.name_plural</l>
+ca_object_representations_default_editor_display_template = "Format: ^ca_object_representations.media_format<br/>
+Dimensions:^ca_object_representations.media_dimensions<br/>
+Filesize: ^ca_object_representations.media_filesize<br/>
+<ifdef code='ca_object_representations.media_colorspace'>Colorspace: ^ca_object_representations.media_bitdepth ^ca_object_representations.media_colorspace<br/></ifdef>
+<ifdef code='ca_object_representations.original_filename'>File name: ^ca_object_representations.original_filename<br/></ifdef>
+<ifdef code='ca_object_representations.page_count'>Pages: ^ca_object_representations.page_count<br/></ifdef>
+<ifdef code='ca_object_representations.preview_count'>Previews: ^ca_object_representations.preview_count<br/></ifdef>
+Access: ^ca_object_representations.access<br/>
+Status: ^ca_object_representations.status<br/>"
+
+# -----------------------------------
+# Default sort options for related bundles
+#
+# Defines options for sorting of related records in the editor. Sorts for specific types can be 
+# defined using keys in the form <table>_<type code>_bundle_display_sorts. Ex. to define sorts specific 
+# to objects of type "artwork" set ca_objects_artwork_bundle_display_sorts. Use "default" in place of a type code
+# to define sorts for records without specified type-specific sorts. 
+#
+# At a minimum, the "options" value must be set to a list of valid bundle codes to allow sorts on. The default sort 
+# can be set using the "sort" value; the default sort direction can be set using the "direction" option. Valid directions are
+# "ASC" (ascending) and "DESC" (descending).
+#
+# To disable sorts for a specific table/type set the "disable" option to a non-zero value. 
+#
+# If no default sort is set the first sort in the options list will be used as default. If no default direction is set
+# then "ASC" (ascending) is assumed.
+# -----------------------------------
+ca_objects_default_bundle_display_sorts = {
+	options = ["ca_objects.preferred_labels.name_sort", "ca_objects.idno_sort"]
+}
+
+ca_object_lots_default_bundle_display_sorts = {
+	options = ["ca_object_lots.preferred_labels.name_sort", "ca_object_lots.idno_stub", "ca_entities.preferred_labels.surname"]
+}
+
+ca_entities_default_bundle_display_sorts = {
+	options = ["_natural", "ca_entities.preferred_labels.surname;ca_entity_labels.forename", "ca_entities.type_id"],
+	#sort = "ca_entities.preferred_labels.surname;ca_entity_labels.forename",
+	#direction = ASC,
+	#disable = 1
+}
+
+ca_places_default_bundle_display_sorts = {
+	options = ["ca_places.preferred_labels.name_sort", "ca_places.idno_sort"]
+}
+
+ca_occurrences_default_bundle_display_sorts = {
+	options = ["ca_occurrences.preferred_labels.name_sort", "ca_occurrences.idno_sort"]
+}
+
+ca_collections_default_bundle_display_sorts = {
+	options = ["ca_collections.preferred_labels.name_sort", "ca_collections.idno_sort"]
+}
+
+ca_object_representations_default_bundle_display_sorts = {
+	options = ["ca_object_representations.access", "ca_object_representations.original_filename"]
+}
+
+ca_loans_default_bundle_display_sorts = {
+	options = ["ca_loans.preferred_labels.name_sort", "ca_loans.idno_sort"]
+}
+
+ca_movements_default_bundle_display_sorts = {
+	options = ["ca_movements.preferred_labels.name_sort", "ca_movements.idno_sort"]
+}
+
+ca_storage_locations_default_bundle_display_sorts = {
+	options = ["ca_storage_locations.preferred_labels.name_sort", "ca_storage_locations.idno_sort"]
+}
+
+# -----------------------------------
+# Default template for media viewer caption
+# -----------------------------------
+media_overlay_titlebar_template = "^ca_objects.preferred_labels.name <ifdef code='ca_objects.idno'>(^ca_objects.idno)</ifdef>"
+
+# -----------------------------------
+# Label type lists
+#
+# Labels, both preferred and non-preferred, for primary items (objects, entities, etc.)
+# can include a type. By default the range of types is defined by a list named for the item.
+# For objects, the types for preferred labels are object_label_types_preferred while the
+# non-preferred label types are defined by the object_label_types list. You can set other
+# lists for each kind of label below. If you don't want to use types for a given category of
+# label set it to an empty list.
+# -----------------------------------
+ca_objects_preferred_label_type_list = object_label_types_preferred
+ca_objects_nonpreferred_label_type_list = object_label_types
+ca_object_lots_preferred_label_type_list = object_lot_label_types_preferred
+ca_object_lots_nonpreferred_label_type_list = object_lot_label_types
+ca_entities_preferred_label_type_list = entity_label_types_preferred
+ca_entities_nonpreferred_label_type_list = entity_label_types
+ca_places_preferred_label_type_list = place_label_types_preferred
+ca_places_nonpreferred_label_type_list = place_label_types
+ca_collections_preferred_label_type_list = collection_label_types_preferred
+ca_collections_nonpreferred_label_type_list = collection_label_types
+ca_occurrences_preferred_label_type_list = occurrence_label_types_preferred
+ca_occurrences_nonpreferred_label_type_list = occurrence_label_types
+ca_loans_preferred_label_type_list = loan_label_types_preferred
+ca_loans_nonpreferred_label_type_list = loan_label_types
+ca_movements_preferred_label_type_list = movement_label_types_preferred
+ca_movements_nonpreferred_label_type_list = movement_label_types
+ca_storage_locations_preferred_label_type_list = storage_location_label_types_preferred
+ca_storage_locations_nonpreferred_label_type_list = storage_location_label_types
+ca_list_items_preferred_label_type_list = list_item_label_types_preferred
+ca_list_items_nonpreferred_label_type_list = list_item_label_types
+ca_object_representations_preferred_label_type_list = object_representation_label_types_preferred
+ca_object_representations_nonpreferred_label_type_list = object_representation_label_types
+ca_representation_annotation_preferred_label_type_list = representation_annotation_label_types_preferred
+ca_representation_annotation_nonpreferred_label_type_list = representation_annotation_label_types
+
+# -----------------------------------
+# Additional label field display
+# -----------------------------------
+ca_objects_preferred_label_show_effective_date = 0
+ca_objects_nonpreferred_label_show_effective_date = 0
+ca_entities_preferred_label_show_effective_date = 0
+ca_entities_nonpreferred_label_show_effective_date = 1
+ca_places_preferred_label_show_effective_date = 0
+ca_places_nonpreferred_label_show_effective_date = 0
+ca_occurrences_preferred_label_show_effective_date = 0
+ca_occurrences_nonpreferred_label_show_effective_date = 0
+ca_collections_preferred_label_show_effective_date = 0
+ca_collections_nonpreferred_label_show_effective_date = 0
+ca_loans_preferred_label_show_effective_date = 0
+ca_loans_nonpreferred_label_show_effective_date = 0
+ca_movements_preferred_label_show_effective_date = 0
+ca_movements_nonpreferred_label_show_effective_date = 0
+ca_storage_locations_preferred_label_show_effective_date = 0
+ca_storage_locations_nonpreferred_label_show_effective_date = 0
+ca_object_lots_preferred_label_show_effective_date = 0
+ca_object_lots_nonpreferred_label_show_effective_date = 0
+ca_object_representations_preferred_label_show_effective_date = 0
+ca_object_representations_nonpreferred_label_show_effective_date = 0
+ca_list_items_preferred_label_show_effective_date = 0
+ca_list_items_nonpreferred_label_show_effective_date = 0
+
+ca_objects_preferred_label_show_access = 0
+ca_objects_nonpreferred_label_show_access = 0
+ca_entities_preferred_label_show_access = 0
+ca_entities_nonpreferred_label_show_access = 1
+ca_places_preferred_label_show_access = 0
+ca_places_nonpreferred_label_show_access = 0
+ca_occurrences_preferred_label_show_access = 0
+ca_occurrences_nonpreferred_label_show_access = 0
+ca_collections_preferred_label_show_access = 0
+ca_collections_nonpreferred_label_show_access = 0
+ca_loans_preferred_label_show_access = 0
+ca_loans_nonpreferred_label_show_access = 0
+ca_movements_preferred_label_show_access = 0
+ca_movements_nonpreferred_label_show_access = 0
+ca_storage_locations_preferred_label_show_access = 0
+ca_storage_locations_nonpreferred_label_show_access = 0
+ca_object_lots_preferred_label_show_access = 0
+ca_object_lots_nonpreferred_label_show_access = 0
+ca_object_representations_preferred_label_show_access = 0
+ca_object_representations_nonpreferred_label_show_access = 0
+ca_list_items_preferred_label_show_access = 0
+ca_list_items_nonpreferred_label_show_access = 0
+                                
+                                     
+# -----------------------------------
+# Default to summary when opening item for editing?
+# 
+# Set to 1 to set all editors for a table to open summaries by default.
+# To set summaries to open by default for selected editors set to a list
+# with editor codes for the selected user interfaces. Ex.:
+#
+#   All editors:
+#       ca_objects_editor_defaults_to_summary_view = 1 
+#   
+#   Two selected editors:
+#       ca_objects_editor_defaults_to_summary_view = [object_ui, media_editor_ui]
+# 
+# -----------------------------------
+ca_objects_editor_defaults_to_summary_view = 0
+ca_object_lots_editor_defaults_to_summary_view = 0
+ca_entities_editor_defaults_to_summary_view = 0
+ca_places_editor_defaults_to_summary_view = 0
+ca_occurrences_editor_defaults_to_summary_view = 0
+ca_collections_editor_defaults_to_summary_view = 0
+ca_lists_editor_defaults_to_summary_view = 0
+ca_list_items_editor_defaults_to_summary_view = 0
+ca_loans_editor_defaults_to_summary_view = 0
+ca_movements_editor_defaults_to_summary_view = 0
+ca_storage_locations_editor_defaults_to_summary_view = 0
+ca_object_representations_editor_defaults_to_summary_view = 0
+ca_tours_editor_defaults_to_summary_view = 0
+ca_tour_stops_editor_defaults_to_summary_view = 0
+ca_representation_annotations_defaults_to_summary_view = 0
+
+
+# -----------------------------------
+# Find defaults
+# -----------------------------------
+items_per_page_options_for_ca_objects_search = [12,24,36,48]
+items_per_page_default_for_ca_objects_search = 24
+view_default_for_ca_objects_search = list
+
+items_per_page_options_for_ca_object_lots_search = [15,30,45]
+items_per_page_default_for_ca_object_lots_search = 30
+view_default_for_ca_object_lots_search = list
+enable_full_thumbnail_result_views_for_ca_object_lots_search = 0
+
+items_per_page_options_for_ca_entities_search = [15,30,45]
+items_per_page_default_for_ca_entities_search = 30
+view_default_for_ca_entities_search = list
+enable_full_thumbnail_result_views_for_ca_entities_search = 0
+
+items_per_page_options_for_ca_places_search = [15,30,45]
+items_per_page_default_for_ca_places_search = 30
+view_default_for_ca_places_search = list
+
+items_per_page_options_for_ca_occurrences_search = [15,30,45]
+items_per_page_default_for_ca_occurrences_search = 30
+view_default_for_ca_occurrences_search = list
+enable_full_thumbnail_result_views_for_ca_occurrences_search = 0
+
+items_per_page_options_for_ca_collections_search = [15,30,45]
+items_per_page_default_for_ca_collections_search = 30
+view_default_for_ca_collections_search = list
+enable_full_thumbnail_result_views_for_ca_collections_search = 0
+
+items_per_page_options_for_ca_storage_locations_search = [15,30,45]
+items_per_page_default_for_ca_storage_locations_search = 30
+view_default_for_ca_storage_locations_search = list
+
+items_per_page_options_for_ca_sets_search = [15,30,45]
+items_per_page_default_for_ca_sets_search = 30
+view_default_for_ca_sets_search = list
+
+items_per_page_options_for_ca_objects_browse = [12,24,36,48]
+items_per_page_default_for_ca_objects_browse = 24
+view_default_for_ca_objects_browse = list
+
+items_per_page_options_for_ca_object_lots_browse = [15,30,45]
+items_per_page_default_for_ca_object_lots_browse = 30
+view_default_for_ca_object_lots_browse = list
+enable_full_thumbnail_result_views_for_ca_object_lots_browse = 0
+
+items_per_page_options_for_ca_entities_browse = [15,30,45]
+items_per_page_default_for_ca_entities_browse = 30
+view_default_for_ca_entities_browse = list
+enable_full_thumbnail_result_views_for_ca_entities_browse = 0
+
+items_per_page_options_for_ca_places_browse = [15,30,45]
+items_per_page_default_for_ca_places_browse = 30
+view_default_for_ca_places_browse = list
+
+items_per_page_options_for_ca_occurrences_browse = [15,30,45]
+items_per_page_default_for_ca_occurrences_browse = 30
+view_default_for_ca_occurrences_browse = list
+enable_full_thumbnail_result_views_for_ca_occurrences_browse = 0
+
+items_per_page_options_for_ca_collections_browse = [15,30,45]
+items_per_page_default_for_ca_collections_browse = 30
+view_default_for_ca_collections_browse = list
+enable_full_thumbnail_result_views_for_ca_collections_browse = 0
+
+items_per_page_options_for_ca_storage_locations_browse = [15,30,45]
+items_per_page_default_for_ca_storage_locations_browse = 30
+view_default_for_ca_storage_locations_browse = list
+
+items_per_page_options_for_ca_sets_browse = [15,30,45]
+items_per_page_default_for_ca_sets_browse = 30
+view_default_for_ca_sets_browse = list
+
+items_per_page_options_for_ca_loans_browse = [15,30,45]
+items_per_page_default_for_ca_loans_browse = 30
+view_default_for_ca_loans_browse = list
+
+items_per_page_options_for_ca_movements_browse = [15,30,45]
+items_per_page_default_for_ca_movements_browse = 30
+view_default_for_ca_movements_browse = list
+
+items_per_page_options_for_ca_lists_browse = [15,30,45]
+items_per_page_default_for_ca_lists_browse = 30
+view_default_for_ca_lists_browse = list
+
+items_per_page_options_for_ca_list_items_browse = [15,30,45]
+items_per_page_default_for_ca_list_items_browse = 30
+view_default_for_ca_list_items_browse = list
+
+items_per_page_options_for_ca_tours_browse = [15,30,45]
+items_per_page_default_for_ca_tours_browse = 30
+view_default_for_ca_tours_browse = list
+
+items_per_page_options_for_ca_tour_stops_browse = [15,30,45]
+items_per_page_default_for_ca_tour_stops_browse = 30
+view_default_for_ca_tour_stops_browse = list
+
+items_per_page_options_for_ca_object_representations_browse = [15,30,45]
+items_per_page_default_for_ca_object_representations_browse = 30
+view_default_for_ca_object_representations_browse = list
+
+# -----------------------------------
+# Set item display templates
+# Used to format records in set item lists when no specific formatting has been specified
+# -----------------------------------
+ca_objects_set_item_display_template = ^ca_objects.preferred_labels.name (^ca_objects.idno)
+ca_object_lots_set_item_display_template = ^ca_object_lots.preferred_labels.name (^ca_object_lots.idno_stub)
+ca_entities_set_item_display_template = ^ca_entities.preferred_labels.displayname
+ca_places_set_item_display_template = ^ca_places.preferred_labels.name
+ca_occurrences_set_item_display_template = ^ca_occurrences.preferred_labels.name
+ca_collections_set_item_display_template = ^ca_collections.preferred_labels.name
+ca_loans_set_item_display_template = ^ca_loans.preferred_labels.name 
+ca_movements_set_item_display_template = ^ca_movements.preferred_labels.name
+ca_storage_locations_set_item_display_template = ^ca_storage_locations.preferred_labels.name
+ca_object_representations_set_item_display_template = ^ca_object_representations.preferred_labels.name
+ca_list_items_set_item_display_template = ^ca_list_items.preferred_labels.name_plural (^ca_list_items.idno)
+ca_tours_set_item_display_template = ^ca_tours.preferred_labels.name
+ca_tour_stops_set_item_display_template = ^ca_tour_stops.preferred_labels.name
+
+# Enable this to always show a default bundle preview for attribute bundles,
+# even if the display template for that particular element isn't set
+always_show_bundle_preview_for_attributes = 0
+
+# Enable this to always show the number of relationships for the curent record in the
+# header of relationship bundles. This will override the showCount setting in the bundle
+# placement.
+always_show_counts_for_relationship_bundles_in_editor = 0
+
+
+# Default editor preferences - used when user has not selected as default in 
+# their account-specific preferences. Can be set on a per-table basis in the form
+# <table>_default_editor (cataloguing editor)
+# <table>_quickadd_editor (quickadd editor)
+# <table>_batch_editor (batch editor)
+#
+# Defaults can also be set on the table/type-specific basis using the form:
+# <table>_<type>_default_editor
+#ca_list_items_default_editor = 
+#ca_list_items_default_quickadd_editor = 
+#ca_list_items_default_batch_editor = 
+
+
+# -----------------------------------
+# Default type to use when creating sets
+# (in search results "sets" options, for example)
+# -----------------------------------
+#
+ca_sets_default_type = user
+
+# Allow multiple instances of the same item in a set?
+allow_duplicate_items_in_sets = 0
+
+# -----------------------------------
+# Timecode output
+# -----------------------------------
+# Controls how timecode values are displayed
+# Valid settings are:
+#	COLON_DELIMITED = format with colons. Ex. 1:20:10
+#	HOURS_MINUTES_SECONDS = format with h/m/s labels. Ex. 1h 20m 10s
+#	RAW = the number of seconds in the interval. Ex. 4810
+#
+timecode_output_format = COLON_DELIMITED
+
+# -----------------------------------
+# Currency settings
+# -----------------------------------
+# By default currency values using the "$" symbol are considered to be in US dollars.
+# You can change that here to another currency using its standard 3-letter code.
+# Ex. CDN = Canadian dollars
+#
+default_dollar_currency = USD
+
+# Default currency to use for values entered without a currency specifier.
+# If blank, the default currency for the user's locale will be used.
+default_currency = 
+
+# -----------------------------------
+# Length settings
+# -----------------------------------
+# Use Unicode fraction glyphs such as (ex. ¼) in place of the text equivalent (ex. 1/4)
+#
+# As of version 1.7.6 these settings are DEPRECATED. In a future version these settings will be removed.
+# Use the settings in the dimensions.conf configuration file if possible.
+# 
+use_unicode_fractions_for_measurements = 1
+force_use_of_fractions_for_measurements = 0
+
+# -----------------------------------
+# Record duplication
+# -----------------------------------
+# By default duplicated records have the word "duplicate" appended to their preferred label. You can disable this behavior by setting this option.
+#
+dont_mark_duplicated_records_in_preferred_label = 0
+
+# -----------------------------------
+# Log options
+# -----------------------------------
+# By default a timestamp is shown for every change in the record-based change log.
+# Enable this to limit the display to the date of the change.
+#
+dont_show_timestamp_in_change_log = 0
+
+
+# When deleting an item it is possible to move any references to or from that item to another. 
+# Alternatively references can be deleted with the item. The system-wide default behavior may be set here 
+# and will be used when the user has not set a preference.
+# Valid options are "remove" or "transfer"
+# Note that you can set per-table defaults by prefacing "delete_reference_handling_default" with a table name. 
+# (For example, "ca_objects_delete_reference_handling_default")
+# 
+delete_reference_handling_default = remove
+
+# -----------------------------------
+# Components
+# -----------------------------------
+# The component user interface provides an alternative method for management of sub-records that is simpler and more
+# streamlined than that provided by the hierarchy browser. With components, sub-records are created from within the 
+# parent record via a popup overlay window and visualized as a flat list. The component UI only supports two-level 
+# hierarchies (parent and children). If deeper hierarchies are required the hierarchy browser user interface must be used.
+#
+# The component UI is supported for objects only and is restricted to specific types (configured using the
+# ca_objects_container_types directive). For configured object types, controls are displayed in the object editor
+# "inspector" information panel allowing the creation of new sub-records with any of the types listed in the 
+# ca_objects_component_types directive from within the record currently being edited. At least one type must be 
+# specified for both the ca_objects_container_types and ca_objects_component_types directives for the user 
+# interface to be functional. 
+#
+# The inspector will list the number of sub-records (components) currently attached to the record. To display a detailed list
+# of components include the ca_objects_components_list bundle in the object editor. This bundle will display all components
+# in the hierarchy when the parent or any child record is edited. The precise formatting of the contents of the bundle can
+# be set using display templates in the bundle, or in default templates specified in app.conf using the 
+# ca_objects_component_container_template, ca_objects_component_display_template and ca_objects_component_num_columns directives.
+# 
+# List of object types to which components may be attached
+ca_objects_container_types = [moving_digital, moving_analog]
+
+# List of object types used for components
+ca_objects_component_types = [moving_component]
+
+# Display inspector tools for merging and unmerging of component media. Merging will take all media attached to components, attach
+# it to the parent as object representations and delete the components. Unmerging will take all object representation media 
+# attached to the parent and create new components with that media under the parent.
+ca_objects_component_allow_merge_unmerge = 0
+
+# In ca_objects_components_list bundle, the number of columns used when listing components
+ca_objects_component_num_columns = 1
+
+# Template used got overall formatting of component list in ca_objects_components_list bundle
+# The ^COMPONENT_LIST tag will contain a full list of attached components, with each component formatted using
+# the template defined in the ca_objects_component_display_template directive.
+ca_objects_component_container_template = "<div class='componentGrid' style='display: flex; flex-direction: column; gap: 0.5rem;'>
+	<div class='componentHeader' style='display: flex; justify-content: space-between;'>
+		<div class='componentHeaderItem' style='width: 33%'>Name</div>
+		<div class='componentHeaderItem' style='width: 33%'>Accession Number</div>
+		<div class='componentHeaderItem' style='width: 33%'>Location</div>
+	</div>
+	^COMPONENT_LIST
+</div>"
+
+# Template used to format each attached component for display
+ca_objects_component_display_template = "
+<case>
+	<if rule='^ca_objects.element_inactive = \"Yes\"'><div class='componentRowDisabled'><div class='componentItem' style='width: 33%'><l>^ca_objects.preferred_labels.name</l> (inactive)</div><div class='componentItem' style='width: 33%'>^ca_objects.idno</div><div class='componentItem' style='width: 33%'>^ca_objects.history_tracking_current_value%policy=current_location</div></div></if>
+	<div class='componentRow' style='display: flex; justify-content: space-between;'><div class='componentItem' style='width: 33%'><l>^ca_objects.preferred_labels.name</l></div><div class='componentItem' style='width: 33%'>^ca_objects.idno</div><div class='componentItem' style='width: 33%'>^ca_objects.history_tracking_current_value%policy=current_location</div></div>"
+ca_objects_component_current_display_template = "<div class='componentRow' style='display: flex; justify-content: space-between;'><div class='componentItem componentItemSelected'>^ca_objects.preferred_labels.name</div><div class='componentItem' style='width: 33%'>^ca_objects.idno</div><div class='componentItem' style='width: 33%'>^ca_objects.history_tracking_current_value%policy=current_location</div></div>
+</case>"
+                                                                    
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   __  __          _ _       
+#  |  \/  |        | (_)      
+#  | \  / | ___  __| |_  __ _ 
+#  | |\/| |/ _ \/ _` | |/ _` |
+#  | |  | |  __/ (_| | | (_| |
+#  |_|  |_|\___|\__,_|_|\__,_|
+#                            
+# 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                           
+
+# -----------------------------------
+# Media processing tweaks
+# -----------------------------------
+# If you have the PECL Imagick extension installed on your server
+# and don't want to use it with CollectiveAccess (it has a bad habit of choking and crashing
+# on some types of files) you can force CA to ignore it by setting 'dont_use_imagick' to 1; leave it
+# set to zero if you want to use Imagick. When Imagick works, it performs well so you should give it a try
+# and see how it works before disabling support for it.
+#
+dont_use_imagick = 0
+
+# If you have ImageMagick or GraphicsMagick installed and PDFs are being inexplicably rejected try setting the corresponding
+# option to 1. It has been observed that ImageMagick chokes on some PDFs. Setting this option will force CA to use Zend_PDF
+# to identify uploaded PDF's, which often resolves the issues at the expense of greater memory consumption.
+#
+dont_use_imagemagick_to_identify_pdfs = 0
+dont_use_graphicsmagick_to_identify_pdfs = 0
+
+# If you're mostly dealing with large video files or images and don't care about PDF support (or you're using Graphics/ImageMagick
+# for identifying PDFs), you can disable Zend PDF support here. Zend PDF always tries to load the whole fine into memory,
+# which for video files can be several GB and usually results in memory_limit errors.
+#
+dont_use_zendpdf_to_identify_pdfs = 1
+
+# Don't import additional pages on multi-page TIFFs
+dont_import_additional_pages_for_tiffs = 0
+
+# Force colorspace of all image derivatives to a specific colorspace supported by the selected image back-end.
+# This can be used to ensure that media using colorspaces that cause issues with web viewering and PDF output such as CMYK
+# are converted no matter what the media configuration looks like
+#force_image_to_colorspace = RGB
+
+# CollectiveAccess supports two methods for generating PDF output for download and printing: dompdf (slower; built-in), 
+# and wkhtmltopdf (faster; requires additional software installation). 
+# By default it will favor using wkhtmltopdf if available, falling back to dompdf which is always available. 
+#
+# You can override the build in preference and force the use of a specific PDF generator by uncommenting and setting this 
+# option to one of the following:
+#		wkhtmltopdf, dompdf 
+# use_pdf_renderer = wkhtmltopdf
+
+# Only media than can be identified by a plugin may be uploaded. If you want to be able to upload any file
+# and have it treated as media, even if the internals of the file cannot be parsed set this to a non-zero value.
+# When set the BinaryFile media plugin is enabled, which will store any unidentifiable uploaded file as binary data.
+# No previews or in-browser viewing will be possible for these files.
+#
+accept_all_files_as_media = 0
+
+# PHPs builtin function exif_read_data (http://php.net/manual/en/function.exif-read-data.php) is known to cause
+# unexpected crashes with some files in some versions of PHP, particularly those shipped with RedHat or CentOS Linux.
+# If you experience any weird behavior while processing large files with extensive EXIF metadata, try enabling this setting.
+# If enabled, CollectiveAccess tries to extract metadata using alternate sources like exiftool or GraphicsMagick.
+#
+dont_use_exif_read_data = 0
+
+# Alternatively if you experiencing out-of-memory issues while importing media it may well be due to very large EXIF
+# metadata blocked embedded in the file. You can limit the size of metadata to be imported here by specifying the threshold in bytes (Eg. 1048576 = 1mb)
+#
+dont_use_exif_read_data_if_larger_than = 2097152
+
+# Files with large embedded metadata blocks may cause out-of-memory errors and/or complicate backup of the datase. You can 
+# limit the size of embedded metadata to be extracted during media loading here by specifying the threshold in bytes (Eg. 1048576 = 1mb)
+# Extraction of embedded metadata for media with metadata exceeding the threshold will be skipped. Set to zero or omit  if you want all metadata 
+# regardless of length to be extracted.
+#
+dont_extract_embedded_media_metdata_when_length_exceeds = 2097152
+
+# If you wish to allow the importing of object representation media and icons via http, https and ftp urls set this to 1.
+# Letting users employ your CA installation as a proxy for downloading arbitrary URLs could be seen as a security hole in
+# some cases, so enable this option only if you really need it.
+#
+allow_fetching_of_media_from_remote_urls = 0
+
+# Check if remotely fetched media is already loaded into an object representation and skip if found
+skip_remote_url_if_media_exists_as_representation = 0
+
+# When EXIF orientation is set on uploaded media, it must be stripped from derivatives. When using the Gmagick 
+# media processing plugin, ExifTool will be used to strip the tag if available. This is preferred as it allows
+# color profiles to be preserved, but it is relatively slow. If you don't care about color profiles set this option 
+# and the Gmagick stripImage() function will be used. It is fast, but does eliminate all embedded metadata, including
+# color profiles
+#
+dont_use_exiftool_to_strip_exif_orientation_tags = 0
+
+# Allow creation of object representation records without associated media. This may be useful in odd cases where one wishes to create placeholder representation records prior to ingest of media
+#
+allow_representations_without_media = 0
+
+# Don't extract content locations in PDFs 
+#
+dont_extract_pdf_content_locations = 0
+
+
+# Allow creation of object representation records containing media already in an existing representation
+#
+allow_representations_duplicate_media = 1
+
+# By default object representations related to a primary record (typically an object) will be deleted when that primary record is deleted unless
+# relationships to other records exist. This prevents "orphan" representations unrelated to any primary record from persisting after removal
+# of their "enclosing" record. 
+#
+# In some cases it is useful for force deletion of a related representation when specific types of primary records are deleted, regardless of
+# whether other relationships exist. For any primary type, a list of types may be set in the always_delete_representation_when_relationship_removed_to option
+# below for which this behavior will be applied.
+#
+#always_delete_representation_when_relationship_removed_to = {
+#	ca_objects = [object_type_1, object_type_2]
+#}
+
+# If you wish to allow the linking to existing object representations in the manner other relationships
+# set the relevant directives below to 1. Using representations as records that can be targets of
+# relationships can be confusing and, well, odd for many common setups. Still, when you need this behavior
+# you need it, so here it is :-)
+#
+ca_objects_allow_relationships_to_existing_representations = 0
+ca_object_lots_allow_relationships_to_existing_representations = 0
+ca_entities_allow_relationships_to_existing_representations = 0
+ca_places_allow_relationships_to_existing_representations = 0
+ca_occurrences_allow_relationships_to_existing_representations = 0
+ca_collections_allow_relationships_to_existing_representations = 0
+ca_storage_locations_allow_relationships_to_existing_representations = 0
+ca_list_items_allow_relationships_to_existing_representations = 0
+ca_loans_allow_relationships_to_existing_representations = 0
+ca_movements_allow_relationships_to_existing_representations = 0
+
+# -----------------------------------
+# Embedded metadata extraction
+# -----------------------------------
+# Allow user to choose mapping used for metadata extraction for representations? 
+# If not set mapping will be automatically chosen using 
+# embedded_metadata_extraction_mapping_defaults below
+allow_user_selection_of_embedded_metadata_extraction_mapping = 0
+
+# Include "no import" option in list of embedded metadata extraction options for representations?
+allow_user_embedded_metadata_extraction_mapping_null_option = 0
+
+# Default embedded metadata extraction mappings by mimetype
+# Wildcards may be used for the second part of the mimetype. Eg. video/* will match
+# any media types beginning with video/
+# 
+# Defaults are used automatically when configured to not present a list of mappings to the user.
+embedded_metadata_extraction_mapping_defaults = {
+#	video/* = a_mapping_code,
+#	image/* = another_mapping_code
+}
+
+# Log level used when performing embedded metadata import. 
+# Valid values are DEBUG, NOTICE, WARN, ERR, CRIT, ALERT and INFO.
+embedded_metadata_extraction_mapping_log_level = DEBUG
+
+# Default representation types based upon uploaded media 
+# You can set representation type codes to be used for a representation when 
+# media of a given MIME type is uploaded to it. Wildcards may be used in MIME types
+# to cover entire classes of media. If no default is set for a given media type then
+# the user specified type is applied.
+object_representation_media_based_type_defaults = {
+#	image/* = image,
+#	video/* = moving_image,
+#	audio/* = audio
+}
+
+
+# -----------------------------------
+# Video preview frame generation
+# -----------------------------------
+# You can have CA generate preview frames from uploaded video
+# These settings control how (and if) the preview frames are generated
+
+# Should we generate frames? (Set to 1 for yes, 0 for no)
+video_preview_generate_frames = 1
+
+# The minimum number of preview frames to generate in any situation
+# CA will adjust timing parameters to ensure at least this number of frames is generated.
+video_preview_min_number_of_frames = 10
+
+# The maximum number of preview frames to generate in any situation
+# CA will always stop generating frames when it hits this limit
+video_preview_max_number_of_frames = 100
+
+# The time between extracted frames; you can enter this is timecode notation (eg. 10s = 10 seconds; 1:10 = 1 minute, 10  seconds)
+video_preview_interval_between_frames = 30s
+
+# The time relative to the start of the video at which to start extracting preview frames; this can be used to ensure you don't generate frames from blank leader footage
+video_preview_start_at = 2s
+
+# The time interval relative to the end of the video at which to stop extracting preview frames; this can be used to ensure you don't generate frames from blank footage at the end of a video
+video_preview_end_at = 2s
+
+# The time relative to the start of the video at which the "main" video poster preview is being extracted.
+# Express as an absolute time (Ex. 1h 5m 3s) or as a precentage of duration (Ex. 50%)
+video_poster_frame_grab_at = 5s
+
+# -----------------------------------
+# Document preview page generation
+# -----------------------------------
+# You can have CA generate preview page images from uploaded documents (only PDFs currently)
+# These settings control how (and if) the preview pages are generated
+
+# Should we generate pages? (Set to 1 for yes, 0 for no)
+document_preview_generate_pages = 1
+
+# The maximum number of preview pages to generate in any situation
+# CA will always stop generating page images when it hits this limit
+document_preview_max_number_of_pages = 500
+
+# The number of pages between extracted pages; set to 1 if you want to generate all pages; set to 10 if you only want to generate every 10th page
+document_preview_interval_between_pages = 1
+
+# The page number at which to start extracting pages
+document_preview_start_page = 1
+
+# Resolution to rasterize PDF pages with, in DPI
+document_preview_resolution = 72
+
+# JPEG quality to rasterize PDF pages with (0-100)
+document_preview_quality = 75
+
+# The page number at which to start extracting text for search indexing
+document_text_extraction_start_page = 1
+
+# The maximum number of pages to extract text for search indexing
+# Leave blank to index all pages
+document_text_extraction_max_number_of_pages = 
+
+# Maximum number of characters of text to extract  for search indexing
+# Leave blank to index all text
+document_text_extraction_max_characters =
+
+# Set to non-zero value if you do not wish to generate representation annotation previews
+# These previews are discrete audio/video files covering a given annotation.
+dont_generate_annotation_previews = 1
+
+# Set to display file sizes in mebibytes (MiB, GiB, TiB) rather than megabytes (mb, gb, tb)
+# 
+show_filesizes_in_mebibytes = 1
+
+# -----------------------------------
+# AV media transcription
+# -----------------------------------
+create_transcriptions = 0
+transcription_media_types = [
+    audio/*, video/*
+]
+
+# -----------------------------------
+# Batch media processing
+# -----------------------------------
+
+# Root directory of staging area for media import – any media in this
+# directory will appear in media importer file listings
+batch_media_import_root_directory = <ca_base_dir>/import
+
+# Allow data importer to pull media from arbitrary directories using paths
+# in the data to be imported. If you don't trust the data being uploaded (or the people
+# doing the uploading) leave this set to zero.
+allow_import_of_media_from_any_directory = 0
+
+
+# Media import modes to allow during import. May contain any or all of these values:
+#	ALWAYS_MATCH = only import media that can be matched with an existing record (mandatory matching)
+#	TRY_TO_MATCH = import all media, matching with existing records when possible (optional matching)
+#	DONT_MATCH = import all media, creating new records in all case (no matching)
+#   DIRECTORY_AS_HIERARCHY = import all media, creating "albums" for imported directories with parent record and 
+#           child records set to types  specified by the  media_importer_hierarchy_parent_type and 
+#           media_importer_hierarchy_child_type settings
+media_importer_allowed_modes = [ALWAYS_MATCH, TRY_TO_MATCH, DONT_MATCH]
+
+# When importing media in DIRECTORY_AS_HIERARCHY mode, types set here will be used by default
+# for the created parent and child records
+#media_importer_hierarchy_parent_type = 
+#media_importer_hierarchy_child_type = 
+
+
+# Defines pattern matches to extract and match values in media file names with identifiers in CollectiveAccess
+# records. Each entry has a unique name as a key. The entry value contains a "displayName", used in logging and 
+# the user interface, and a list of regular expressions ("regexes"). Each "regexes" entry contains a list of valid
+# PCREs against which file names will be matched. Enclose the part of the pattern you want to extract for matching
+# in parens. Only the first parenthesized group will be used for matching. Additional groups will be ignored.
+#
+# Filenames may be rewritten before they are matched using the "media_filename_rewrites" setting below. Identifiers may be
+# transformed prior to matching using the "media_idno_rewrites" below.
+#
+# (Until version 1.7.9 this setting was named "mediaFilenameToObjectIdnoRegexes". The older name is still supported.)
+#
+media_filename_to_idno_matching = {
+	filename_exactly = {
+		displayName = _(Filename exactly),
+		regexes = { "^(.*)$" }
+	},
+	filename_without_extension = {
+		displayName = _(Filename without extension),
+		regexes = { "(.*?)\\.[A-Za-z]{2,4}[0-9]{0,1}$" }
+	},
+#	filename_with_page_number_included = {
+#		displayName = _(Filename with page number - page number included),
+#		regexes = { "(.*?\\.[A-Za-z0-9\\-]+)\\.[A-Za-z]+$", "(.*?)\\.[A-Za-z0-9]+$" }
+#	},
+#	filename_with_page_number = {
+#		displayName = _(Filename with page number - page number stripped),
+#		regexes = { "(.*?)\\.[A-Za-z0-9\\-]+\\.[A-Za-z]+$" }
+#	}
+}
+
+# Uncomment and customize the following to transform the names of media
+# files using Perl-compatible regular expressions (PCRE). The setting is basically
+# a wrapper around PHP's preg_replace function (http://php.net/manual/en/function.preg-replace.php).
+# Each entry has a unique name as a key. The entry value contains a "displayName", used in logging and 
+# the user interface, and a list of regular expressions ("regexes"). Each "regexes" entry has a valid
+# PCRE as its key and a replacement as its value. Back references are permitted in the replacement value.
+#
+# Note that the media importer will try to mach the result of these replacements to CollectiveAccess
+# records using the "media_filename_to_idno_matching" list above for each file or directory name
+# IN ADDITION to whatever the original name was. The original file name is matched first.
+#
+# (Until version 1.7.9 this setting was named "mediaFilenameReplacements". The older name is still supported.)
+#
+#media_filename_rewrites = {
+#	replace_period_w_dash = {
+#		displayName = _(Replace period with dash),
+#		regexes = { "([A-Za-z0-9]+)\\.([0-9]+)\\.([A-Za-z0-9]+)" = "$1-$2.$3" }
+#	},
+#	strip_punctuation = {
+#		displayName = _(Strip punctuation),
+#		regexes = { "[^\\w]+" = "" }
+#	}
+#}
+
+# Uncomment and customize the following to transform the values of record identifiers (Eg. the idno values 
+# for object records) using Perl-compatible regular expressions (PCRE). The setting is basically
+# a wrapper around PHP's preg_replace function (http://php.net/manual/en/function.preg-replace.php).
+# Each entry has a unique name as a key. The entry value contains a "displayName", used in logging and 
+# the user interface, and a list of regular expressions ("regexes"). Each "regexes" entry has a valid
+# PCRE as its key and a replacement as its value. Back references are permitted in the replacement value.
+#
+# Note that the media importer will try to match the original identifier value as well as the transformed 
+# identifiers resulting from these replacements with imported files using the "media_filename_to_idno_matching"
+# list above. Matching using the original identifier value is attempted before matches with transformed values.
+#
+# (Until version 1.7.9 this setting was named "mediaObjectIdnoRegexes". The older name is still supported.)
+#media_idno_rewrites = {
+#	strip_punctuation = {
+#		displayName = _(Strip punctuation),
+#		regexes = { "[^\\w]+" = "" }
+#	}
+#}
+
+# List of fields to attempt to match filename-extracted data on
+# Matching will be performed on fields in order, with the first matching
+# record used for import.
+#
+# You can specify intrinsic field names (Eg. idno), metadata element codes or
+# "preferred_labels" and "nonpreferred_labels" to match on labels
+#
+batch_media_import_match_on = [idno]
+
+# -----------------------------------
+# Batch metadata import
+# -----------------------------------
+batch_metadata_import_log_directory = <ca_base_dir>/app/log
+
+# -----------------------------------
+# Reprocess media
+# -----------------------------------
+reprocess_media_log_directory = <ca_base_dir>/app/log
+
+
+# -----------------------------------
+# Conditional media versions
+# -----------------------------------
+# Normally all configured versions are generated when media is uploaded. In some cases it 
+# may be desirable to not create a version if a file exceeds a certain size. For example, it
+# may not be practical to store large original, high-quality media files, but the derivatives of that file
+# are still required. In this case you can specify in the media_processing.conf configuration file 
+# that selected versions be skipped after a threshold is reached, and optionally that another, existing, version
+# is used in its place whenever it is referenced. The SKIP_WHEN_FILE_LARGER_THAN and REPLACE_WITH_VERSION
+# options may be set for this purpose.
+#
+# For situations where skipping versions must be dependent upon metadata in the representation record, rather than
+# just file type and size, rules can be specified using the skip_object_representation_versions_for_mimetype_when directive
+# below. Rules are set by mime type and version. The example will skip the "original" version for video files if they 
+# are larger than 500k and have their "ca_object_representations.access_pres" metadata value set to "Preservation". 
+# When skipped the "medium" version will be used as a placeholder wherever "original" is referenced.
+#
+#skip_object_representation_versions_for_mimetype_when = {
+#	video/* = {
+#		original = {
+#			threshold = 50000, replaceWithVersion = medium, when = "^access_pres = 'Preservation'"
+#		}
+#	}
+#}
+
+# -----------------------------------
+# Object representation download options
+# -----------------------------------
+
+# Media versions to provide downloads of
+ca_object_representation_download_versions = [original, large, medium, small]
+
+# Set maximum number of files to allow to be downloaded in one go. Leave set to 0 or blank for no limit.
+maximum_download_file_count = 
+
+# Formatting of download file name. Can be one of the following:
+# idno, idno_and_version, idno_and_rep_id_and_version, original_name
+#
+# You may also set this to a display template evaluated relative to representation being
+# downloaded. Ex. "DOWNLOAD_^ca_object_representations.original_filename" will name the file
+# using the originally uploaded file name prefixed with "DOWNLOAD_"; "^ca_object_representations.md5"
+# will name the downloaded file with the MD5 checksum of the originally uploaded file.
+# 
+# Your template should not include an extension as it will be added to the end of your
+# template. Values that include non-alphanumeric values such as mimetype will have those
+# characters converted to underscores. You can surround tags with curly brackets {} to 
+# ensure that your tags don't blend into the file name. An example template that 
+# includes idno and original file name:
+#
+#      download_{^ca_object_representations.idno}<ifdef code='ca_object_representations.original_filename'>_{^ca_object_representations.original_filename}</ifdef>
+#
+# For TIFF media from object 2016.2 with an originally uploaded name of test_file.jpg this
+# template will return the file name "download_2016_2_test_file.tiff"
+#
+# You can set the naming policy on a per-table basis (Eg. representations related to an object 
+# can be named following one format and representations related to an occurrence another) using
+# the <table name>_downloaded_file_naming directive (Ex. ca_objects_downloaded_file_naming = idno_and_version)
+#
+# You can set a global policy to be applied if a table-specific policy is not defined using the
+# downloaded_file_naming directive.
+# 
+
+downloaded_file_naming = original_name
+#ca_objects_downloaded_file_naming = "Meow_^ca_object_representations.original_filename"
+
+# Formatting of download file name for media archives (multiple files bound together in a ZIP file)
+# 
+# Set to 'idno' to name the archive using the identifier of the source record. You may also set 
+# this to a display template evaluated relative to the source record. Ex. When downloading an
+# archive of media from an object, setting this to "DOWNLOAD_^ca_object.preferred_labels.name" will
+# name the archive with the preferred label of the objet prefixed with the word "DOWNLOAD"
+downloaded_media_archive_file_naming = idno
+
+# Tables to allow media downloads from search/browse interface for
+allow_representation_downloads_from_find_for = [ca_objects, ca_object_representations]
+
+# -----------------------------------
+# Task queue set up (deferred processing of uploaded media)
+# -----------------------------------
+taskqueue_handler_plugins = <ca_lib_dir>/Plugins/TaskQueueHandlers
+taskqueue_tmp_directory = <ca_app_dir>/tmp
+taskqueue_max_processes = 4
+taskqueue_process_timeout = 3600
+taskqueue_max_items_processed_per_session = 100
+
+
+# -----------------------------------
+# Media uploader
+# -----------------------------------
+
+# Allow use of media uploader?
+media_uploader_enabled = 0
+
+# Directory for media upload logging
+media_uploader_log_directory = <ca_base_dir>/app/log
+
+# Directory to write user-uploaded files into
+media_uploader_root_directory = <ca_base_dir>/uploads
+
+# Max time in seconds to let media live in user upload directory before it can be removed
+# Set to 0 for no timeout
+media_uploader_directory_timeout = 86400
+
+# Maximum file storage allowed for media uploader across all users
+# If threshold is crossed no uploads will be allowed until files are deleted
+media_uploader_max_storage = 500gb
+
+# Default maximum file storage allowed for each user. May be overridden on a per-user
+# basis by user settings
+media_uploader_max_user_storage = 50gb
+
+# Maximum number of concurrent uploads 
+media_uploader_max_concurrent_uploads = 50
+
+# Maximum number of concurrent uploads per user
+media_uploader_max_concurrent_user_uploads = 4
+
+# Maximum size of any single uploaded file (set to zero for no limit)
+media_uploader_max_file_size = 0
+
+# Maximum number of files allowed per upload session (set to zero for no limit)
+media_uploader_max_files_per_session = 0
+
+# Force protocol used for upload. Can be either http or https. 
+# This can be useful when running behind a proxy that doesn't set 
+# X-Forwarded-Host and X-Forwarded-Proto headers
+#media_uploader_force_protocol_to = https
+
+# Uploaded files with these extensions will be discarded
+media_uploader_exclude_file_extensions = ["php", "exe", "py", "rb", "pl", "sh"]
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#              _           _       
+#     /\      | |         (_)      
+#    /  \   __| |_ __ ___  _ _ __  
+#   / /\ \ / _` | '_ ` _ \| | '_ \ 
+#  / ____ \ (_| | | | | | | | | | |
+# /_/    \_\__,_|_| |_| |_|_|_| |_|
+#                                  
+#  Nit picky stuff related to system configuration and administration.                               
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# -----------------------------------
+# System configuration check options (under "Manage" > "Administrate" > "Configuration Check")
+# -----------------------------------
+	# The configuration check can do a thorough, but time consuming, check of file permissions and other settings.
+	# These checks can be useful but on some servers, especially those using file systems mounted over a network, they can be very slow.
+	# If you are on such a server you can disable all "expensive" configuration checks here.
+dont_do_expensive_configuration_checks_in_web_ui = 0
+
+# Extremly time consuming check of file permissions  in media folder can be disabled, because it slow on otherwise fast servers.
+dont_do_media_dir_expensive_check =0
+
+# -----------------------------------
+# Configuration exporter options
+# -----------------------------------
+configuration_export_only_system_displays = 1
+configuration_export_only_system_search_forms = 1
+configuration_export_user_logins = 0
+
+# Exclude lists from configuration export with more than a specified number of items. If set to zero no limit is enforced. 
+configuration_export_exclude_lists_larger_than = 0
+
+# List of list codes to exclude from configuration export
+configuration_export_exclude_lists = []
+
+# -----------------------------------
+# Object lot inheritance
+# -----------------------------------
+# Controls whether a newly created object will inherit its lot relationship from its parent object
+ca_objects_dont_inherit_lot_from_parent = 1
+
+# Controls whether a newly created object will inherit its default idno from the lot set at creation time
+ca_objects_dont_inherit_idno_from_lot = 0
+
+
+# -----------------------------------
+# Restrict editing of codes for list and metadata elements
+# -----------------------------------
+# Allowing free editing and code and data type settings can result in invalid configuration.
+# The ability to edit these values once set can be restricted here.
+#
+ca_lists_dont_allow_editing_of_codes_when_in_use = 0
+ca_list_items_dont_allow_editing_of_codes_when_in_use = 0
+ca_metadata_elements_dont_allow_editing_of_codes_when_in_use = 0
+ca_metadata_elements_dont_allow_editing_of_data_types_when_in_use = 0
+
+# -----------------------------------
+# SMS notifications
+# -----------------------------------
+enable_sms_notifications = 0
+
+# Each SMS plugin supports a specific gateway. For now only SendHub.com is supported.
+sms_plugin = SendHub
+sms_user = MY_SENDHUB_USERNAME
+sms_api_key = MY_SENDHUB_API_KEY
+
+# -----------------------------------
+# Session settings
+# -----------------------------------
+session_lifetime = 31536000
+session_domain =
+
+# -----------------------------------
+# Email notifications
+# -----------------------------------
+# Settings for notifications system used for metadata-based alerts
+#
+notification_email_sender = no-reply@<site_hostname>
+notification_email_subject = (<app_display_name>) Notification
+
+# -----------------------------------
+# Display template debugging
+# -----------------------------------
+# Show display template debugger on "summary" screen in editors?
+#
+display_template_debugger = 0
+
+# -----------------------------------
+# Display system statistics
+# -----------------------------------
+# Show system statistics, including media storage usage and data metrics
+# to users with the can_view_system_statistics privilege. This setting simply enables
+# visibility of the statistics user interface. For data to be displayed statistics must 
+# be configured by modifying the statistics.conf configuration file with a valid 
+# login to this (and optionally other) systems. Statistics must be periodically updated 
+# via the command-line caUtils fetch-statistics command.
+#
+enable_statistics = 0
+
+
+# -----------------------------------
+# Disable gzip on progress bar
+# -----------------------------------
+# Gzip adds a buffer so progress bar that incrementally sends javascript to update
+# the bar will not take effect til the buffer is full. In order to render the
+# progress bar immediately, content negotiation should be disabled for
+# those Controllers.
+#
+# Each entry has the controller name as a key.
+# Do not use the name of the class but the controller name.
+# Use Editor and not EditorController.
+# A controller with no actions will disable gzip for all of its actions.
+#
+# The entry value contains an "action" key to apply it to just
+# one action or a list of actions.
+#
+disable_gzip_on_controllers = {
+	SearchReindex = {
+		action = Reindex
+	},
+	HierarchicalReindex = {
+		action = Reindex
+	},
+	SortValuesReload = {
+		action = Reload
+	},
+	MediaImport = {
+		action = Save
+	},
+	MetadataImport = {
+		action = [ImportData]
+	},
+	Editor = {
+		action = Save
+	},
+	MetadataExport = {
+		action = ExportData
+	}
+}
+
+# Application tmp directory garbage collection threshold
+# Clear stray files in the app/tmp directory older than specified age (in seconds)
+tmp_directory_garbage_collection_threshold = 1800
+
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#  ______                       _   
+# |  ____|                     | |  
+# | |__  __  ___ __   ___  _ __| |_ 
+# |  __| \ \/ / '_ \ / _ \| '__| __|
+# | |____ >  <| |_) | (_) | |  | |_ 
+# |______/_/\_\ .__/ \___/|_|   \__|
+#             | |                   
+#             |_|                   
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# -----------------------------------
+# File names for data export download files
+# -----------------------------------
+# If the given display template doesn't yield a usable result, the exporter falls back to relatively
+# nondescript defaults
+
+# single item exports via inspector in the corresponding editor
+ca_objects_single_item_export_filename = ^ca_objects.idno
+ca_object_lots_single_item_export_filename = ^ca_object_lots.idno_stub
+ca_entities_single_item_export_filename = ^ca_entities.idno
+ca_places_single_item_export_filename = ^ca_places.idno
+ca_occurrences_single_item_export_filename = ^ca_occurrences.idno
+ca_collections_single_item_export_filename = ^ca_collections.idno
+ca_lists_single_item_export_filename = ^ca_lists.list_code
+ca_list_items_single_item_export_filename = ^ca_list_items.idno
+ca_loans_single_item_export_filename = ^ca_loans.idno
+ca_movements_single_item_export_filename = ^ca_movements.idno
+ca_object_representations_single_item_export_filename = ^ca_object_representations.idno
+ca_representation_annotations_single_item_export_filename = ^ca_representation.annotations.annotation_id
+ca_storage_locations_single_item_export_filename = ^ca_storage_locations.idno
+ca_tours_single_item_export_filename = ^ca_tours.tour_code
+ca_tour_stops_single_item_export_filename = ^ca_tours_stops.idno
+
+# batch exports via sets or browse results
+ca_objects_batch_export_filename = objects_batch_export
+ca_object_lots_batch_export_filename = lots_batch_export
+ca_entities_batch_export_filename = entities_batch_export
+ca_places_batch_export_filename = places_batch_export
+ca_occurrences_batch_export_filename = occurrences_batch_export
+ca_collections_batch_export_filename = collections_batch_export
+ca_lists_batch_export_filename = lists_batch_export
+ca_list_items_batch_export_filename = list_items_batch_export
+ca_loans_batch_export_filename = loans_batch_export
+ca_movements_batch_export_filename = movements_batch_export
+ca_object_representations_batch_export_filename = representations_batch_export
+ca_representation_annotations_batch_export_filename = annotations_batch_export
+ca_storage_locations_batch_export_filename = storage_locations_batch_export
+ca_tours_batch_export_filename = tours_batch_export
+ca_tour_stops_batch_export_filename = tour_stops_batch_export
+
+# List of alternate destinations for data exports. The only supported type for now is 'github'.
+#
+# For GitHub repositories it's highly recommended to *not* enter your main account password
+# here but to use a personal access token instead. You can create it in the GitHub account
+# settings under "Applications">"Personal Access Tokens". The token has to have 'repo' access.
+#exporter_alternate_destinations = {
+#	github = {
+#		type = github,
+#		display = GitHub repository,
+#		# user credentials
+#		username = your_github_username,
+#		token = enter_access_token_here,
+#		# repository information
+#		owner = enter_repository_owner,
+#		repository = collectiveaccess_export,
+#		base_dir = exports/from_ca,
+#		branch = master,
+#		update_existing = 1
+#	},
+#}
+
+
+#
+# Force inclusion of primary representation media in Excel (xlsx) exports when the
+# selected display does not already have a media placement. The value should be 
+# set to the media version to include in the file.  Omit or leave blank to not force inclusion.
+#
+ca_objects_always_include_primary_representation_media_in_xlsx_output = 
+
+#
+# List of standard formats included in results export options list
+# Possible values are xlsx (Excel), csv (comma delimited), tab (tab-delimited), docx (Microsoft Word)
+#
+ca_objects_standard_results_export_formats = [xlsx, csv, tab, docx]
+
+#
+# Formatting of download file name for exports from sets. Can be set to a display
+# template evaluated relative to the set being exported. This means you can use any
+# set-level metadata in the file name. If not set, the download will default to the 
+# preferred label set the exported set.
+#
+#ca_sets_export_file_naming = "Export from ^ca_sets.preferred_labels.name"
+
+#
+# Omit available displays as options for PDF output? Can be set per-table
+#
+ca_objects_dont_use_displays_for_pdf_summary_output = 0
+
+#
+# Formatting of download file name for summary PDFs generated from the record editor. 
+# Can be set to a display template evaluated relative to the record being summarized. 
+# This means you can use any record metadata in the file name. If not set, the download 
+# will default to the using the template defined by the @filename setting in the summary
+# print template.
+#
+ca_objects_summary_file_naming = "^ca_objects.idno"
+ca_object_lots_summary_file_naming = "^ca_object_lots.idno_stub"
+ca_entities_summary_file_naming = "^ca_entities.idno"
+ca_places_summary_file_naming = "^ca_places.idno"
+ca_occurrences_summary_file_naming = "^ca_occurrences.idno"
+ca_collections_summary_file_naming = "^ca_collections.idno"
+ca_lists_summary_file_naming = "^ca_lists.list_code"
+ca_list_items_summary_file_naming = "^ca_list_items.idno"
+ca_loans_summary_file_naming = "^ca_loans.idno"
+ca_movements_summary_file_naming = "^ca_movements.idno"
+ca_object_representations_summary_file_naming = "^ca_object_representations.idno"
+ca_representation_annotations_summary_file_naming = "Annotation_for_^ca_object_representations.idno"
+ca_storage_locations_summary_file_naming = "^ca_storage_locations.idno"
+ca_tours_summary_file_naming = "^ca_tours.tour_code"
+ca_tour_stops_summary_file_naming = "^ca_tour_stops.idno"
+
+#
+# Include unrestricted displays in relationship bundles? By default displays are
+# only shows an export options in relationship editor bundles when explicitly set to do so
+# via a "show in" restriction. Option can be set on a per-table basis in the form <table name>_show_unrestricted_displays_in_relationship_bundles 
+# Eg. setting ca_objects_show_unrestricted_displays_in_relationship_bundles = 1 will cause 
+# all unrestricted displays to be available as export options in ca_objects relationship bundles.
+#
+ca_objects_show_unrestricted_displays_in_relationship_bundles = 0
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# ______          _     _                         _ 
+# |  _  \        | |   | |                       | |
+# | | | |__ _ ___| |__ | |__   ___   __ _ _ __ __| |
+# | | | / _` / __| '_ \| '_ \ / _ \ / _` | '__/ _` |
+# | |/ / (_| \__ \ | | | |_) | (_) | (_| | | | (_| |
+# |___/ \__,_|___/_| |_|_.__/ \___/ \__,_|_|  \__,_|
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   
+#
+# Force a default layout for new user's dashboards. Specify the dashboard layout
+# by column – the dashboard has two columns referenced as "1" and "2". Each column
+# must have a list of widget codes. Widget codes are the identical to the directory names
+# for each installed widget in the app/widgets directory. Codes for the standard
+# widgets are: 
+#
+# advancedSearchForm, clock, count, lastLogins, links, lolCat,  message, notifications,
+# randomObject, recentChanges, recentComments, recentRegistrations, recentTags, 
+# recentlyCreated, recordsByStatus, rssViewer, savedSearches, searchBySet, trackProcessing,
+# watchedItems
+#
+# Other widget codes may available. Check the app/widgets directory for a list of all
+# available dashboard widgets.
+
+dashboard_default_layout = {
+    columns = {
+        1 = [count],
+        2 = []
+    }
+}
+                                              
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# 
+# _                       _             
+# | |                     (_)            
+# | |     ___   __ _  __ _ _ _ __   __ _ 
+# | |    / _ \ / _` |/ _` | | '_ \ / _` |
+# | |___| (_) | (_| | (_| | | | | | (_| |
+# \_____/\___/ \__, |\__, |_|_| |_|\__, |
+#              __/ | __/ |         __/ |
+#             |___/ |___/         |___/ 
+#                                              
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  
+# Instances where a new record is not created due to the dont_create setting
+# in the data importer being set are normally logged as notices. Set this
+# to a non-zero value to elevate these to logged errors.
+log_import_dont_create_events_as_errors = 0   
+
+# Disable logging of search details for all users by setting 
+# this option to a non-zero value.
+dont_use_search_log = 0
+
+# Logging of PHP warnings, deprecations and notices may be controlled using the 
+# following options. Warnings are typically, but not always, indicative of issues that
+# may need to be addressed in CollectiveAccess code, your configuration or your environment.
+# As such, it is recommended that that are logged. Note that in some cases a warnings may
+# be generated in normal use (Eg. gzuncompress warnings) and can be ignored by adding 
+# indicative error message text to the "log_ignore" list below.
+#
+# Deprecation warnings are generated by PHP when CollectiveAccess, or one of the libraries
+# it relies upon, uses patterns that are being phased out in the version of PHP your 
+# environment provides. While these are generally not critical errors, they may be logged
+# for eventual remediation.
+#
+# Notices are PHP advisories for conditions that may or may not be errors. There may be many
+# notices depending upon your environment and configuration. Logging and display of notices
+# is only recommended for developers. 
+#
+
+# Location of warning log
+warning_log = <ca_app_dir>/log/warning_log.txt
+
+# Log PHP warnings?
+log_warnings = 1
+
+# Display PHP warnings to users?
+display_warnings = 0
+
+# Log PHP deprecations?
+log_deprecation_warnings = 0
+
+# Display PHP deprecations to users?
+display_deprecation_warnings = 0
+
+# Log PHP notices?
+log_notices = 0
+
+# Display PHP notices to users?
+display_notices = 0
+
+# Errors to ignore. Place indicative text for the ignored warnings/deprecations/notices in the list.
+# Note that "gzuncompress" and "Redis" throw warnings in normal use and are ignored by default.
+log_ignore = ["gzuncompress", "Redis", "hoa"]
+
+# Bundles to omit from the editor change log. Define bundles using the full table.code form (Eg. ca_objects.description)
+# For labels, use table.preferred_labels (Eg. ca_objects.preferred_labels)
+#
+# Note that all changes are still written to the log. This setting merely suppressed display of changes to these
+# bundles in the editor user inteface.
+omit_from_changelog_display = []
+ 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  _____                             _       _   _             
+# |_   _|                           (_)     | | (_)            
+#   | |_ __ __ _ _ __  ___  ___ _ __ _ _ __ | |_ _  ___  _ __  
+#   | | '__/ _` | '_ \/ __|/ __| '__| | '_ \| __| |/ _ \| '_ \ 
+#   | | | | (_| | | | \__ \ (__| |  | | |_) | |_| | (_) | | | |
+#   \_/_|  \__,_|_| |_|___/\___|_|  |_| .__/ \__|_|\___/|_| |_|
+#                                     | |                      
+#                                     |_|                                                                
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+allow_transcription = 1
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   _____                 _               
+#  /  ___|               (_)              
+#  \ `--.  ___ _ ____   ___  ___ ___  ___ 
+#   `--. \/ _ \ '__\ \ / / |/ __/ _ \/ __|
+#  /\__/ /  __/ |   \ V /| | (_|  __/\__ \
+#  \____/ \___|_|    \_/ |_|\___\___||___/
+# 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                    
+                                    
+# Key used to generate JSON web tokens (JWT) for authentication with GraphQL-based API services
+# Set this to a random string of letters and numbers.
+graphql_services_jwt_token_key = blah
+
+# Interval before JWT will require refresh, in seconds
+graphql_services_jwt_access_token_lifetime = 600
+graphql_services_jwt_refresh_token_lifetime = 86400
+
+# Provide debugging information in error messages?
+graphql_services_debug = 0
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#  \ \   / /        ( )              | |                 
+#   \ \_/ /__  _   _|/ _ __ ___    __| | ___  _ __   ___ 
+#    \   / _ \| | | | | '__/ _ \  / _` |/ _ \| '_ \ / _ \
+#     | | (_) | |_| | | | |  __/ | (_| | (_) | | | |  __/
+#     |_|\___/ \__,_| |_|  \___|  \__,_|\___/|_| |_|\___|....
+#                                                       
+#  
+#  ....probably. Most users don't modify the configs below.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# -----------------------------------
+# URL configuration (paths to controllers and themes)
+# -----------------------------------
+auth_login_path = system/auth/login
+auth_login_url = <ca_url_root>/index.php/system/auth/login
+auth_logout_url = <ca_url_root>/index.php
+controllers_directory = <ca_app_dir>/controllers
+
+# Url path to error display page; user will be directed here upon unrecoverable error (eg. bad controller or action)
+error_display_url = <ca_url_root>/index.php/system/Error/Show
+
+# Url to redirect user to when nothing is specified (eg. they go to /index.php)
+# ONLY PUT THE CONTROLLER/ACTION PATH HERE - leave out the 'index.php'
+default_action = /Dashboard/Index
+
+# Services
+service_controllers_directory = <ca_app_dir>/service/controllers
+service_default_action = /search/rest/doSearch
+service_view_path = <ca_app_dir>/service/views
+
+# -----------------------------------
+# Filtering of text input
+#
+# Set to filter all entered data through HTMLPurifier
+# removing any potentially dangerous markup. This is generally 
+# a good thing, but significantly impacts performance. You may
+# wish to disable it if all user input is trusted.
+# -----------------------------------
+purify_all_text_input = 1
+
+# Allow external URL references (eg. images) in HTML text input? 
+# Leaving this enabled may be a security risk
+purify_allow_external_references = 0
+
+
+# Override path to HTMLPurifier working directory.
+# Set to null to disable caching
+purify_serializer_path = <ca_app_dir>/tmp/purifier
+
+
+# -----------------------------------
+# Paths to other config files
+# -----------------------------------
+data_model = <ca_conf_dir>/datamodel.conf
+user_pref_defs = <ca_conf_dir>/user_pref_defs.conf
+external_applications = <ca_conf_dir>/external_applications.conf
+media_volumes = <ca_conf_dir>/media_volumes.conf
+file_volumes = <ca_conf_dir>/file_volumes.conf
+default_media_icons = <ca_conf_dir>/default_media_icons.conf
+search_config = <ca_conf_dir>/search.conf
+browse_config = <ca_conf_dir>/browse.conf
+media_processing_settings = <ca_conf_dir>/media_processing.conf
+annotation_type_config = <ca_conf_dir>/annotation_types.conf
+attribute_type_config = <ca_conf_dir>/attribute_types.conf
+application_monitor_config = <ca_conf_dir>/monitor.conf
+assets_config = <ca_conf_dir>/assets.conf
+user_actions = <ca_conf_dir>/user_actions.conf
+find_navigation = <ca_conf_dir>/find_navigation.conf
+media_display = <ca_conf_dir>/media_display.conf
+media_metadata = <ca_conf_dir>/media_metadata.conf
+access_restrictions = <ca_conf_dir>/access_restrictions.conf
+datetime_config = <ca_conf_dir>/datetime.conf
+authentication_config = <ca_conf_dir>/authentication.conf
+services_config = <ca_conf_dir>/services.conf
+visualization_config = <ca_conf_dir>/visualization.conf
+prepopulate_config = <ca_conf_dir>/prepopulate.conf
+linked_data_config = <ca_conf_dir>/linked_data.conf
+
+# Path to navigation config file - defines menu structure
+nav_config = <ca_conf_dir>/navigation.conf
+
+# OAI configuration
+oai_harvester_config = <ca_conf_dir>/oai_harvester.conf
+oai_provider_config = <ca_conf_dir>/oai_provider.conf
+
+
+# -----------------------------------
+# Path to application plugins
+# -----------------------------------
+application_plugins = <ca_app_dir>/plugins
+
+# -----------------------------------
+# Path to dashboard widgets
+# -----------------------------------
+dashboard_widgets = <ca_app_dir>/widgets
+
+# -----------------------------------
+# Password reset parameters
+# -----------------------------------
+password_reset_url = <site_host><ca_url_root>/index.php?action=reset_password&form_action=reset
+
+# -----------------------------------
+# ID numbering (for objects, object lots and authorities)
+# -----------------------------------
+multipart_id_numbering_config = <ca_conf_dir>/multipart_id_numbering.conf
+
+# -----------------------------------
+# Media and file processing paths
+# -----------------------------------
+media_plugins = <ca_lib_dir>/Plugins/Media
+file_plugins = <ca_lib_dir>/Plugins/File
+
+# Directory to use for Tilepic generation temporary files
+tilepic_tmpdir = <ca_app_dir>/tmp
+
+#
+# Name of plugin class to use for id number field in objects, object lots
+# and authorities that support id numbering (entities, places, collections and occurrences)
+#
+ca_objects_id_numbering_plugin = MultipartIDNumber
+ca_object_lots_id_numbering_plugin = MultipartIDNumber
+ca_entities_id_numbering_plugin = MultipartIDNumber
+ca_places_id_numbering_plugin = MultipartIDNumber
+ca_collections_id_numbering_plugin = MultipartIDNumber
+ca_occurrences_id_numbering_plugin = MultipartIDNumber
+ca_list_items_id_numbering_plugin = MultipartIDNumber
+ca_loans_id_numbering_plugin = MultipartIDNumber
+ca_movements_id_numbering_plugin = MultipartIDNumber
+ca_tours_id_numbering_plugin = MultipartIDNumber
+ca_tour_stops_id_numbering_plugin = MultipartIDNumber
+ca_object_representations_id_numbering_plugin = MultipartIDNumber
+ca_storage_locations_id_numbering_plugin = MultipartIDNumber
+ca_site_pages_id_numbering_plugin = MultipartIDNumber
+ca_site_page_media_id_numbering_plugin = MultipartIDNumber
+ca_sets_id_numbering_plugin = MultipartIDNumber
+
+# -----------------------------------
+# Formats for form elements
+# -----------------------------------
+
+# If set text of "required_field_marker" will be displayed for bundles in editors for which input is required
+show_required_field_marker = 1
+
+# Text to display for bundles in editors for which input is required
+required_field_marker = <span style="color: #bb0000; font-size:10px; font-weight: bold;">_([Required]) </span>
+
+# These are used to format data entry elements in various editing formats. Don't change them unless
+# you know what you're doing
+# Used for intrinsic fields (simple fields)
+form_element_display_format = <div class='formLabel'>^EXTRA^LABEL ^BUNDLECODE<br/>^ELEMENT</div>
+form_element_display_format_without_label = <div class='formLabel'>^ELEMENT</div>
+form_element_display_format_single_line = <div class='formLabelPlain'>^ELEMENT ^EXTRA^LABEL</div>
+form_element_error_display_format = <div class='formLabel'>^EXTRA^LABEL (<span class='formLabelError'>^ERRORS</span>) ^BUNDLECODE<br/>^ELEMENT</div>
+
+# Used for bundle-able fields such as attributes
+bundle_element_display_format = <div class='bundleLabel'>^LABEL ^BUNDLECODE ^DOCUMENTATIONLINK ^ELEMENT</div>
+bundle_element_display_format_without_label = <div class='formLabel'>^ELEMENT</div>
+bundle_element_error_display_format = <div class='bundleLabel'>^LABEL ^BUNDLECODE (<span class='bundleLabelError'>^ERRORS</span>)<br/>^ELEMENT</div>
+
+# Used for the 'idno' field of bundle-providers (Eg. ca_objects, ca_places, etc.)
+idno_element_display_format_without_label = <div class='formLabel'>^ELEMENT <span id='idnoStatus'></span></div>
+
+# -----------------------------------
+# Proxy server configuration for web services
+# -----------------------------------
+# In some larger networks servers are required to run their HTTP/HTTPS requests
+# through a proxy server. If this applies to your setup, uncomment the following lines
+# and enter your proxy configuration here.
+# web_services_proxy_url = tcp://127.0.0.1:8080
+
+# Log directory for external export activity
+external_export_log_directory = <ca_base_dir>/app/log
+
+# New configuration for history tracking
+# Uses example configuration supporting combined workflow- and movement-based history tracking
+history_tracking_policies = {
+	defaults = { 
+		ca_objects = current_location
+	},
+	policies = {
+		current_location = {
+			name = _(Current location),
+			table = ca_objects,
+			elements = {
+				ca_storage_locations = {
+					__default__ = {
+						date = ca_objects_x_storage_locations.effective_date,
+						setInterstitialElementsOnAdd = [effective_date],
+						useDatePicker = 0,
+						template = "<l>^ca_storage_locations.hierarchy.preferred_labels.name%delimiter=_➜_</l>  <ifdef code='ca_objects_x_storage_locations.movement_by'> <br>MOVED BY: ^ca_objects_x_storage_locations.movement_by</ifdef>  <ifdef code='ca_objects_x_storage_locations.movement_comments'> <br>COMMENTS: ^ca_objects_x_storage_locations.movement_comments</ifdef>",
+						trackingRelationshipType = related,
+						restrictToRelationshipTypes = [related]
+					}
+				},
+				ca_occurrences = {
+					exhibition = {
+						date = ca_occurrences.exhibition_date,
+						setInterstitialElementsOnAdd = [effective_date],
+						template = "<l>^ca_occurrences.preferred_labels.name</l>",
+					},
+					__default__ = {
+						date = ca_objects_x_occurrences.effective_date,
+						setInterstitialElementsOnAdd = [effective_date],
+						template = "<l>^ca_occurrences.idno</l> ^ca_occurrences.preferred_labels.name",
+					}
+				},
+				ca_loans = {
+					__default__  = { 
+						date = ca_loans_x_objects.effective_date,
+						setInterstitialElementsOnAdd = [effective_date],
+						color = F78B8B,
+						template = <l>^ca_loans.idno</l> ^ca_loans.preferred_labels (^ca_loans.institution ^ca_loans.date) <ifdef code='ca_loans_x_objects.movement_comments'> <br>COMMENTS: ^ca_loans_x_objects.movement_comments</ifdef>,
+						restrictToRelationshipTypes = [loan]
+					  }   
+				},
+				ca_movements = {
+					__default__ = {
+						date = ca_movements.placementDate,
+						setInterstitialElementsOnAdd = [effective_date],
+						template ="<unit relativeTo='ca_movements'>[^ca_movements.idno] <l>^ca_movements.preferred_labels.name</l>,  ^ca_movements.purposeNotes<br/>
+								<unit relativeTo='ca_storage_locations' restrictToRelationshipTypes='location'>Moved to <l>^ca_storage_locations.hierarchy.preferred_labels.name%delimiter=_➜_</l></unit>
+							</unit>",
+						trackingRelationshipType = location,
+
+						# useRelated = for browsing purposes log the current value as the first related item in this table
+						useRelated = ca_storage_locations,
+
+						# useRelatedRelationshipType = relationship type used when logging current value against related table
+						useRelatedRelationshipType = location_tracking,
+
+						# ca_movements_x_storage_locations relationship types for old and new parent locations 
+						# (used when tracking movements of storage locations within the location hierarchy)
+						originalLocationTrackingRelationshipType = original_location,
+						newLocationTrackingRelationshipType = new_location,
+						subLocationTrackingRelationshipType = sub_location
+					}
+				}
+			}
+		}
+	}
+ }


### PR DESCRIPTION
Implements [SYS-1810](https://uclalibrary.atlassian.net/browse/SYS-1810)

Makes the following changes to support movements/location tracking:

* Sets `ca_movements_disable = 1` to make Movements available in the Providence UI.
* Creates a new `history_tracking_policies` entry, based on the [CollectiveAccess documentation](https://docs.collectiveaccess.org/providence/user/workflow/history_tracking_current_value) (search for “Set up of movement-based tracking” in this page).
  * The code in this PR differs from the sample in the documentation in one line (#3416). I added the value `useHierarchicalBrowser = 1` to enable the hierarchical browser for Locations when doing tracking on Object pages. This was much easier for me to use than the default type-ahead search.
*  Moves custom `app.conf` files to `local` subfolders of `app/conf` in both the `ucla_providence` and `ucla_customizations` directories.

Steps to test:
1. After getting new `app.conf` files, restart the application. (Not sure whether this is now needed because of the move to `local` subfolders, or because of the particular settings we're changing.)
2. Add the location tracking bundle to the Objects UI. 
  a. Manage -> Administration -> User Interfaces -> Standard Object editor, edit Basic Info screen. 
  b. Drag the "Object History tracking - chronology" bundle to the "Elements to display on this screen" column. 
  c. Click the small "i" on the bundle and ensure the "Use history tracking policy" dropdown is set to "Current location". 
  d. Save the editor UI screen.

After this, you should see the "History tracking – chronology" bundle on all Objects, from which you can link Loans, Movements, and Locations.

[SYS-1810]: https://uclalibrary.atlassian.net/browse/SYS-1810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ