### PR TITLE
SYS-1814: Home location and history tracking config

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -2,7 +2,7 @@
 service: ucla-ca-providence
 
 # Name of the container image.
-image: uclalibrary/ucla-ca-providence:1.0.8
+image: uclalibrary/ucla-ca-providence:1.0.9
 
 # Deploy to these servers.
 servers:
@@ -42,7 +42,7 @@ ssh:
 
 accessories:
   providence: 
-    image: uclalibrary/ucla-ca-providence:1.0.8
+    image: uclalibrary/ucla-ca-providence:1.0.9
     host: t-u-kamalapp01.library.ucla.edu
     proxy:
       ssl: true

--- a/ucla_customizations/app/conf/local/app.conf
+++ b/ucla_customizations/app/conf/local/app.conf
@@ -3463,3 +3463,32 @@ history_tracking_policies = {
 		}
 	}
  }
+
+# Home location display on Objects
+# Displayed in "inspector" (top of left sidebar) of Object editor
+inspector_home_location_display_template = "<unit relativeTo='ca_storage_locations.hierarchy' delimiter=' ➜ '>^ca_storage_locations.preferred_labels.name</unit>"
+home_location_display_template = <l><inspector_home_location_display_template></l>
+
+# Add "current location" to Object inspector
+inspector_tracking_displays = {
+	ca_objects = {
+		__default__ = {
+			policy = current_location,
+			label = _(Current location)
+		}
+	}
+}
+
+# Object/Storage Location Relationship Type to use to associate storage locations with objects for history tracking
+# Used for both movement- and workflow-based history tracking
+object_storage_location_tracking_relationship_type = related
+
+
+# Movement-specific settings
+# Code of Movement metadata element to use as "effective date" for movement tracking
+movement_storage_location_date_element = removal_date
+# Code of Movement/Storage Location Relationship Type to use to associate storage locations with movements
+movement_storage_location_tracking_relationship_type = related
+# Code of Movement/Object Relationship Type to use to associate objects with movements
+movement_object_tracking_relationship_type = part
+

--- a/ucla_providence/app/conf/local/app.conf
+++ b/ucla_providence/app/conf/local/app.conf
@@ -3463,3 +3463,32 @@ history_tracking_policies = {
 		}
 	}
  }
+
+# Home location display on Objects
+# Displayed in "inspector" (top of left sidebar) of Object editor
+inspector_home_location_display_template = "<unit relativeTo='ca_storage_locations.hierarchy' delimiter=' ➜ '>^ca_storage_locations.preferred_labels.name</unit>"
+home_location_display_template = <l><inspector_home_location_display_template></l>
+
+# Add "current location" to Object inspector
+inspector_tracking_displays = {
+	ca_objects = {
+		__default__ = {
+			policy = current_location,
+			label = _(Current location)
+		}
+	}
+}
+
+# Object/Storage Location Relationship Type to use to associate storage locations with objects for history tracking
+# Used for both movement- and workflow-based history tracking
+object_storage_location_tracking_relationship_type = related
+
+
+# Movement-specific settings
+# Code of Movement metadata element to use as "effective date" for movement tracking
+movement_storage_location_date_element = removal_date
+# Code of Movement/Storage Location Relationship Type to use to associate storage locations with movements
+movement_storage_location_tracking_relationship_type = related
+# Code of Movement/Object Relationship Type to use to associate objects with movements
+movement_object_tracking_relationship_type = part
+


### PR DESCRIPTION
Implements [SYS-1814](https://uclalibrary.atlassian.net/browse/SYS-1814)

Adds several new values to `app.conf` to support history tracking and use of Home locations for Objects. Also includes tag bumps in `deploy.yml`.

Testing:
* Home locations: create or edit an Object. Click the house icon near the top of the left sidebar. Set a home location and save. The path to the location should now be visible in the sidebar.
* Location tracking: edit an Object. Use one of the features of the "History tracking – chronology" bundle to update the object (Add to loan, Add to movement, Update location, or Return to home location). Save the object. Observe the new "Current location" value in the sidebar.

[SYS-1814]: https://uclalibrary.atlassian.net/browse/SYS-1814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ