### PR TITLE
SYS-1809: implement automated ID numbering for Objects

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -2,7 +2,7 @@
 service: ucla-ca-providence
 
 # Name of the container image.
-image: uclalibrary/ucla-ca-providence:1.0.6
+image: uclalibrary/ucla-ca-providence:1.0.7
 
 # Deploy to these servers.
 servers:
@@ -42,7 +42,7 @@ ssh:
 
 accessories:
   providence: 
-    image: uclalibrary/ucla-ca-providence:1.0.6
+    image: uclalibrary/ucla-ca-providence:1.0.7
     host: t-u-kamalapp01.library.ucla.edu
     proxy:
       ssl: true

--- a/ucla_customizations/app/conf/local/multipart_id_numbering.conf
+++ b/ucla_customizations/app/conf/local/multipart_id_numbering.conf
@@ -1,0 +1,411 @@
+#
+# ID numbering config (for MultipartIDNumber ID numbering plug-in)
+#
+#
+# ID numbers are the identifying numbers you provide for certain types of data 
+# items in your CollectiveAccess database. They are stored as simple strings and reflect
+# what *you* refer to the item by. They should be unique but don't have to be. They may contain non-numeric characters.
+# They may have a regular format or they may vary widely from item to item. Numbering systems for existing collections almost 
+# always have inconsistencies and irregularities and CollectiveAccess can accomodate them. 
+#
+# Note that ID numbers are *not* the row_id's automatically assigned to data items
+# by CollectiveAccess. row_id's are guaranteed to be unique, are always simple integers 
+# and cannot be changed once assigned. CollectiveAccess uses row_id's internally to unambiguously 
+# refer to data items. You do not have to worry about CollectiveAccess mixing up items with the same ID number
+# because CollectiveAccess never uses ID numbers for its internal operations. 
+#
+# By contrast ID numbers allow CollectiveAccess users to refer to data items using familiar (and perhaps 
+# arbitrary) identifers and to cross-reference CollectiveAccess-hosted data with data from other sources that use the
+# same ID numbering system. They can be in any format, from simply integers to arbitrarily formatted alphanumeric 
+# strings of text.
+#
+# Since ID numbers are stored as strings any input format is considered valid. While this is acceptable for many
+# uses, often it is desirable to enforce standards for data entry and/or provide a more structured data entry interface -
+# perhaps one with drop-down menus for certain values or separate fields for different parts of the number.
+#
+# CollectiveAccess provides a plug-in framework for implementing ID number entry interfaces and validation of input.
+# By developing your own plug-in, you can implement any behaviors you need. For instance, one could develop a plug-in 
+# that uses an external system to generate new object accession numbers. Most implementors will never have to deal with 
+# plug-ins, however. CollectiveAccess ships with a general-purpose "MultipartIDNumber" plugin which should be suitable 
+# for the vast majority of users. This configuration file sets the parameters for the MultipartIDNumber plug-in.
+#
+# The MultiPartIDNumber plug-in models an ID number as a collection of "elements" joined together by a 
+# "separator." Each element has a type and various parameters that determine what is valid for the element and how it 
+# behaves in the user interface. For a complete description of the parameters see http://wiki.collectiveaccess.org/index.php?title=Multipart_ID_Numbers
+#
+# CollectiveAccess supports ID numbers for the following data items:
+#
+# - objects ("ca_objects")
+# - object lots ("ca_object_lots")
+# - entity authority ("ca_entities")
+# - place names authority ("ca_places")
+# - collection authority items ("ca_collections")
+# - items in user-defined authorities (aka "occurrences") ("ca_occurrences")
+#
+# You can specify different numbering systems for different types of a given data item. So, for example, you can
+# have different numbering schemes for "video" objects than "book" objects. When specifying a format for a specific type
+# use the 'idno' value for the type as entered in its ca_list_items entry. This corresponds to the left-hand side identifier
+# for the type in the installation profile you used to configure your system.
+#
+# Each data item also has a default numbering format used for all types for which a format has not been specified. 
+# At a minimum you must define a default format for each type of data item.
+# 
+# Each format is used to generate user interface and validate input for the 'idno' field
+# of the respective data item. For objects, this is the 'idno' field; for lots this is the 
+# 'idno_stub' field; for the various authorities it is the 'idno' field.
+# 
+# Options to require ID numbers for the various data items to be unique and/or valid are set in the application
+# configuration (app.conf) file.
+#
+
+
+formats = {
+	ca_objects = {
+		# default format for objects of unspecified type
+		__default__ = {
+			# desired format: O-000001
+			separator =-,
+			elements = {
+				object_type = {
+					type = CONSTANT,
+					value = OBJ,
+					description = _(Object type),
+				},
+				object_number = {
+					type = SERIAL, 
+					zeropad_to_length = 6,
+					description = _(Object number), 
+				}
+			}
+		}
+		# specific format for object components
+		# moving_component is the idno of both digital and analog components
+		moving_component = {
+			# desired format: O-000001-C-000001
+			separator =-,
+			elements = {
+				parent_idno = {
+					type = PARENT,
+					description = _(Parent ID number),
+				}
+				object_type = {
+					type = CONSTANT,
+					value = C,
+					description = _(Object type),
+
+				},
+				object_number = {
+					type = SERIAL, 
+					zeropad_to_length = 6,
+					description = _(Object number), 
+	
+				}
+			}
+
+		}
+		# specific format for (parent) analog objects
+		# moving_analog is the default idno from the PBCore 2.1 installation profile
+		# format is the same as for moving_digital
+		moving_analog = {
+			# desired format: O-000001
+			separator =-,
+			elements = {
+				object_type = {
+					# set to a constant value of "O"
+					type = CONSTANT,
+					value = O,
+					description = _(Object type),
+				},
+				object_number = {
+					type = SERIAL, 
+					zeropad_to_length = 6,
+					description = _(Object number), 
+				}
+			}
+
+		}
+		# specific format for (parent) digital objects
+		# moving_digital is the default idno from the PBCore 2.1 installation profile
+		# format is the same as for moving_analog
+		moving_digital = {
+			# desired format: O-000001
+			separator =-,
+			elements = {
+				object_type = {
+					type = CONSTANT,
+					value = O,
+					description = _(Object type),
+				},
+				object_number = {
+					type = SERIAL, 
+					zeropad_to_length = 6,
+					description = _(Object number), 
+				}
+			}
+
+		}
+	},
+
+
+
+# ----------------------------------------------------
+#
+#	Below is an example of a default format for objects that will format
+#	id numbers in the format <year>.<code>.<number>; for example: 2009.ORG.10
+# 	where <number> is automatically assigned
+#
+#	ca_objects = {
+#		__default__ = {
+#			separator = .,
+#			
+#			elements = {
+#				accession_number = {
+#					type = YEAR,
+#					width = 6,
+#					editable = 1,
+#					
+#					description = _(Accession year)
+#				},
+#				accession_type = {
+#					type = LIST, 
+#					values = [PER, ORG, GRP], 
+#					default = ORG, 
+#					width = 6, 
+#					description = _(Accession type), 
+#					editable = 1
+#				},
+#				object_number = {
+#					type = SERIAL, 
+#					width = 6, 
+#					description = _(Object number), 
+#					editable = 1
+#				}
+#			}
+#		}
+#	},
+# ----------------------------------------------------
+	ca_object_lots = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				lot_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Lot number)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_entities = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				entity_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_places = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				place_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_occurrences = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				occurrence_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_collections = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				collection_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_storage_locations = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				location_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_object_representations = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				representation_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_list_items = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				list_item_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_loans = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				list_item_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_movements = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				list_item_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_tours = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				list_item_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	}
+# ----------------------------------------------------
+	ca_tour_stops = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				list_item_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_site_pages = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				path = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Path)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_sets = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				path = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Set code)
+				}
+			}
+		}
+	}
+# ----------------------------------------------------
+}

--- a/ucla_providence/app/conf/local/multipart_id_numbering.conf
+++ b/ucla_providence/app/conf/local/multipart_id_numbering.conf
@@ -1,0 +1,411 @@
+#
+# ID numbering config (for MultipartIDNumber ID numbering plug-in)
+#
+#
+# ID numbers are the identifying numbers you provide for certain types of data 
+# items in your CollectiveAccess database. They are stored as simple strings and reflect
+# what *you* refer to the item by. They should be unique but don't have to be. They may contain non-numeric characters.
+# They may have a regular format or they may vary widely from item to item. Numbering systems for existing collections almost 
+# always have inconsistencies and irregularities and CollectiveAccess can accomodate them. 
+#
+# Note that ID numbers are *not* the row_id's automatically assigned to data items
+# by CollectiveAccess. row_id's are guaranteed to be unique, are always simple integers 
+# and cannot be changed once assigned. CollectiveAccess uses row_id's internally to unambiguously 
+# refer to data items. You do not have to worry about CollectiveAccess mixing up items with the same ID number
+# because CollectiveAccess never uses ID numbers for its internal operations. 
+#
+# By contrast ID numbers allow CollectiveAccess users to refer to data items using familiar (and perhaps 
+# arbitrary) identifers and to cross-reference CollectiveAccess-hosted data with data from other sources that use the
+# same ID numbering system. They can be in any format, from simply integers to arbitrarily formatted alphanumeric 
+# strings of text.
+#
+# Since ID numbers are stored as strings any input format is considered valid. While this is acceptable for many
+# uses, often it is desirable to enforce standards for data entry and/or provide a more structured data entry interface -
+# perhaps one with drop-down menus for certain values or separate fields for different parts of the number.
+#
+# CollectiveAccess provides a plug-in framework for implementing ID number entry interfaces and validation of input.
+# By developing your own plug-in, you can implement any behaviors you need. For instance, one could develop a plug-in 
+# that uses an external system to generate new object accession numbers. Most implementors will never have to deal with 
+# plug-ins, however. CollectiveAccess ships with a general-purpose "MultipartIDNumber" plugin which should be suitable 
+# for the vast majority of users. This configuration file sets the parameters for the MultipartIDNumber plug-in.
+#
+# The MultiPartIDNumber plug-in models an ID number as a collection of "elements" joined together by a 
+# "separator." Each element has a type and various parameters that determine what is valid for the element and how it 
+# behaves in the user interface. For a complete description of the parameters see http://wiki.collectiveaccess.org/index.php?title=Multipart_ID_Numbers
+#
+# CollectiveAccess supports ID numbers for the following data items:
+#
+# - objects ("ca_objects")
+# - object lots ("ca_object_lots")
+# - entity authority ("ca_entities")
+# - place names authority ("ca_places")
+# - collection authority items ("ca_collections")
+# - items in user-defined authorities (aka "occurrences") ("ca_occurrences")
+#
+# You can specify different numbering systems for different types of a given data item. So, for example, you can
+# have different numbering schemes for "video" objects than "book" objects. When specifying a format for a specific type
+# use the 'idno' value for the type as entered in its ca_list_items entry. This corresponds to the left-hand side identifier
+# for the type in the installation profile you used to configure your system.
+#
+# Each data item also has a default numbering format used for all types for which a format has not been specified. 
+# At a minimum you must define a default format for each type of data item.
+# 
+# Each format is used to generate user interface and validate input for the 'idno' field
+# of the respective data item. For objects, this is the 'idno' field; for lots this is the 
+# 'idno_stub' field; for the various authorities it is the 'idno' field.
+# 
+# Options to require ID numbers for the various data items to be unique and/or valid are set in the application
+# configuration (app.conf) file.
+#
+
+
+formats = {
+	ca_objects = {
+		# default format for objects of unspecified type
+		__default__ = {
+			# desired format: O-000001
+			separator =-,
+			elements = {
+				object_type = {
+					type = CONSTANT,
+					value = OBJ,
+					description = _(Object type),
+				},
+				object_number = {
+					type = SERIAL, 
+					zeropad_to_length = 6,
+					description = _(Object number), 
+				}
+			}
+		}
+		# specific format for object components
+		# moving_component is the idno of both digital and analog components
+		moving_component = {
+			# desired format: O-000001-C-000001
+			separator =-,
+			elements = {
+				parent_idno = {
+					type = PARENT,
+					description = _(Parent ID number),
+				}
+				object_type = {
+					type = CONSTANT,
+					value = C,
+					description = _(Object type),
+
+				},
+				object_number = {
+					type = SERIAL, 
+					zeropad_to_length = 6,
+					description = _(Object number), 
+	
+				}
+			}
+
+		}
+		# specific format for (parent) analog objects
+		# moving_analog is the default idno from the PBCore 2.1 installation profile
+		# format is the same as for moving_digital
+		moving_analog = {
+			# desired format: O-000001
+			separator =-,
+			elements = {
+				object_type = {
+					# set to a constant value of "O"
+					type = CONSTANT,
+					value = O,
+					description = _(Object type),
+				},
+				object_number = {
+					type = SERIAL, 
+					zeropad_to_length = 6,
+					description = _(Object number), 
+				}
+			}
+
+		}
+		# specific format for (parent) digital objects
+		# moving_digital is the default idno from the PBCore 2.1 installation profile
+		# format is the same as for moving_analog
+		moving_digital = {
+			# desired format: O-000001
+			separator =-,
+			elements = {
+				object_type = {
+					type = CONSTANT,
+					value = O,
+					description = _(Object type),
+				},
+				object_number = {
+					type = SERIAL, 
+					zeropad_to_length = 6,
+					description = _(Object number), 
+				}
+			}
+
+		}
+	},
+
+
+
+# ----------------------------------------------------
+#
+#	Below is an example of a default format for objects that will format
+#	id numbers in the format <year>.<code>.<number>; for example: 2009.ORG.10
+# 	where <number> is automatically assigned
+#
+#	ca_objects = {
+#		__default__ = {
+#			separator = .,
+#			
+#			elements = {
+#				accession_number = {
+#					type = YEAR,
+#					width = 6,
+#					editable = 1,
+#					
+#					description = _(Accession year)
+#				},
+#				accession_type = {
+#					type = LIST, 
+#					values = [PER, ORG, GRP], 
+#					default = ORG, 
+#					width = 6, 
+#					description = _(Accession type), 
+#					editable = 1
+#				},
+#				object_number = {
+#					type = SERIAL, 
+#					width = 6, 
+#					description = _(Object number), 
+#					editable = 1
+#				}
+#			}
+#		}
+#	},
+# ----------------------------------------------------
+	ca_object_lots = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				lot_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Lot number)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_entities = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				entity_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_places = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				place_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_occurrences = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				occurrence_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_collections = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				collection_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_storage_locations = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				location_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_object_representations = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				representation_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_list_items = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				list_item_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_loans = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				list_item_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_movements = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				list_item_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_tours = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				list_item_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	}
+# ----------------------------------------------------
+	ca_tour_stops = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				list_item_number = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Identifier)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_site_pages = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				path = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Path)
+				}
+			}
+		}
+	},
+# ----------------------------------------------------
+	ca_sets = {
+		__default__ = {
+			separator =,
+			
+			elements = {
+				path = {
+					type = FREE,
+					width = 30,
+					editable = 1,
+					
+					description = _(Set code)
+				}
+			}
+		}
+	}
+# ----------------------------------------------------
+}


### PR DESCRIPTION
Implements [SYS-1809](https://uclalibrary.atlassian.net/browse/SYS-1809)
Confluence documentation: https://uclalibrary.atlassian.net/wiki/x/AYBCQg

Sets up automated generation of ID numbers for Objects. Analog Moving Images and Digital Moving Images will have IDs like "O-000001", and components will have IDs like "O-000001-C-000001" (where O-000001 is the full ID number of their parent Object). This format was chosen based on Thelma's comment on the linked Confluence page.

To test, pull the changed `multipart_id_numbering.conf` files and create or edit an Object. New Objects will have sequentially created IDs. Editing and saving existing Objects will cause their IDs to be overwritten to match the specified format.

[SYS-1809]: https://uclalibrary.atlassian.net/browse/SYS-1809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ