### PR TITLE
SYS-1808: allow Object advanced search by Acquisition Date

### DIFF
--- a/ucla_customizations/app/conf/local/search_indexing.conf
+++ b/ucla_customizations/app/conf/local/search_indexing.conf
@@ -1,0 +1,1855 @@
+# Field level options
+#
+#	STORE 			 				(forces value to be stored in index, if possible; this can speed display of the content in a search but may slow down indexing and increases index size)
+#	TOKENIZE						(forces tokenization of value alongside non-tokenized value when DONT_TOKENIZE is set; 
+#										you only need to set this when you need to index a value in both tokenized and untokenized form; tokenization is assumed when DONT_TOKENIZE is not set)
+#	DONT_TOKENIZE	 				(indexes value as-is without tokenization)
+#	DONT_INCLUDE_IN_SEARCH_FORM 	(causes field to not be includable in user-defined search forms)
+#	BOOST							(numeric "boost" value to index field with; higher values will cause search hits on the boosted field to count for more when sorting by relevance)
+#	INDEX_AS_IDNO					(causes value to be indexed with various permutations for flexible retrieval as a record identifer)
+#	IDNO_DELIMITERS					(if set to a list of delimeters and INDEX_AS_IDNO is set, value will be split on the delimiter and resulting components indexed separately).
+#	INDEX_AS_MIMETYPE				(causes value to be indexed as a mimetype, including both the literal mimetype and the display text value for the type)
+#	INDEX_ANCESTORS					(enables hierarchical indexing for field, assuming it is in an hierarchical table, resulting in all values for this field in 
+#									 records above the subject in the hierarchy being indexed against the subject)
+#	INDEX_ANCESTORS_START_AT_LEVEL  (forces hierarchical indexing to start X levels down from the root. This allows you to omit the very highest, and least selective, levels of
+#									 the hierarchy when indexing. If omitted indexing starts from the hierarchy root.)
+#	INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS	(sets the maximum number of levels above the subject to be indexed. If omitted all levels of the hierarchy above the subject
+#											 are indexed.)
+#	INDEX_ANCESTORS_AS_PATH_WITH_DELIMITER	(sets a delimiter to place between each level of the hierarchy prior to indexing the entire hierarchy path above the subject. This is 
+#											 useful when you want to treat the hierarchy path as an identifier)
+#
+#	CHILDREN_INHERIT 				(copies indexing onto all records below the subject in the hierarchy. This can be useful when it is desirable to have child records returned in searches for parents.)
+#
+#	ANCESTORS_INHERIT				(copies indexing onto all records above the subject in the hierarchy. This can be useful when it is desirable to have parent records returned in searches for children.)
+#
+#   INDEX_LIST_ANCESTORS            (copies idno, item_id and label for ancestors of list item referenced by subject into index for subject. Useful for indexing hierarchical types for a subject.)
+#
+#	PRIVATE							(marks indexing for field as being only for use by authenticated users, not for public use; typically Pawtucket front-ends will ignore indexing so flagged)
+#
+#	PRIVATE_WHEN					(for container metadata elements, conditionally marks all subfields as private when a container sub-field has a specified value. This is only available for containers. The value of this
+#											option is a dictionary with sub-element codes and lists of values to match. Ex:
+#
+#											_ca_attribute_object_notes = { 
+#												PRIVATE_WHEN = {
+#													object_note_status = [internal]
+#												}
+#											}
+#
+#											The above example makes all "object_notes" container sub-fields indexed as private when the sub-field
+#											object_note_status is set to "internal"
+#
+#	COUNT							(for metadata attributes only; indicates that the number of values set for the attribute for a record should be indexed; allows searching on records by number of 
+#									 values in a given field; to index counts on relationships use the _count special field)
+#
+#   CURRENT                         (for metadata attributes and related tables with effective_date support only; only index latest repeat for this metadata element.)
+#
+#   CURRENT_DATE                    (for container metadata attributes only; use date element with specified element code to determine the current value to index is; implies CURRENT option is set.)
+#
+# Special fields (always start with underscore character):
+#	_metadata		(marks all metadata attributes on the record for indexing; this obviates the need to list each and every configured attribute in the configuration; to index a specific 
+#					 metadata attribute use ca_attribute_<element_code>, replacing <element_code> with the code for the desired element)
+#
+#	_count			(embeds the number of related rows for a given table in the index; you can specify this for both relationship and primary tables; the field is named 
+#					 <table_name>.count - for example: ca_object_representations.count for table 'ca_object_representations'; this can be used to find rows that have, or 
+#					 don't have, related rows in a given table. When specified on a primary table, counts are indexed in aggregate as well as for each type. For
+#					 relationship tables counts are indexed in aggregate as well as for each relationship type. Querying on a specific type or types is done like this:
+#						 ca_entities.count/individual:3 (finds records with exactly three related entities of type "individual")
+#						 ca_objects_x_entities.count/artist:[2 to 4] (finds objects with between two and four entities related as artist)
+#
+#					 
+# Access point are "virtual fields" for use in searches. They can be employed in three ways:
+#	(1) as simple aliases for individual fields. For example, if you wanted to enabled searches on object synonym using objsyn like so: 
+#				objsyn:Volkswagen
+#		then you'd simply define 'objsyn' to be an access point to objects.synonym
+#
+#	(2) as aliases for bundles of fields. If an access point is defined to include several fields, then a search on the access point will search all of the included fields at the same time.
+#
+# Note that all fields included in an access point must be included in the search index - they must appear in the "fields" list in other words. All indexed fields automatically
+# have access points created in the format tablename.fieldname (ex. objects.title); indexed metadata also have access points in the format tablename.md_<element_id> (ex. objects.md_5)
+#
+# When creating an access point you define an access point configuration associative list, then create a key for each access point.
+
+# ------------------------------------------------------------------------------------------------------------
+ca_objects = {
+	# ------------------------------------
+	ca_objects = {
+		fields = {
+			object_id = { },
+			_metadata = { },					# forces indexing of all attributes
+			parent_id = {STORE, DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM },
+			source_id = {},
+			lot_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },	
+			type_id = { STORE, DONT_TOKENIZE },
+			source_id = { STORE, DONT_TOKENIZE },
+			acquisition_type_id = { STORE, DONT_TOKENIZE },
+			hier_object_id = { STORE, DONT_TOKENIZE },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE },
+			is_deaccessioned = { STORE, DONT_TOKENIZE },
+			deaccession_notes = {},
+			deaccession_date = {},
+			circulation_status_id = { STORE, DONT_TOKENIZE },
+			submission_session_id = { STORE, DONT_TOKENIZE }
+		},
+		# Index idno's of related objects 
+		related = {
+			fields = {
+				idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 10 }
+			}
+		}
+	},
+	# ------------------------------------
+	ca_object_labels = {
+		key = object_id,
+		#filter = { is_preferred = 1 }, // limit indexing to preferred labels only
+		fields = {
+			name = { BOOST = 100, INDEX_ANCESTORS, INDEX_ANCESTORS_START_AT_LEVEL = 0, INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS = 4, INDEX_ANCESTORS_AS_PATH_WITH_DELIMITER = . },
+			name_sort = { DONT_INCLUDE_IN_SEARCH_FORM },
+			_count = {}
+		},
+		# Index names of related objects
+		related = {
+			fields = {
+				name = { BOOST = 10, INDEX_ANCESTORS, INDEX_ANCESTORS_START_AT_LEVEL = 0, INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS = 4, INDEX_ANCESTORS_AS_PATH_WITH_DELIMITER = . }
+			}
+		} 
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	ca_objects_x_entities = {
+		key = object_id,
+		fields = {
+			_count = { }
+		}
+	},
+	# ------------------------------------
+	ca_entities = {
+		tables = {
+			entities = [ca_objects_x_entities],
+			object_lots = [ca_object_lots, ca_object_lots_x_entities]
+		},
+		fields = {
+			entity_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			_count = { }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = {
+				ca_objects_x_entities = { }, 
+				ca_entities = {}
+			},
+			object_lots = [ca_object_lots, ca_object_lots_x_entities, ca_entities],
+			annotations = [ca_objects_x_object_representations, ca_object_representations, ca_representation_annotations, ca_representation_annotations_x_entities, ca_entities]
+		},
+		fields = {
+			entity_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			displayname = { },
+			forename = {},
+			surname = {},
+			middlename = {},
+			access = {},
+			checked = {}
+		}
+	},
+	# ------------------------------------
+	ca_places = {
+		tables = {
+			collections = [ca_objects_x_places],
+		},
+		fields = {
+			place_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_place_labels = {
+		tables = {
+			places = [ca_objects_x_places, ca_places],
+			annotations = [ca_objects_x_object_representations, ca_object_representations, ca_representation_annotations, ca_representation_annotations_x_places, ca_places]
+		},
+		fields = {
+			place_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = { INDEX_ANCESTORS, INDEX_ANCESTORS_START_AT_LEVEL = 1, INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS = 3 }
+		}
+	},
+	# ------------------------------------
+	ca_occurrences = {
+		tables = {
+			collections = [ca_objects_x_occurrences],
+		},
+		fields = {
+			occurrence_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_occurrence_labels = {
+		tables = {
+			occurrences = [ca_objects_x_occurrences, ca_occurrences],
+			annotations = [ca_objects_x_object_representations, ca_object_representations, ca_representation_annotations, ca_representation_annotations_x_occurrences, ca_occurrences]
+		},
+		fields = {
+			occurrence_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_collections = {
+		tables = {
+			collections = [ca_objects_x_collections],
+		},
+		fields = {
+			collection_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = {STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_collection_labels = {
+		tables = {
+			collections = [ca_objects_x_collections, ca_collections],
+		},
+		fields = {
+			collection_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_loan_labels = {
+		tables = {
+			loans = [ca_loans_x_objects, ca_loans],
+		},
+		fields = {
+			loan_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_loans = {
+		tables = {
+			loans = [ca_loans_x_objects],
+		},
+		fields = {
+			loan_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_list_items = {
+		tables = {
+			list_items = [ca_objects_x_vocabulary_terms],
+		},
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_list_item_labels = {
+		tables = {
+			vocabulary = [ca_objects_x_vocabulary_terms, ca_list_items],
+			annotations = [ca_objects_x_object_representations, ca_object_representations, ca_representation_annotations, ca_representation_annotations_x_vocabulary_terms, ca_list_items],
+			types = [ca_list_items, ca_list_item_labels],
+			sources = [ca_list_items, ca_list_item_labels]
+		},
+		keys = {
+			types = {
+				ca_objects = {
+					ca_list_items = {
+						left_key = type_id,
+						right_key = item_id
+					}
+				}
+			},
+			sources = {
+				ca_objects = {
+					ca_list_items = {
+						left_key = source_id,
+						right_key = item_id
+					}
+				}
+			}
+		}
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM }, 
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_representation_annotation_labels = {
+		tables = {
+			vocabulary = [ca_objects_x_object_representations, ca_object_representations, ca_representation_annotations]
+		},
+		fields = {
+			name = {},
+			name_sort = { DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_item_tags = {
+		tables = {
+			tags = [ca_items_x_tags],
+		},
+		keys = {		# manually override joins with explicit setting
+			tags = {
+				ca_items_x_tags = {
+					ca_objects = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = object_id
+					}
+				}
+			}
+		},
+		fields = {
+			tag = { BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_sets = {
+		tables = {
+			sets = [ca_set_items],
+		},
+		keys = {		# manually override joins with explicit setting
+			sets = {
+				ca_set_items = {
+					ca_objects = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = object_id
+					}
+				}
+			}
+		},
+		fields = {
+			set_code = { },
+			set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_storage_locations = {
+		tables = {
+			places = [ca_objects_x_storage_locations],
+		},
+		fields = {
+			location_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_storage_location_labels = {
+		tables = {
+			places = [ca_objects_x_storage_locations, ca_storage_locations]
+		},
+		fields = {
+			location_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = { INDEX_ANCESTORS, INDEX_ANCESTORS_START_AT_LEVEL = 0, INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS = 10, INDEX_ANCESTORS_AS_PATH_WITH_DELIMITER = .}
+		}
+	},
+	# ------------------------------------
+	ca_object_representations = {
+		tables = {
+			reps = [ca_objects_x_object_representations]
+		},
+		fields = {
+			representation_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			media_content = { DONT_INCLUDE_IN_SEARCH_FORM },
+			mimetype = { STORE, INDEX_AS_MIMETYPE },
+			md5 = { STORE, DONT_TOKENIZE },
+			original_filename = { STORE, DONT_TOKENIZE },
+			media_class = { },
+			is_transcribable = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_representation_transcriptions = {
+		tables = {
+			reps = [ca_objects_x_object_representations, ca_object_representations]
+		},
+		fields = {
+			transcription_id = { },
+			transcription = { },
+			_count = { },
+			user_id = { }
+		}
+	},
+	# ------------------------------------
+	ca_object_lots = {
+		key = lot_id,
+		fields = {
+			idno_stub = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			_metadata = { },
+			lot_status_id = { STORE, DONT_TOKENIZE },
+			type_id = { STORE, DONT_TOKENIZE },
+			extent = { STORE, DONT_TOKENIZE },
+			extent_units = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			access = { STORE, DONT_TOKENIZE },
+			acquistion_date = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	ca_object_lot_labels = {
+		tables = {
+			lots = [ca_object_lots]
+		},
+		fields = {
+			name = { BOOST = 100 },
+			name_sort = { DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		label = {
+			fields = [ca_object_labels.name],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		term_id = {
+			fields = [ca_list_items.item_id],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		entity_id = {
+			fields = [ca_entities.entity_id],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		place_id = {
+			fields = [ca_places.place_id],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		occurrence_id = {
+			fields = [ca_occurrences.occurrence_id],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		collection_id = {
+			fields = [ca_collections.collection_id],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		entity = {
+			fields = [ca_entities.idno],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		place = {
+			fields = [ca_places.idno],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		occurrence = {
+			fields = [ca_occurrences.idno],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		collection = {
+			fields = [ca_collections.idno],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		children = {
+			fields = [ca_objects.parent_id],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		type_id = {
+			fields = [ca_objects.type_id],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		source_id = {
+			fields = [ca_objects.source_id],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		access = {
+			fields = [ca_objects.access],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		idno = {
+			fields = [ca_objects.idno],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		tags = {
+			fields = [ca_item_tags.tag],
+			name = _(User tags),
+			options = { }
+		},
+		set = {
+			fields = [ca_sets.set_code],
+			boolean = OR,
+			name = _(Set code),
+			options = { DONT_STEM }
+		},
+		place = {
+			fields = [ca_place_labels.name],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		term = {
+			fields = [ca_list_item_labels.name_singular, ca_list_item_labels.name_plural],
+			boolean = OR,
+			name = _(Related term)
+		},
+		entity = {
+			fields = [ca_entity_labels.displayname],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		filename = {
+			fields = [ca_object_representations.original_filename],
+			options = {  }	
+		},
+		mimetype = {
+			fields = [ca_object_representations.mimetype],
+			options = {  }	
+		},
+		md5 = {
+			fields = [ca_object_representations.md5],
+			options = {  }	
+		},
+		deaccession = {
+			fields = [ca_objects.is_deaccessioned],
+			options = { }
+		},
+		deaccessioned = {
+			fields = [ca_objects.is_deaccessioned],
+			options = { }
+		},
+		deaccessionDate = {
+			fields = [ca_objects.deaccession_date],
+			options = { }
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		},
+		acquisitionDate = {
+			fields = [ca_object_lots.acquisition_date],
+			options = { }
+		}
+	},
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_representation_annotations = {
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = [ca_representation_annotations_x_entities, ca_entities]
+		},
+		fields = {
+			displayname = {}
+		}
+	},
+	# ------------------------------------
+	ca_place_labels = {
+		tables = {
+			places = [ca_representation_annotations_x_places, ca_places]
+		},
+		fields = {
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_list_item_labels = {
+		tables = {
+			vocabularies = [ca_representation_annotations_x_vocabulary_terms, ca_list_items]
+		},
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM }, 
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_representation_annotation_labels = {
+		key = annotation_id,
+		fields = {
+			name = {},
+			name_sort = { DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		access = {
+			fields = [ca_representation_annotations.access]
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_object_lots = {
+	# ------------------------------------
+	ca_object_lots = {
+		fields = {
+			idno_stub = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			_metadata = { },
+			lot_status_id = { STORE, DONT_TOKENIZE },
+			type_id = { STORE, DONT_TOKENIZE },
+			extent = { STORE, DONT_TOKENIZE },
+			extent_units = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			access = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_object_lot_labels = {
+		key = lot_id,
+		fields = {
+			name = { BOOST = 100 },
+			name_sort = { DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = [ca_object_lots_x_entities, ca_entities]
+		},
+		fields = {
+			displayname = {}
+		}
+	},
+	# ------------------------------------
+	ca_list_item_labels = {
+		tables = {
+			vocabulary = [ca_object_lots_x_vocabulary_terms, ca_list_items]
+		},
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_objects = {
+		key = lot_id,
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_storage_location_labels = {
+		tables = {
+			places = [ca_object_lots_x_storage_locations, ca_storage_locations]
+		},
+		fields = {
+			location_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_sets = {
+		tables = {
+			sets = [ca_set_items],
+		},
+		keys = {		# manually override joins with explicit setting
+			sets = {
+				ca_set_items = {
+					ca_object_lots = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = lot_id
+					}
+				}
+			}
+		},
+		fields = {
+			set_code = { },
+			set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_entities = {
+	# ------------------------------------
+	ca_entities = {
+		fields = {
+			type_id = { STORE, DONT_TOKENIZE },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },	
+			_metadata = { },
+			hier_entity_id = { STORE, DONT_TOKENIZE },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		key = entity_id,
+		fields = {
+			forename = { BOOST = 100 },
+			other_forenames = {},
+			surname = { BOOST = 100 },
+			middlename = {},
+			displayname = { BOOST = 100 },
+			access = {},
+			checked = {}
+		}
+	},
+	# ------------------------------------
+	ca_place_labels = {
+		tables = {
+			places = [ca_entities_x_places, ca_places],
+		},
+		fields = {
+			place_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_occurrence_labels = {
+		tables = {
+			occurrences = [ca_entities_x_occurrences, ca_occurrences],
+		},
+		fields = {
+			occurrence_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_collection_labels = {
+		tables = {
+			collections = [ca_entities_x_collections, ca_collections],
+		},
+		fields = {
+			collection_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_list_item_labels = {
+		tables = {
+			vocabulary = [ca_entities_x_vocabulary_terms, ca_list_items]
+		},
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_sets = {
+		tables = {
+			sets = [ca_set_items],
+		},
+		keys = {		# manually override joins with explicit setting
+			sets = {
+				ca_set_items = {
+					ca_entities = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = entity_id
+					}
+				}
+			}
+		},
+		fields = {
+			set_code = { },
+			set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_places = {
+	# ------------------------------------
+	ca_places = {
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			hierarchy_id = { STORE, DONT_TOKENIZE },
+			parent_id = {STORE, DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_place_labels = {
+		key = place_id,
+		fields = {
+			name = { BOOST = 100, INDEX_ANCESTORS, INDEX_ANCESTORS_START_AT_LEVEL = 1, INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS = 10 }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = [ca_entities_x_places, ca_entities],
+		},
+		fields = {
+			entity_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			displayname = {}
+		}
+	},
+	# ------------------------------------
+	ca_occurrence_labels = {
+		tables = {
+			places = [ca_places_x_occurrences, ca_occurrences],
+		},
+		fields = {
+			occurrence_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_collection_labels = {
+		tables = {
+			collections = [ca_places_x_collections, ca_collections],
+		},
+		fields = {
+			collection_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_list_item_labels = {
+		tables = {
+			vocabulary = [ca_places_x_vocabulary_terms, ca_list_items]
+		},
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_sets = {
+		tables = {
+			sets = [ca_set_items],
+		},
+		keys = {		# manually override joins with explicit setting
+			sets = {
+				ca_set_items = {
+					ca_places = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = place_id
+					}
+				}
+			}
+		},
+		fields = {
+			set_code = { },
+			set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_occurrences = {
+	# ------------------------------------
+	ca_occurrences = {
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			hier_occurrence_id = { STORE, DONT_TOKENIZE },
+			parent_id = {STORE, DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_occurrence_labels = {
+		key = occurrence_id,
+		fields = {
+			name = { BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = [ca_entities_x_occurrences, ca_entities]
+		},
+		fields = {
+			displayname = {}
+		}
+	},
+	# ------------------------------------
+	ca_entities = {
+		tables = {
+			collections = [ca_entities_x_occurrences],
+		},
+		fields = {
+			entity_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_place_labels = {
+		tables = {
+			places = [ca_places_x_occurrences, ca_places]
+		},
+		fields = {
+			name = { INDEX_ANCESTORS, INDEX_ANCESTORS_START_AT_LEVEL = 1, INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS = 3 }
+		}
+	},
+	# ------------------------------------
+	ca_collections = {
+		tables = {
+			collections = [ca_occurrences_x_collections],
+		},
+		fields = {
+			collection_id = { DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_collection_labels = {
+		tables = {
+			collections = [ca_occurrences_x_collections, ca_collections],
+		},
+		fields = {
+			collection_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_collections = {
+		tables = {
+			collections = [ca_occurrences_x_collections],
+		},
+		fields = {
+			collection_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_list_item_labels = {
+		tables = {
+			vocabulary = [ca_occurrences_x_vocabulary_terms, ca_list_items]
+		},
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_sets = {
+		tables = {
+			sets = [ca_set_items],
+		},
+		keys = {		# manually override joins with explicit setting
+			sets = {
+				ca_set_items = {
+					ca_occurrences = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = occurrence_id
+					}
+				}
+			}
+		},
+		fields = {
+			set_code = { },
+			set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+
+ca_collections = {
+	# ------------------------------------
+	ca_collections = {
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			hier_collection_id = { STORE, DONT_TOKENIZE },
+			parent_id = {STORE, DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_collection_labels = {
+		key = collection_id,
+		fields = {
+			name = { BOOST = 100 },
+			name_sort = { DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = [ca_entities_x_collections, ca_entities]
+		},
+		fields = {
+			displayname = {}
+		}
+	},
+	# ------------------------------------
+	ca_place_labels = {
+		tables = {
+			places = [ca_places_x_collections, ca_places]
+		},
+		fields = {
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_occurrence_labels = {
+		tables = {
+			occurrences = [ca_occurrences_x_collections, ca_occurrences]
+		},
+		fields = {
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_list_item_labels = {
+		tables = {
+			vocabulary = [ca_collections_x_vocabulary_terms, ca_list_items]
+		},
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_sets = {
+		tables = {
+			sets = [ca_set_items],
+		},
+		keys = {		# manually override joins with explicit setting
+			sets = {
+				ca_set_items = {
+					ca_collections = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = collection_id
+					}
+				}
+			}
+		},
+		fields = {
+			set_code = { },
+			set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+
+ca_object_representations = {
+	# ------------------------------------
+	ca_object_representations = {
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			mimetype = { STORE, INDEX_AS_MIMETYPE },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			md5 = { STORE, DONT_TOKENIZE },
+			original_filename = { STORE, DONT_TOKENIZE },
+			media_class = { },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_object_representation_labels = {
+		key = representation_id,
+		fields = {
+			name = { BOOST = 100 },
+			name_sort = { DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_object_labels = {
+		tables = {
+			objects = [ca_objects_x_object_representations, ca_objects]
+		},
+		fields = {
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_objects = {
+		tables = {
+			objects = [ca_objects_x_object_representations]
+		},
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = [ca_object_representations_x_entities, ca_entities]
+		},
+		fields = {
+			displayname = {}
+		}
+	},
+	# ------------------------------------
+	ca_place_labels = {
+		tables = {
+			places = [ca_object_representations_x_places, ca_places]
+		},
+		fields = {
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_occurrence_labels = {
+		tables = {
+			occurrences = [ca_object_representations_x_occurrences, ca_occurrences]
+		},
+		fields = {
+			name = {}
+		}
+	},      
+	# ------------------------------------
+	ca_list_item_labels = {
+		tables = {
+			vocabulary = [ca_object_representations_x_vocabulary_terms, ca_list_items]
+		},
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_collection_labels = {
+		tables = {
+			collections = [ca_object_representations_x_collections, ca_collections],
+		},
+		fields = {
+			collection_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_storage_location_labels = {
+		tables = {
+			places = [ca_object_representations_x_storage_locations, ca_storage_locations]
+		},
+		fields = {
+			location_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_sets = {
+		tables = {
+			sets = [ca_set_items],
+		},
+		keys = {		# manually override joins with explicit setting
+			sets = {
+				ca_set_items = {
+					ca_object_representations = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = representation_id
+					}
+				}
+			}
+		},
+		fields = {
+			set_code = { },
+			set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	}
+	# ------------------------------------
+}
+# ------------------------------------------------------------------------------------------------------------
+
+ca_list_items = {
+	# ------------------------------------
+	ca_list_items = {
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			list_id = { STORE, DONT_TOKENIZE },
+			parent_id = {STORE, DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	}
+	# ------------------------------------
+	ca_list_item_labels = {
+		key = item_id,
+		fields = {
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_lists = {
+		key = list_id,
+		fields = {
+			use_as_vocabulary = { STORE, DONT_TOKENIZE },
+			list_code = { STORE, DONT_TOKENIZE }
+		}
+	}
+	# ------------------------------------
+	ca_sets = {
+    	tables = {
+    		sets = [ca_set_items],
+    	},
+    	keys = {		# manually override joins with explicit setting
+    		sets = {
+    			ca_set_items = {
+    				ca_list_items = {
+    					left_key = row_id,
+    					left_table_num = table_num,
+    					right_key = item_id
+    				}
+    			}
+    		}
+    	},
+    	fields = {
+    		set_code = { },
+    		set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+    	}
+    },
+	# ------------------------------------
+	_access_points = {
+		list = {
+			fields = [ca_lists.list_code, ca_lists.list_id],
+			boolean = OR
+		},
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR,
+			name = _(Set code)
+		},
+	}
+    # ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+
+ca_item_comments = {
+	# ------------------------------------
+	ca_item_comments = {
+		fields = {
+			comment = { },
+			email = { },
+			name = { },
+			user_id = { },
+			created_on = { },
+			moderated_on = { } 
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		comment = {
+			fields = [ca_item_comments.comment]
+		},
+		email = {
+			fields = [ca_item_comments.email]
+		},
+		name = {
+			fields = [ca_item_comments.name]
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+
+ca_storage_locations = {
+	# ------------------------------------
+	ca_storage_locations = {
+		fields = {
+			status = { },
+			type_id = { },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100, INDEX_ANCESTORS, INDEX_ANCESTORS_START_AT_LEVEL = 0, INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS = 10  },
+			_metadata = { },
+			parent_id = {STORE, DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM },
+			is_enabled = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	}
+	# ------------------------------------
+	ca_storage_location_labels = {
+		key = location_id,
+		fields = {
+			name = { INDEX_ANCESTORS, INDEX_ANCESTORS_START_AT_LEVEL = 0, INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS = 10 }
+		}
+	},
+	# ------------------------------------
+	ca_sets = {
+		tables = {
+			sets = [ca_set_items],
+		},
+		keys = {		# manually override joins with explicit setting
+			sets = {
+				ca_set_items = {
+					ca_storage_locations = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = location_id
+					}
+				}
+			}
+		},
+		fields = {
+			set_code = { },
+			set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		name = {
+			fields = [ca_storage_location_labels.name]
+		},
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+
+ca_relationship_types = {
+	# ------------------------------------
+	ca_relationship_types = {
+		fields = {
+			type_code = { },
+			hier_type_id = { STORE, DONT_TOKENIZE }
+		}
+	}
+	# ------------------------------------
+	ca_relationship_type_labels = {
+		key = type_id,
+		fields = {
+			typename = {},
+			typename_reverse = {}
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		name = {
+			fields = [ca_relationship_type_labels.typename, ca_relationship_type_labels.typename_reverse]
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_loans = {
+	# ------------------------------------
+	ca_loans = {
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			hier_loan_id = { STORE, DONT_TOKENIZE },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_loan_labels = {
+		key = loan_id,
+		fields = {
+			name = { BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = [ca_loans_x_entities, ca_entities, ca_entity_labels]
+		},
+		fields = {
+			displayname = {},
+			forename = {},
+			surname = {}
+		}
+	},
+	# ------------------------------------
+	ca_objects = {
+		tables = {
+			objects = [ca_loans_x_objects, ca_objects]
+		},
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_object_labels = {
+		tables = {
+			objects = [ca_loans_x_objects, ca_objects, ca_object_labels]
+		},
+		fields = {
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_movements = {
+	# ------------------------------------
+	ca_movements = {
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_movement_labels = {
+		key = movement_id,
+		fields = {
+			name = { BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = [ca_movements_x_entities, ca_entities, ca_entity_labels]
+		},
+		fields = {
+			displayname = {},
+			forename = {},
+			surname = {}
+		}
+	},
+	# ------------------------------------
+	ca_objects = {
+		tables = {
+			objects = [ca_movements_x_objects, ca_objects]
+		},
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_object_labels = {
+		tables = {
+			objects = [ca_movements_x_objects, ca_objects, ca_object_labels]
+		},
+		fields = {
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	},
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_item_tags = {
+	# ------------------------------------
+	ca_item_tags = {
+		fields = {
+			tag = {}
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		tag = {
+			fields = [ca_item_tags.tag]
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_users = {
+	# ------------------------------------
+	ca_users = {
+		fields = {
+			user_id = {},
+			user_name = {},
+			fname = {},
+			lname = {},
+			email = {}
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		username = {
+			fields = [ca_users.user_name]
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_user_groups = {
+	# ------------------------------------
+	ca_user_groups = {
+		fields = {
+			name = {},
+			code = {},
+			description = {}
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		name = {
+			fields = [ca_user_groups.name]
+		}
+	}
+	# ------------------------------------
+}
+# ------------------------------------------------------------------------------------------------------------
+ca_sets = {
+	# ------------------------------------
+	ca_sets = {
+		fields = {
+			set_code = { },
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			table_num = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	ca_set_labels = {
+		key = set_id,
+		fields = {
+			name = { BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		type_id = {
+			fields = [ca_sets.type_id],
+			boolean = OR
+		},
+	}
+	# ------------------------------------
+}
+# ------------------------------------------------------------------------------------------------------------
+ca_set_items = {
+	# ------------------------------------
+	ca_set_items = {
+    	fields = {
+    		set_id = { STORE, DONT_TOKENIZE },
+    		type_id = { STORE, DONT_TOKENIZE },
+    		row_id = { STORE, DONT_TOKENIZE },
+    		_metadata = { },
+    	}
+    },
+	# ------------------------------------
+	ca_set_item_labels = {
+		key = item_id,
+		fields = {
+			caption = { BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_set_items.set_id],
+			boolean = OR
+		},
+		type_id = {
+			fields = [ca_set_items.type_id],
+			boolean = OR
+		},
+		row = {
+			fields = [ca_set_items.row_id],
+            boolean = OR
+		}
+	}
+	# ------------------------------------
+}
+# ------------------------------------------------------------------------------------------------------------
+ca_tours = {
+	# ------------------------------------
+	ca_tours = {
+		fields = {
+			tour_code = { STORE, DONT_TOKENIZE },
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_tour_labels = {
+		key = tour_id,
+		fields = {
+			name = { BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		tour = {
+			fields = [ca_tours.tour_id, ca_tours.tour_code],
+			boolean = OR
+		},
+		type_id = {
+			fields = [ca_tours.type_id],
+			boolean = OR
+		}
+	}
+	# ------------------------------------
+}
+# ------------------------------------------------------------------------------------------------------------
+ca_tour_stops = {
+	# ------------------------------------
+	ca_tour_stops = {
+		fields = {
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			hier_stop_id = { STORE, DONT_TOKENIZE },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_tour_stop_labels = {
+		key = stop_id,
+		fields = {
+			name = { BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_object_checkouts = {
+	# ------------------------------------
+	ca_object_checkouts = {
+		fields = {
+			object_id = { STORE, DONT_TOKENIZE },
+			group_uuid = { STORE, DONT_TOKENIZE },
+			user_id = { STORE, DONT_TOKENIZE },
+			created_on = { },
+			checkout_date = { },
+			due_date = { },
+			return_date = { },
+			checkout_notes = { },
+			return_notes = { },
+			
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_users = {
+		key = user_id,
+		fields = {
+			user_id = {},
+			fname = {},
+			lname = {},
+			email = {},
+			user_name = {}
+		}
+	},
+	# ------------------------------------
+	ca_object_labels = {
+		tables = {
+			objects = [ca_objects]
+		},
+		fields = {
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_objects = {
+		key = object_id,
+		fields = {
+			lot_id = {},
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },	
+			type_id = { STORE, DONT_TOKENIZE },
+			is_deaccessioned = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		
+	}
+	# ------------------------------------
+}
+# ------------------------------------------------------------------------------------------------------------

--- a/ucla_providence/app/conf/local/search_indexing.conf
+++ b/ucla_providence/app/conf/local/search_indexing.conf
@@ -1,0 +1,1855 @@
+# Field level options
+#
+#	STORE 			 				(forces value to be stored in index, if possible; this can speed display of the content in a search but may slow down indexing and increases index size)
+#	TOKENIZE						(forces tokenization of value alongside non-tokenized value when DONT_TOKENIZE is set; 
+#										you only need to set this when you need to index a value in both tokenized and untokenized form; tokenization is assumed when DONT_TOKENIZE is not set)
+#	DONT_TOKENIZE	 				(indexes value as-is without tokenization)
+#	DONT_INCLUDE_IN_SEARCH_FORM 	(causes field to not be includable in user-defined search forms)
+#	BOOST							(numeric "boost" value to index field with; higher values will cause search hits on the boosted field to count for more when sorting by relevance)
+#	INDEX_AS_IDNO					(causes value to be indexed with various permutations for flexible retrieval as a record identifer)
+#	IDNO_DELIMITERS					(if set to a list of delimeters and INDEX_AS_IDNO is set, value will be split on the delimiter and resulting components indexed separately).
+#	INDEX_AS_MIMETYPE				(causes value to be indexed as a mimetype, including both the literal mimetype and the display text value for the type)
+#	INDEX_ANCESTORS					(enables hierarchical indexing for field, assuming it is in an hierarchical table, resulting in all values for this field in 
+#									 records above the subject in the hierarchy being indexed against the subject)
+#	INDEX_ANCESTORS_START_AT_LEVEL  (forces hierarchical indexing to start X levels down from the root. This allows you to omit the very highest, and least selective, levels of
+#									 the hierarchy when indexing. If omitted indexing starts from the hierarchy root.)
+#	INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS	(sets the maximum number of levels above the subject to be indexed. If omitted all levels of the hierarchy above the subject
+#											 are indexed.)
+#	INDEX_ANCESTORS_AS_PATH_WITH_DELIMITER	(sets a delimiter to place between each level of the hierarchy prior to indexing the entire hierarchy path above the subject. This is 
+#											 useful when you want to treat the hierarchy path as an identifier)
+#
+#	CHILDREN_INHERIT 				(copies indexing onto all records below the subject in the hierarchy. This can be useful when it is desirable to have child records returned in searches for parents.)
+#
+#	ANCESTORS_INHERIT				(copies indexing onto all records above the subject in the hierarchy. This can be useful when it is desirable to have parent records returned in searches for children.)
+#
+#   INDEX_LIST_ANCESTORS            (copies idno, item_id and label for ancestors of list item referenced by subject into index for subject. Useful for indexing hierarchical types for a subject.)
+#
+#	PRIVATE							(marks indexing for field as being only for use by authenticated users, not for public use; typically Pawtucket front-ends will ignore indexing so flagged)
+#
+#	PRIVATE_WHEN					(for container metadata elements, conditionally marks all subfields as private when a container sub-field has a specified value. This is only available for containers. The value of this
+#											option is a dictionary with sub-element codes and lists of values to match. Ex:
+#
+#											_ca_attribute_object_notes = { 
+#												PRIVATE_WHEN = {
+#													object_note_status = [internal]
+#												}
+#											}
+#
+#											The above example makes all "object_notes" container sub-fields indexed as private when the sub-field
+#											object_note_status is set to "internal"
+#
+#	COUNT							(for metadata attributes only; indicates that the number of values set for the attribute for a record should be indexed; allows searching on records by number of 
+#									 values in a given field; to index counts on relationships use the _count special field)
+#
+#   CURRENT                         (for metadata attributes and related tables with effective_date support only; only index latest repeat for this metadata element.)
+#
+#   CURRENT_DATE                    (for container metadata attributes only; use date element with specified element code to determine the current value to index is; implies CURRENT option is set.)
+#
+# Special fields (always start with underscore character):
+#	_metadata		(marks all metadata attributes on the record for indexing; this obviates the need to list each and every configured attribute in the configuration; to index a specific 
+#					 metadata attribute use ca_attribute_<element_code>, replacing <element_code> with the code for the desired element)
+#
+#	_count			(embeds the number of related rows for a given table in the index; you can specify this for both relationship and primary tables; the field is named 
+#					 <table_name>.count - for example: ca_object_representations.count for table 'ca_object_representations'; this can be used to find rows that have, or 
+#					 don't have, related rows in a given table. When specified on a primary table, counts are indexed in aggregate as well as for each type. For
+#					 relationship tables counts are indexed in aggregate as well as for each relationship type. Querying on a specific type or types is done like this:
+#						 ca_entities.count/individual:3 (finds records with exactly three related entities of type "individual")
+#						 ca_objects_x_entities.count/artist:[2 to 4] (finds objects with between two and four entities related as artist)
+#
+#					 
+# Access point are "virtual fields" for use in searches. They can be employed in three ways:
+#	(1) as simple aliases for individual fields. For example, if you wanted to enabled searches on object synonym using objsyn like so: 
+#				objsyn:Volkswagen
+#		then you'd simply define 'objsyn' to be an access point to objects.synonym
+#
+#	(2) as aliases for bundles of fields. If an access point is defined to include several fields, then a search on the access point will search all of the included fields at the same time.
+#
+# Note that all fields included in an access point must be included in the search index - they must appear in the "fields" list in other words. All indexed fields automatically
+# have access points created in the format tablename.fieldname (ex. objects.title); indexed metadata also have access points in the format tablename.md_<element_id> (ex. objects.md_5)
+#
+# When creating an access point you define an access point configuration associative list, then create a key for each access point.
+
+# ------------------------------------------------------------------------------------------------------------
+ca_objects = {
+	# ------------------------------------
+	ca_objects = {
+		fields = {
+			object_id = { },
+			_metadata = { },					# forces indexing of all attributes
+			parent_id = {STORE, DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM },
+			source_id = {},
+			lot_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },	
+			type_id = { STORE, DONT_TOKENIZE },
+			source_id = { STORE, DONT_TOKENIZE },
+			acquisition_type_id = { STORE, DONT_TOKENIZE },
+			hier_object_id = { STORE, DONT_TOKENIZE },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE },
+			is_deaccessioned = { STORE, DONT_TOKENIZE },
+			deaccession_notes = {},
+			deaccession_date = {},
+			circulation_status_id = { STORE, DONT_TOKENIZE },
+			submission_session_id = { STORE, DONT_TOKENIZE }
+		},
+		# Index idno's of related objects 
+		related = {
+			fields = {
+				idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 10 }
+			}
+		}
+	},
+	# ------------------------------------
+	ca_object_labels = {
+		key = object_id,
+		#filter = { is_preferred = 1 }, // limit indexing to preferred labels only
+		fields = {
+			name = { BOOST = 100, INDEX_ANCESTORS, INDEX_ANCESTORS_START_AT_LEVEL = 0, INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS = 4, INDEX_ANCESTORS_AS_PATH_WITH_DELIMITER = . },
+			name_sort = { DONT_INCLUDE_IN_SEARCH_FORM },
+			_count = {}
+		},
+		# Index names of related objects
+		related = {
+			fields = {
+				name = { BOOST = 10, INDEX_ANCESTORS, INDEX_ANCESTORS_START_AT_LEVEL = 0, INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS = 4, INDEX_ANCESTORS_AS_PATH_WITH_DELIMITER = . }
+			}
+		} 
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	ca_objects_x_entities = {
+		key = object_id,
+		fields = {
+			_count = { }
+		}
+	},
+	# ------------------------------------
+	ca_entities = {
+		tables = {
+			entities = [ca_objects_x_entities],
+			object_lots = [ca_object_lots, ca_object_lots_x_entities]
+		},
+		fields = {
+			entity_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			_count = { }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = {
+				ca_objects_x_entities = { }, 
+				ca_entities = {}
+			},
+			object_lots = [ca_object_lots, ca_object_lots_x_entities, ca_entities],
+			annotations = [ca_objects_x_object_representations, ca_object_representations, ca_representation_annotations, ca_representation_annotations_x_entities, ca_entities]
+		},
+		fields = {
+			entity_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			displayname = { },
+			forename = {},
+			surname = {},
+			middlename = {},
+			access = {},
+			checked = {}
+		}
+	},
+	# ------------------------------------
+	ca_places = {
+		tables = {
+			collections = [ca_objects_x_places],
+		},
+		fields = {
+			place_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_place_labels = {
+		tables = {
+			places = [ca_objects_x_places, ca_places],
+			annotations = [ca_objects_x_object_representations, ca_object_representations, ca_representation_annotations, ca_representation_annotations_x_places, ca_places]
+		},
+		fields = {
+			place_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = { INDEX_ANCESTORS, INDEX_ANCESTORS_START_AT_LEVEL = 1, INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS = 3 }
+		}
+	},
+	# ------------------------------------
+	ca_occurrences = {
+		tables = {
+			collections = [ca_objects_x_occurrences],
+		},
+		fields = {
+			occurrence_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_occurrence_labels = {
+		tables = {
+			occurrences = [ca_objects_x_occurrences, ca_occurrences],
+			annotations = [ca_objects_x_object_representations, ca_object_representations, ca_representation_annotations, ca_representation_annotations_x_occurrences, ca_occurrences]
+		},
+		fields = {
+			occurrence_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_collections = {
+		tables = {
+			collections = [ca_objects_x_collections],
+		},
+		fields = {
+			collection_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = {STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_collection_labels = {
+		tables = {
+			collections = [ca_objects_x_collections, ca_collections],
+		},
+		fields = {
+			collection_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_loan_labels = {
+		tables = {
+			loans = [ca_loans_x_objects, ca_loans],
+		},
+		fields = {
+			loan_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_loans = {
+		tables = {
+			loans = [ca_loans_x_objects],
+		},
+		fields = {
+			loan_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_list_items = {
+		tables = {
+			list_items = [ca_objects_x_vocabulary_terms],
+		},
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_list_item_labels = {
+		tables = {
+			vocabulary = [ca_objects_x_vocabulary_terms, ca_list_items],
+			annotations = [ca_objects_x_object_representations, ca_object_representations, ca_representation_annotations, ca_representation_annotations_x_vocabulary_terms, ca_list_items],
+			types = [ca_list_items, ca_list_item_labels],
+			sources = [ca_list_items, ca_list_item_labels]
+		},
+		keys = {
+			types = {
+				ca_objects = {
+					ca_list_items = {
+						left_key = type_id,
+						right_key = item_id
+					}
+				}
+			},
+			sources = {
+				ca_objects = {
+					ca_list_items = {
+						left_key = source_id,
+						right_key = item_id
+					}
+				}
+			}
+		}
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM }, 
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_representation_annotation_labels = {
+		tables = {
+			vocabulary = [ca_objects_x_object_representations, ca_object_representations, ca_representation_annotations]
+		},
+		fields = {
+			name = {},
+			name_sort = { DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_item_tags = {
+		tables = {
+			tags = [ca_items_x_tags],
+		},
+		keys = {		# manually override joins with explicit setting
+			tags = {
+				ca_items_x_tags = {
+					ca_objects = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = object_id
+					}
+				}
+			}
+		},
+		fields = {
+			tag = { BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_sets = {
+		tables = {
+			sets = [ca_set_items],
+		},
+		keys = {		# manually override joins with explicit setting
+			sets = {
+				ca_set_items = {
+					ca_objects = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = object_id
+					}
+				}
+			}
+		},
+		fields = {
+			set_code = { },
+			set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_storage_locations = {
+		tables = {
+			places = [ca_objects_x_storage_locations],
+		},
+		fields = {
+			location_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_storage_location_labels = {
+		tables = {
+			places = [ca_objects_x_storage_locations, ca_storage_locations]
+		},
+		fields = {
+			location_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = { INDEX_ANCESTORS, INDEX_ANCESTORS_START_AT_LEVEL = 0, INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS = 10, INDEX_ANCESTORS_AS_PATH_WITH_DELIMITER = .}
+		}
+	},
+	# ------------------------------------
+	ca_object_representations = {
+		tables = {
+			reps = [ca_objects_x_object_representations]
+		},
+		fields = {
+			representation_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			media_content = { DONT_INCLUDE_IN_SEARCH_FORM },
+			mimetype = { STORE, INDEX_AS_MIMETYPE },
+			md5 = { STORE, DONT_TOKENIZE },
+			original_filename = { STORE, DONT_TOKENIZE },
+			media_class = { },
+			is_transcribable = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_representation_transcriptions = {
+		tables = {
+			reps = [ca_objects_x_object_representations, ca_object_representations]
+		},
+		fields = {
+			transcription_id = { },
+			transcription = { },
+			_count = { },
+			user_id = { }
+		}
+	},
+	# ------------------------------------
+	ca_object_lots = {
+		key = lot_id,
+		fields = {
+			idno_stub = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			_metadata = { },
+			lot_status_id = { STORE, DONT_TOKENIZE },
+			type_id = { STORE, DONT_TOKENIZE },
+			extent = { STORE, DONT_TOKENIZE },
+			extent_units = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			access = { STORE, DONT_TOKENIZE },
+			acquistion_date = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	ca_object_lot_labels = {
+		tables = {
+			lots = [ca_object_lots]
+		},
+		fields = {
+			name = { BOOST = 100 },
+			name_sort = { DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		label = {
+			fields = [ca_object_labels.name],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		term_id = {
+			fields = [ca_list_items.item_id],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		entity_id = {
+			fields = [ca_entities.entity_id],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		place_id = {
+			fields = [ca_places.place_id],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		occurrence_id = {
+			fields = [ca_occurrences.occurrence_id],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		collection_id = {
+			fields = [ca_collections.collection_id],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		entity = {
+			fields = [ca_entities.idno],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		place = {
+			fields = [ca_places.idno],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		occurrence = {
+			fields = [ca_occurrences.idno],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		collection = {
+			fields = [ca_collections.idno],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		children = {
+			fields = [ca_objects.parent_id],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		type_id = {
+			fields = [ca_objects.type_id],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		source_id = {
+			fields = [ca_objects.source_id],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		access = {
+			fields = [ca_objects.access],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		idno = {
+			fields = [ca_objects.idno],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		tags = {
+			fields = [ca_item_tags.tag],
+			name = _(User tags),
+			options = { }
+		},
+		set = {
+			fields = [ca_sets.set_code],
+			boolean = OR,
+			name = _(Set code),
+			options = { DONT_STEM }
+		},
+		place = {
+			fields = [ca_place_labels.name],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		term = {
+			fields = [ca_list_item_labels.name_singular, ca_list_item_labels.name_plural],
+			boolean = OR,
+			name = _(Related term)
+		},
+		entity = {
+			fields = [ca_entity_labels.displayname],
+			options = { DONT_INCLUDE_IN_SEARCH_FORM }
+		},
+		filename = {
+			fields = [ca_object_representations.original_filename],
+			options = {  }	
+		},
+		mimetype = {
+			fields = [ca_object_representations.mimetype],
+			options = {  }	
+		},
+		md5 = {
+			fields = [ca_object_representations.md5],
+			options = {  }	
+		},
+		deaccession = {
+			fields = [ca_objects.is_deaccessioned],
+			options = { }
+		},
+		deaccessioned = {
+			fields = [ca_objects.is_deaccessioned],
+			options = { }
+		},
+		deaccessionDate = {
+			fields = [ca_objects.deaccession_date],
+			options = { }
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		},
+		acquisitionDate = {
+			fields = [ca_object_lots.acquisition_date],
+			options = { }
+		}
+	},
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_representation_annotations = {
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = [ca_representation_annotations_x_entities, ca_entities]
+		},
+		fields = {
+			displayname = {}
+		}
+	},
+	# ------------------------------------
+	ca_place_labels = {
+		tables = {
+			places = [ca_representation_annotations_x_places, ca_places]
+		},
+		fields = {
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_list_item_labels = {
+		tables = {
+			vocabularies = [ca_representation_annotations_x_vocabulary_terms, ca_list_items]
+		},
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM }, 
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_representation_annotation_labels = {
+		key = annotation_id,
+		fields = {
+			name = {},
+			name_sort = { DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		access = {
+			fields = [ca_representation_annotations.access]
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_object_lots = {
+	# ------------------------------------
+	ca_object_lots = {
+		fields = {
+			idno_stub = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			_metadata = { },
+			lot_status_id = { STORE, DONT_TOKENIZE },
+			type_id = { STORE, DONT_TOKENIZE },
+			extent = { STORE, DONT_TOKENIZE },
+			extent_units = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			access = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_object_lot_labels = {
+		key = lot_id,
+		fields = {
+			name = { BOOST = 100 },
+			name_sort = { DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = [ca_object_lots_x_entities, ca_entities]
+		},
+		fields = {
+			displayname = {}
+		}
+	},
+	# ------------------------------------
+	ca_list_item_labels = {
+		tables = {
+			vocabulary = [ca_object_lots_x_vocabulary_terms, ca_list_items]
+		},
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_objects = {
+		key = lot_id,
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_storage_location_labels = {
+		tables = {
+			places = [ca_object_lots_x_storage_locations, ca_storage_locations]
+		},
+		fields = {
+			location_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_sets = {
+		tables = {
+			sets = [ca_set_items],
+		},
+		keys = {		# manually override joins with explicit setting
+			sets = {
+				ca_set_items = {
+					ca_object_lots = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = lot_id
+					}
+				}
+			}
+		},
+		fields = {
+			set_code = { },
+			set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_entities = {
+	# ------------------------------------
+	ca_entities = {
+		fields = {
+			type_id = { STORE, DONT_TOKENIZE },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },	
+			_metadata = { },
+			hier_entity_id = { STORE, DONT_TOKENIZE },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		key = entity_id,
+		fields = {
+			forename = { BOOST = 100 },
+			other_forenames = {},
+			surname = { BOOST = 100 },
+			middlename = {},
+			displayname = { BOOST = 100 },
+			access = {},
+			checked = {}
+		}
+	},
+	# ------------------------------------
+	ca_place_labels = {
+		tables = {
+			places = [ca_entities_x_places, ca_places],
+		},
+		fields = {
+			place_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_occurrence_labels = {
+		tables = {
+			occurrences = [ca_entities_x_occurrences, ca_occurrences],
+		},
+		fields = {
+			occurrence_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_collection_labels = {
+		tables = {
+			collections = [ca_entities_x_collections, ca_collections],
+		},
+		fields = {
+			collection_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_list_item_labels = {
+		tables = {
+			vocabulary = [ca_entities_x_vocabulary_terms, ca_list_items]
+		},
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_sets = {
+		tables = {
+			sets = [ca_set_items],
+		},
+		keys = {		# manually override joins with explicit setting
+			sets = {
+				ca_set_items = {
+					ca_entities = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = entity_id
+					}
+				}
+			}
+		},
+		fields = {
+			set_code = { },
+			set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_places = {
+	# ------------------------------------
+	ca_places = {
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			hierarchy_id = { STORE, DONT_TOKENIZE },
+			parent_id = {STORE, DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_place_labels = {
+		key = place_id,
+		fields = {
+			name = { BOOST = 100, INDEX_ANCESTORS, INDEX_ANCESTORS_START_AT_LEVEL = 1, INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS = 10 }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = [ca_entities_x_places, ca_entities],
+		},
+		fields = {
+			entity_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			displayname = {}
+		}
+	},
+	# ------------------------------------
+	ca_occurrence_labels = {
+		tables = {
+			places = [ca_places_x_occurrences, ca_occurrences],
+		},
+		fields = {
+			occurrence_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_collection_labels = {
+		tables = {
+			collections = [ca_places_x_collections, ca_collections],
+		},
+		fields = {
+			collection_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_list_item_labels = {
+		tables = {
+			vocabulary = [ca_places_x_vocabulary_terms, ca_list_items]
+		},
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_sets = {
+		tables = {
+			sets = [ca_set_items],
+		},
+		keys = {		# manually override joins with explicit setting
+			sets = {
+				ca_set_items = {
+					ca_places = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = place_id
+					}
+				}
+			}
+		},
+		fields = {
+			set_code = { },
+			set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_occurrences = {
+	# ------------------------------------
+	ca_occurrences = {
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			hier_occurrence_id = { STORE, DONT_TOKENIZE },
+			parent_id = {STORE, DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_occurrence_labels = {
+		key = occurrence_id,
+		fields = {
+			name = { BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = [ca_entities_x_occurrences, ca_entities]
+		},
+		fields = {
+			displayname = {}
+		}
+	},
+	# ------------------------------------
+	ca_entities = {
+		tables = {
+			collections = [ca_entities_x_occurrences],
+		},
+		fields = {
+			entity_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_place_labels = {
+		tables = {
+			places = [ca_places_x_occurrences, ca_places]
+		},
+		fields = {
+			name = { INDEX_ANCESTORS, INDEX_ANCESTORS_START_AT_LEVEL = 1, INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS = 3 }
+		}
+	},
+	# ------------------------------------
+	ca_collections = {
+		tables = {
+			collections = [ca_occurrences_x_collections],
+		},
+		fields = {
+			collection_id = { DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_collection_labels = {
+		tables = {
+			collections = [ca_occurrences_x_collections, ca_collections],
+		},
+		fields = {
+			collection_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_collections = {
+		tables = {
+			collections = [ca_occurrences_x_collections],
+		},
+		fields = {
+			collection_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_list_item_labels = {
+		tables = {
+			vocabulary = [ca_occurrences_x_vocabulary_terms, ca_list_items]
+		},
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_sets = {
+		tables = {
+			sets = [ca_set_items],
+		},
+		keys = {		# manually override joins with explicit setting
+			sets = {
+				ca_set_items = {
+					ca_occurrences = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = occurrence_id
+					}
+				}
+			}
+		},
+		fields = {
+			set_code = { },
+			set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+
+ca_collections = {
+	# ------------------------------------
+	ca_collections = {
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			hier_collection_id = { STORE, DONT_TOKENIZE },
+			parent_id = {STORE, DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_collection_labels = {
+		key = collection_id,
+		fields = {
+			name = { BOOST = 100 },
+			name_sort = { DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = [ca_entities_x_collections, ca_entities]
+		},
+		fields = {
+			displayname = {}
+		}
+	},
+	# ------------------------------------
+	ca_place_labels = {
+		tables = {
+			places = [ca_places_x_collections, ca_places]
+		},
+		fields = {
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_occurrence_labels = {
+		tables = {
+			occurrences = [ca_occurrences_x_collections, ca_occurrences]
+		},
+		fields = {
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_list_item_labels = {
+		tables = {
+			vocabulary = [ca_collections_x_vocabulary_terms, ca_list_items]
+		},
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_sets = {
+		tables = {
+			sets = [ca_set_items],
+		},
+		keys = {		# manually override joins with explicit setting
+			sets = {
+				ca_set_items = {
+					ca_collections = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = collection_id
+					}
+				}
+			}
+		},
+		fields = {
+			set_code = { },
+			set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+
+ca_object_representations = {
+	# ------------------------------------
+	ca_object_representations = {
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			mimetype = { STORE, INDEX_AS_MIMETYPE },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			md5 = { STORE, DONT_TOKENIZE },
+			original_filename = { STORE, DONT_TOKENIZE },
+			media_class = { },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_object_representation_labels = {
+		key = representation_id,
+		fields = {
+			name = { BOOST = 100 },
+			name_sort = { DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_object_labels = {
+		tables = {
+			objects = [ca_objects_x_object_representations, ca_objects]
+		},
+		fields = {
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_objects = {
+		tables = {
+			objects = [ca_objects_x_object_representations]
+		},
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = [ca_object_representations_x_entities, ca_entities]
+		},
+		fields = {
+			displayname = {}
+		}
+	},
+	# ------------------------------------
+	ca_place_labels = {
+		tables = {
+			places = [ca_object_representations_x_places, ca_places]
+		},
+		fields = {
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_occurrence_labels = {
+		tables = {
+			occurrences = [ca_object_representations_x_occurrences, ca_occurrences]
+		},
+		fields = {
+			name = {}
+		}
+	},      
+	# ------------------------------------
+	ca_list_item_labels = {
+		tables = {
+			vocabulary = [ca_object_representations_x_vocabulary_terms, ca_list_items]
+		},
+		fields = {
+			item_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_collection_labels = {
+		tables = {
+			collections = [ca_object_representations_x_collections, ca_collections],
+		},
+		fields = {
+			collection_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_storage_location_labels = {
+		tables = {
+			places = [ca_object_representations_x_storage_locations, ca_storage_locations]
+		},
+		fields = {
+			location_id = { DONT_INCLUDE_IN_SEARCH_FORM },
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_sets = {
+		tables = {
+			sets = [ca_set_items],
+		},
+		keys = {		# manually override joins with explicit setting
+			sets = {
+				ca_set_items = {
+					ca_object_representations = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = representation_id
+					}
+				}
+			}
+		},
+		fields = {
+			set_code = { },
+			set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	}
+	# ------------------------------------
+}
+# ------------------------------------------------------------------------------------------------------------
+
+ca_list_items = {
+	# ------------------------------------
+	ca_list_items = {
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			list_id = { STORE, DONT_TOKENIZE },
+			parent_id = {STORE, DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	}
+	# ------------------------------------
+	ca_list_item_labels = {
+		key = item_id,
+		fields = {
+			name_singular = {},
+			name_plural = {}
+		}
+	},
+	# ------------------------------------
+	ca_lists = {
+		key = list_id,
+		fields = {
+			use_as_vocabulary = { STORE, DONT_TOKENIZE },
+			list_code = { STORE, DONT_TOKENIZE }
+		}
+	}
+	# ------------------------------------
+	ca_sets = {
+    	tables = {
+    		sets = [ca_set_items],
+    	},
+    	keys = {		# manually override joins with explicit setting
+    		sets = {
+    			ca_set_items = {
+    				ca_list_items = {
+    					left_key = row_id,
+    					left_table_num = table_num,
+    					right_key = item_id
+    				}
+    			}
+    		}
+    	},
+    	fields = {
+    		set_code = { },
+    		set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+    	}
+    },
+	# ------------------------------------
+	_access_points = {
+		list = {
+			fields = [ca_lists.list_code, ca_lists.list_id],
+			boolean = OR
+		},
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR,
+			name = _(Set code)
+		},
+	}
+    # ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+
+ca_item_comments = {
+	# ------------------------------------
+	ca_item_comments = {
+		fields = {
+			comment = { },
+			email = { },
+			name = { },
+			user_id = { },
+			created_on = { },
+			moderated_on = { } 
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		comment = {
+			fields = [ca_item_comments.comment]
+		},
+		email = {
+			fields = [ca_item_comments.email]
+		},
+		name = {
+			fields = [ca_item_comments.name]
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+
+ca_storage_locations = {
+	# ------------------------------------
+	ca_storage_locations = {
+		fields = {
+			status = { },
+			type_id = { },
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100, INDEX_ANCESTORS, INDEX_ANCESTORS_START_AT_LEVEL = 0, INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS = 10  },
+			_metadata = { },
+			parent_id = {STORE, DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM },
+			is_enabled = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	}
+	# ------------------------------------
+	ca_storage_location_labels = {
+		key = location_id,
+		fields = {
+			name = { INDEX_ANCESTORS, INDEX_ANCESTORS_START_AT_LEVEL = 0, INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS = 10 }
+		}
+	},
+	# ------------------------------------
+	ca_sets = {
+		tables = {
+			sets = [ca_set_items],
+		},
+		keys = {		# manually override joins with explicit setting
+			sets = {
+				ca_set_items = {
+					ca_storage_locations = {
+						left_key = row_id,
+						left_table_num = table_num,
+						right_key = location_id
+					}
+				}
+			}
+		},
+		fields = {
+			set_code = { },
+			set_id = { DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM }
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		name = {
+			fields = [ca_storage_location_labels.name]
+		},
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+
+ca_relationship_types = {
+	# ------------------------------------
+	ca_relationship_types = {
+		fields = {
+			type_code = { },
+			hier_type_id = { STORE, DONT_TOKENIZE }
+		}
+	}
+	# ------------------------------------
+	ca_relationship_type_labels = {
+		key = type_id,
+		fields = {
+			typename = {},
+			typename_reverse = {}
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		name = {
+			fields = [ca_relationship_type_labels.typename, ca_relationship_type_labels.typename_reverse]
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_loans = {
+	# ------------------------------------
+	ca_loans = {
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			hier_loan_id = { STORE, DONT_TOKENIZE },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_loan_labels = {
+		key = loan_id,
+		fields = {
+			name = { BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = [ca_loans_x_entities, ca_entities, ca_entity_labels]
+		},
+		fields = {
+			displayname = {},
+			forename = {},
+			surname = {}
+		}
+	},
+	# ------------------------------------
+	ca_objects = {
+		tables = {
+			objects = [ca_loans_x_objects, ca_objects]
+		},
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_object_labels = {
+		tables = {
+			objects = [ca_loans_x_objects, ca_objects, ca_object_labels]
+		},
+		fields = {
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_movements = {
+	# ------------------------------------
+	ca_movements = {
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_movement_labels = {
+		key = movement_id,
+		fields = {
+			name = { BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_entity_labels = {
+		tables = {
+			entities = [ca_movements_x_entities, ca_entities, ca_entity_labels]
+		},
+		fields = {
+			displayname = {},
+			forename = {},
+			surname = {}
+		}
+	},
+	# ------------------------------------
+	ca_objects = {
+		tables = {
+			objects = [ca_movements_x_objects, ca_objects]
+		},
+		fields = {
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	ca_object_labels = {
+		tables = {
+			objects = [ca_movements_x_objects, ca_objects, ca_object_labels]
+		},
+		fields = {
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_media_upload_sessions = {
+		key = session_id,
+		fields = {
+			session_key = { STORE, DONT_TOKENIZE },
+			session_id = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		mediaUploadSession = {
+			fields = [ca_media_upload_sessions.session_key],
+			options = { }
+		}
+	},
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_item_tags = {
+	# ------------------------------------
+	ca_item_tags = {
+		fields = {
+			tag = {}
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		tag = {
+			fields = [ca_item_tags.tag]
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_users = {
+	# ------------------------------------
+	ca_users = {
+		fields = {
+			user_id = {},
+			user_name = {},
+			fname = {},
+			lname = {},
+			email = {}
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		username = {
+			fields = [ca_users.user_name]
+		}
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_user_groups = {
+	# ------------------------------------
+	ca_user_groups = {
+		fields = {
+			name = {},
+			code = {},
+			description = {}
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		name = {
+			fields = [ca_user_groups.name]
+		}
+	}
+	# ------------------------------------
+}
+# ------------------------------------------------------------------------------------------------------------
+ca_sets = {
+	# ------------------------------------
+	ca_sets = {
+		fields = {
+			set_code = { },
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			table_num = { STORE, DONT_TOKENIZE },
+		}
+	},
+	# ------------------------------------
+	ca_set_labels = {
+		key = set_id,
+		fields = {
+			name = { BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_sets.set_id, ca_sets.set_code],
+			boolean = OR
+		},
+		type_id = {
+			fields = [ca_sets.type_id],
+			boolean = OR
+		},
+	}
+	# ------------------------------------
+}
+# ------------------------------------------------------------------------------------------------------------
+ca_set_items = {
+	# ------------------------------------
+	ca_set_items = {
+    	fields = {
+    		set_id = { STORE, DONT_TOKENIZE },
+    		type_id = { STORE, DONT_TOKENIZE },
+    		row_id = { STORE, DONT_TOKENIZE },
+    		_metadata = { },
+    	}
+    },
+	# ------------------------------------
+	ca_set_item_labels = {
+		key = item_id,
+		fields = {
+			caption = { BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		set = {
+			fields = [ca_set_items.set_id],
+			boolean = OR
+		},
+		type_id = {
+			fields = [ca_set_items.type_id],
+			boolean = OR
+		},
+		row = {
+			fields = [ca_set_items.row_id],
+            boolean = OR
+		}
+	}
+	# ------------------------------------
+}
+# ------------------------------------------------------------------------------------------------------------
+ca_tours = {
+	# ------------------------------------
+	ca_tours = {
+		fields = {
+			tour_code = { STORE, DONT_TOKENIZE },
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_tour_labels = {
+		key = tour_id,
+		fields = {
+			name = { BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		tour = {
+			fields = [ca_tours.tour_id, ca_tours.tour_code],
+			boolean = OR
+		},
+		type_id = {
+			fields = [ca_tours.type_id],
+			boolean = OR
+		}
+	}
+	# ------------------------------------
+}
+# ------------------------------------------------------------------------------------------------------------
+ca_tour_stops = {
+	# ------------------------------------
+	ca_tour_stops = {
+		fields = {
+			type_id = { STORE, DONT_TOKENIZE },
+			_metadata = { },
+			hier_stop_id = { STORE, DONT_TOKENIZE },
+			access = { STORE, DONT_TOKENIZE },
+			status = { STORE, DONT_TOKENIZE },
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_tour_stop_labels = {
+		key = stop_id,
+		fields = {
+			name = { BOOST = 100 }
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		
+	}
+	# ------------------------------------
+}
+
+# ------------------------------------------------------------------------------------------------------------
+ca_object_checkouts = {
+	# ------------------------------------
+	ca_object_checkouts = {
+		fields = {
+			object_id = { STORE, DONT_TOKENIZE },
+			group_uuid = { STORE, DONT_TOKENIZE },
+			user_id = { STORE, DONT_TOKENIZE },
+			created_on = { },
+			checkout_date = { },
+			due_date = { },
+			return_date = { },
+			checkout_notes = { },
+			return_notes = { },
+			
+			deleted = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	ca_users = {
+		key = user_id,
+		fields = {
+			user_id = {},
+			fname = {},
+			lname = {},
+			email = {},
+			user_name = {}
+		}
+	},
+	# ------------------------------------
+	ca_object_labels = {
+		tables = {
+			objects = [ca_objects]
+		},
+		fields = {
+			name = {}
+		}
+	},
+	# ------------------------------------
+	ca_objects = {
+		key = object_id,
+		fields = {
+			lot_id = {},
+			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },	
+			type_id = { STORE, DONT_TOKENIZE },
+			is_deaccessioned = { STORE, DONT_TOKENIZE }
+		}
+	},
+	# ------------------------------------
+	_access_points = {
+		
+	}
+	# ------------------------------------
+}
+# ------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Implements [SYS-1808](https://uclalibrary.atlassian.net/browse/SYS-1808)
Detailed notes available on Confluence: https://uclalibrary.atlassian.net/wiki/x/aoBrQg

This PR modifies `search_indexing.conf` to allow searching Objects by Acquisition Date (among other Object Lots metadata). 

To test:
1. Get new `search_indexing.conf` file in `app/conf/local/`. No restart needed.
2. Perform reindexing through Providence UI (Manage → Administration → Maintenance → Rebuild search indices).
3. Update search forms to include "Object lot Acquisition Date" (Manage → My Search Tools → Search Forms). This field should be available for both Objects and Object Lots search forms.
  a. Note that the current Pilot instance has an Object Lots form called "Acquisitions Advanced Search" that appears to contain a "General Generic" field. The inclusion of this field appears to break search entirely. If possible, it should be removed from this search form, but it looks like only the original creator (Thelma?) has permission to edit it. In the meantime, if testing with a recent copy of the pilot database, you will probably need to create an entirely new search form and select it from the Forms dropdown on the Advanced Search page.
![image](https://github.com/user-attachments/assets/ba75d376-9265-4288-8a86-d49843f231f6)
4. Test the new field. You should be able to use the date picker to search by specific dates, or type plain text in the field (e.g. "2024", "april 2025") to perform broader searches.


[SYS-1808]: https://uclalibrary.atlassian.net/browse/SYS-1808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ