### PR TITLE
SYS-1816: Add utilities for images and pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ ucla_providence/app/log
 # Ignore secrets, except for kamal "secrets" which really aren't
 *secret*
 !.kamal/secrets
+
+# Ignore database dumps
+*.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ RUN docker-php-ext-install bcmath gd gmp intl mysqli opcache zip && \
     docker-php-ext-enable bcmath gd gmp intl mysqli opcache zip
 # TODO: configure / enable opcache, see https://laravel-news.com/php-opcache-docker
 
+# Install imagemagick, poppler-utils, and ghostscript, all of which apparently are needed for PDF
+# support.  # poppler-utils provides pdf info but not viewing.
+RUN apt-get install --no-install-recommends -y graphicsmagick ghostscript poppler-utils
+
 # The application will be placed here, apache's default directory in this base image.
 WORKDIR /var/www/html
 

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -2,7 +2,7 @@
 service: ucla-ca-providence
 
 # Name of the container image.
-image: uclalibrary/ucla-ca-providence:1.0.9
+image: uclalibrary/ucla-ca-providence:1.0.10
 
 # Deploy to these servers.
 servers:
@@ -42,7 +42,7 @@ ssh:
 
 accessories:
   providence: 
-    image: uclalibrary/ucla-ca-providence:1.0.9
+    image: uclalibrary/ucla-ca-providence:1.0.10
     host: t-u-kamalapp01.library.ucla.edu
     proxy:
       ssl: true


### PR DESCRIPTION
Implements [SYS-1816](https://uclalibrary.atlassian.net/browse/SYS-1816).  Tagged as 1.0.10 for deployment.

This PR adds imagemagick, ghostscript, and poppler-utils to our application docker image for Providence.  This should enable PDF processing and display... but it doesn't, or at least I could not get it work correctly in my local environment.

Since it doesn't hurt to have these available in the pilot environment, I'm merging and deploying.  Maybe something will work right there, or at least support local experimentation with config files.

@ztucker4 and @henry-r18 FYI.


[SYS-1816]: https://uclalibrary.atlassian.net/browse/SYS-1816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ