### PR TITLE
BUG: Fix typo in acquisitions_date search definition

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -2,7 +2,7 @@
 service: ucla-ca-providence
 
 # Name of the container image.
-image: uclalibrary/ucla-ca-providence:1.0.7
+image: uclalibrary/ucla-ca-providence:1.0.8
 
 # Deploy to these servers.
 servers:
@@ -42,7 +42,7 @@ ssh:
 
 accessories:
   providence: 
-    image: uclalibrary/ucla-ca-providence:1.0.7
+    image: uclalibrary/ucla-ca-providence:1.0.8
     host: t-u-kamalapp01.library.ucla.edu
     proxy:
       ssl: true

--- a/ucla_customizations/app/conf/local/search_indexing.conf
+++ b/ucla_customizations/app/conf/local/search_indexing.conf
@@ -397,7 +397,7 @@ ca_objects = {
 			extent_units = { STORE, DONT_TOKENIZE },
 			status = { STORE, DONT_TOKENIZE },
 			access = { STORE, DONT_TOKENIZE },
-			acquistion_date = { STORE, DONT_TOKENIZE },
+			acquisition_date = { STORE, DONT_TOKENIZE },
 		}
 	},
 	# ------------------------------------

--- a/ucla_providence/app/conf/local/search_indexing.conf
+++ b/ucla_providence/app/conf/local/search_indexing.conf
@@ -397,7 +397,7 @@ ca_objects = {
 			extent_units = { STORE, DONT_TOKENIZE },
 			status = { STORE, DONT_TOKENIZE },
 			access = { STORE, DONT_TOKENIZE },
-			acquistion_date = { STORE, DONT_TOKENIZE },
+			acquisition_date = { STORE, DONT_TOKENIZE },
 		}
 	},
 	# ------------------------------------


### PR DESCRIPTION
This fixed a bug which caused a crash when rebuilding the search index.  The field for acquisitions date was misspelled on one place; this just corrects that typo.

After making this change and restarting my application (probably optional), I was able to rebuild indexes successfully both via the UI and command line:
`docker compose exec providence bash -c "php support/bin/caUtils rebuild-search-index"`
