### PR TITLE
Add FTVA profile with metadata config

### DIFF
--- a/README_UCLA.md
+++ b/README_UCLA.md
@@ -38,7 +38,7 @@ Useful for restarting Apache
 1. Build and start the system as above.
 2. Visit the [installation page](127.0.0.1:8090/install).
 3. Enter your email address for the local administrator account.
-4. Choose an installation profile (probably `[Standard] PBCore v1.2 REVISED 2013`)
+4. Choose an installation profile (probably `UCLA FTVA`)
 5. Click "Begin installation".
 
 Installation takes a couple of minutes, as the database is built.  When done, a randomly-created administrator password
@@ -57,6 +57,28 @@ To try a different profile, the old database must be wiped out. Be sure you real
 2. Delete the docker database volume: `docker volume rm ucla-ca-providence_db`
 3. Start up the system.
 4. Run the installation process as described above, starting at step 2.
+
+### Exporting and importing configuration via profiles
+
+CA provides utilities for exporting and importing configuration defined in installation profiles, available in `support/bin/caUtils`.
+
+#### Exporting configuration
+
+To export configuration, run: `support/bin/caUtils export-profile -t TIMESTAMP -o ./install/profiles/xml/custom_export.xml`
+
+Parameters used:
+
+* -t: optional timestamp parameter. You can get the current timestamp with `date +%s` (if running a local dockerized development setup, `docker compose exec providence date +%s`).
+
+* -o: output file destination. The provided example will save the output file in the folder where it will be expected by the configuration import. The file name can be changed as desired.
+
+#### Importing configuration
+
+To import configuration, run: `support/bin/caUtils update-installation-profile -n custom_export.xml`
+
+Parameters used:
+
+* -n: the filename of the configuration profile, which should be in the folder `install/profiles/xml/`.
 
 ## Login and logout
 

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -2,7 +2,7 @@
 service: ucla-ca-providence
 
 # Name of the container image.
-image: uclalibrary/ucla-ca-providence:1.0.6
+image: uclalibrary/ucla-ca-providence:1.0.11
 
 # Deploy to these servers.
 servers:
@@ -42,7 +42,7 @@ ssh:
 
 accessories:
   providence: 
-    image: uclalibrary/ucla-ca-providence:1.0.6
+    image: uclalibrary/ucla-ca-providence:1.0.11
     host: t-u-kamalapp01.library.ucla.edu
     proxy:
       ssl: true

--- a/ucla_customizations/install/profiles/xml/ucla_ftva.xml
+++ b/ucla_customizations/install/profiles/xml/ucla_ftva.xml
@@ -1,0 +1,18811 @@
+<?xml version="1.0" encoding="utf-8"?>
+<profile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="profile.xsd" useForConfiguration="1" infoUrl="">
+  <profileName>UCLA FTVA</profileName>
+  <profileDescription>CollectiveAccess Providence installation profile for UCLA Film and Television Archive. Based on PBCore 2.1.</profileDescription>
+  <locales>
+    <locale lang="en" country="US">English</locale>
+    <locale lang="en" country="CA" dontUseForCataloguing="1">English (Canadian)</locale>
+    <locale lang="en" country="AU" dontUseForCataloguing="1">English (Australian)</locale>
+    <locale lang="en" country="UK" dontUseForCataloguing="1">English (UK)</locale>
+    <locale lang="de" country="DE" dontUseForCataloguing="1">Deutsch (Deutschland)</locale>
+    <locale lang="de" country="AT" dontUseForCataloguing="1">Deutsch (Österreich)</locale>
+    <locale lang="fr" country="FR" dontUseForCataloguing="1">Français</locale>
+    <locale lang="fr" country="CA" dontUseForCataloguing="1">Français (Canadien)</locale>
+    <locale lang="cs" country="CZ" dontUseForCataloguing="1">Czech</locale>
+    <locale lang="es" country="ES" dontUseForCataloguing="1">Español</locale>
+    <locale lang="it" country="IT" dontUseForCataloguing="1">Italiano</locale>
+    <locale lang="nl" country="NL" dontUseForCataloguing="1">Nederlands</locale>
+    <locale lang="sv" country="SE" dontUseForCataloguing="1">Svenska</locale>
+  </locales>
+  <lists>
+    <list code="list_item_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>List item types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="concept" enabled="1" default="1" access="0" value="concept" rank="2">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>concept</name_singular>
+              <name_plural>concepts</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="facet" enabled="1" default="0" access="0" value="facet" rank="3">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>facet</name_singular>
+              <name_plural>facets</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="guide_term" enabled="1" default="0" access="0" value="guide_term" rank="4">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>guide term</name_singular>
+              <name_plural>guide terms</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="hierarchy_name" enabled="1" default="0" access="0" value="hierarchy_name"
+          rank="5">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>hierarchy name</name_singular>
+              <name_plural>hierarchy names</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="list_item_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>List item sources</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="local" enabled="1" default="0" access="0" value="local" rank="7">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Local</name_singular>
+              <name_plural>Local</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="list_item_label_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>List item label types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="uf" enabled="1" default="1" access="0" value="uf" rank="9">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Use for</name_singular>
+              <name_plural>Use for</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="alt" enabled="1" default="0" access="0" value="alt" rank="10">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Alternate</name_singular>
+              <name_plural>Alternate</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="set_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Set types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="user" enabled="1" default="0" access="0" value="user" rank="12">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>User set</name_singular>
+              <name_plural>User sets</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="public_presentation" enabled="1" default="1" access="0"
+          value="public_presentation" rank="13">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Public presentation</name_singular>
+              <name_plural>Public presentations</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="set_presentation_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Set presentation types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="slideshow" enabled="1" default="1" access="0" value="slideshow" rank="15">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Slideshow</name_singular>
+              <name_plural>Slideshows</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="thumbnail_image_list" enabled="1" default="0" access="0"
+          value="thumbnail_image_list" rank="16">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Thumbnail image list</name_singular>
+              <name_plural>Thumbnail image lists</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="title_list" enabled="1" default="0" access="0" value="title_list" rank="17">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Title list</name_singular>
+              <name_plural>Title lists</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="chronology" enabled="1" default="0" access="0" value="chronology" rank="18">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Chronology</name_singular>
+              <name_plural>Chronologies</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="set_item_is_primary" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Set item primary status types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="is_primary" enabled="1" default="0" access="0" value="is_primary" rank="20">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Is primary</name_singular>
+              <name_plural>Is primary</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="is_not_primary" enabled="1" default="1" access="0" value="is_not_primary"
+          rank="21">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Is not primary</name_singular>
+              <name_plural>Is not primary</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_types" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Object Types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="audio" enabled="0" default="0" access="0" value="audio" rank="23">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio</name_singular>
+              <name_plural>Audio</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="audio_analog" enabled="1" default="0" access="0" value="audio_analog"
+              rank="24">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Analog Audio</name_singular>
+                  <name_plural>Analog Audio</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="audio_digital" enabled="1" default="0" access="0" value="audio_digital"
+              rank="25">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Digital Audio</name_singular>
+                  <name_plural>Digital Audio</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="moving_image" enabled="0" default="0" access="0" value="moving_image" rank="26">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Moving Image</name_singular>
+              <name_plural>Moving Images</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="moving_analog" enabled="1" default="0" access="0" value="moving_analog"
+              rank="27">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Analog Moving Image</name_singular>
+                  <name_plural>Analog Moving Images</name_plural>
+                  <description />
+                </label>
+              </labels>
+              <items>
+                <item idno="moving_component" enabled="1" default="0" access="0" rank="448"
+                  type="concept">
+                  <labels>
+                    <label locale="en_US" preferred="1">
+                      <name_singular>AMI component</name_singular>
+                      <name_plural>AMI components</name_plural>
+                      <description>Analog Moving Image component</description>
+                    </label>
+                  </labels>
+                </item>
+              </items>
+            </item>
+            <item idno="moving_digital" enabled="1" default="0" access="0" value="moving_digital"
+              rank="28">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Digital Moving Image</name_singular>
+                  <name_plural>Digital Moving Images</name_plural>
+                  <description />
+                </label>
+              </labels>
+              <settings>
+                <setting name="show_source_for_preferred_labels">0</setting>
+                <setting name="show_source_for_nonpreferred_labels">0</setting>
+                <setting name="render_in_new_menu">1</setting>
+              </settings>
+              <items>
+                <item idno="moving_component_2" enabled="1" default="0" access="0" rank="449"
+                  type="concept">
+                  <labels>
+                    <label locale="en_US" preferred="1">
+                      <name_singular>DMI component</name_singular>
+                      <name_plural>DMI components</name_plural>
+                      <description>Digital Moving Image component</description>
+                    </label>
+                  </labels>
+                </item>
+              </items>
+            </item>
+          </items>
+        </item>
+      </items>
+    </list>
+    <list code="object_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object Source</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="internal" enabled="1" default="1" access="0" value="internal" rank="30">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Our collection</name_singular>
+              <name_plural>Our collections</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="external" enabled="1" default="0" access="0" value="external" rank="31">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>External collection</name_singular>
+              <name_plural>External collections</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_statuses" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object statuses</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="pending_accession" enabled="1" default="1" access="0" value="pending_accession"
+          rank="33">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>pending accession</name_singular>
+              <name_plural>pending accession</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="accessioned" enabled="1" default="0" access="0" value="accessioned" rank="34">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>accessioned</name_singular>
+              <name_plural>accessioned</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="non_accessioned" enabled="1" default="0" access="0" value="non_accessioned"
+          rank="35">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>non-accessioned</name_singular>
+              <name_plural>non-accessioned</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="potential_acquisition" enabled="1" default="0" access="0"
+          value="potential_acquisition" rank="36">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>potential acquisition</name_singular>
+              <name_plural>potential acquisitions</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_deaccession_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object deaccession types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="disposed" enabled="1" default="1" access="0" value="disposed" rank="38">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>disposed</name_singular>
+              <name_plural>disposed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_acq_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object acquisition types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="gift" enabled="1" default="1" access="0" value="gift" rank="40">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>gift</name_singular>
+              <name_plural>gifts</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="bequest" enabled="1" default="0" access="0" value="bequest" rank="41">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>bequest</name_singular>
+              <name_plural>bequests</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="purchase" enabled="1" default="0" access="0" value="purchase" rank="42">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>purchase</name_singular>
+              <name_plural>purchases</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="loan" enabled="1" default="0" access="0" value="loan" rank="43">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>loan</name_singular>
+              <name_plural>loans</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="long_term_loan" enabled="1" default="0" access="0" value="long_term_loan"
+          rank="44">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>long-term loan</name_singular>
+              <name_plural>long-term loans</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_label_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object label types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="uf" enabled="1" default="0" access="0" value="uf" rank="46">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>use for</name_singular>
+              <name_plural>use for</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="alt" enabled="1" default="1" access="0" value="alt" rank="47">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>alternate</name_singular>
+              <name_plural>alternates</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="workflow_statuses" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object workflow statuses</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="new" enabled="1" default="1" access="0" value="0" rank="49">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>new</name_singular>
+              <name_plural>new</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="editing_in_progress" enabled="1" default="0" access="0" value="1" rank="50">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>editing in progress</name_singular>
+              <name_plural>editing in progress</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="editing_complete" enabled="1" default="0" access="0" value="2" rank="51">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>editing complete</name_singular>
+              <name_plural>editing complete</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="review_in_progress" enabled="1" default="0" access="0" value="3" rank="52">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>review in progress</name_singular>
+              <name_plural>review in progress</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="completed" enabled="1" default="0" access="0" value="4" rank="53">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>completed</name_singular>
+              <name_plural>completed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="access_statuses" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object access statuses</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="internal_only" enabled="1" default="1" access="0" value="0" rank="55">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>not accessible to public</name_singular>
+              <name_plural>not accessible to public</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="restricted_public_access" enabled="1" default="0" access="0" value="2" rank="56">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>restricted public access</name_singular>
+              <name_plural>restricted public access</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="public_access" enabled="1" default="0" access="0" value="1" rank="57">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>accessible to public</name_singular>
+              <name_plural>accessible to public</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="not_available_for_projection" enabled="1" default="0" access="0"
+          value="not_available_for_projection" rank="454" type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>not available for projection</name_singular>
+              <name_plural>not available for projection</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="projection_only" enabled="1" default="0" access="0" value="projection_only"
+          rank="455" type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>projection only</name_singular>
+              <name_plural>projection only</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="viewing_only" enabled="1" default="0" access="0" value="viewing_only" rank="456"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>viewing only</name_singular>
+              <name_plural>viewing only</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_circulation_statuses" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object circulation statuses</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="available" enabled="1" default="1" access="0" value="available" rank="59">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Available</name_singular>
+              <name_plural>Available</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="in_library" enabled="1" default="0" access="0" value="in_library" rank="60">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>In-library use only</name_singular>
+              <name_plural>In-library use only</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="unavailable" enabled="1" default="0" access="0" value="unavailable" rank="61">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Unavailable</name_singular>
+              <name_plural>Unavailable</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_lot_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object lot types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="gift" enabled="1" default="1" access="0" value="gift" rank="63">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>gift</name_singular>
+              <name_plural>gifts</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="restricted_gift" enabled="1" default="0" access="0" value="restricted_gift"
+          rank="64">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>restricted gift</name_singular>
+              <name_plural>restricted gift</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="bequest" enabled="1" default="0" access="0" value="bequest" rank="65">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>bequest</name_singular>
+              <name_plural>bequests</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="purchase" enabled="1" default="0" access="0" value="purchase" rank="66">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>purchase</name_singular>
+              <name_plural>purchases</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="loan" enabled="1" default="0" access="0" value="loan" rank="67">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>loan</name_singular>
+              <name_plural>loans</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="long_term_loan" enabled="1" default="0" access="0" value="long_term_loan"
+          rank="68">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>long-term loan</name_singular>
+              <name_plural>long-term loans</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_lot_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object lot sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="object_lot_statuses" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object lot statuses</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="pending_accession" enabled="1" default="1" access="0" value="pending_accession"
+          rank="71">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>pending accession</name_singular>
+              <name_plural>pending accession</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="accessioned" enabled="1" default="0" access="0" value="accessioned" rank="72">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>accessioned</name_singular>
+              <name_plural>accessioned</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="non_accessioned" enabled="1" default="0" access="0" value="non_accessioned"
+          rank="73">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>non-accessioned</name_singular>
+              <name_plural>non-accessioned</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="potential_acquisition" enabled="1" default="0" access="0"
+          value="potential_acquisition" rank="74">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>potential acquisition</name_singular>
+              <name_plural>potential acquisitions</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_lot_label_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object lot label type values</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="uf" enabled="1" default="0" access="0" value="uf" rank="76">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>use for</name_singular>
+              <name_plural>use for</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="alt" enabled="1" default="1" access="0" value="alt" rank="77">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>alternate</name_singular>
+              <name_plural>alternates</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="loan_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Loan types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="in" enabled="1" default="0" access="0" value="in" rank="79">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>loan in</name_singular>
+              <name_plural>loans in</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="out" enabled="1" default="1" access="0" value="out" rank="80">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>loan out</name_singular>
+              <name_plural>loans out</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="loan_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Loan sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="movement_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Movement type values</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="movement" enabled="1" default="1" access="0" value="movement" rank="83">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Movement</name_singular>
+              <name_plural>Movements</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="movement_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Movement sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="entity_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Entity types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="individual" enabled="1" default="1" access="0" value="individual" rank="86">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>individual</name_singular>
+              <name_plural>individuals</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="organization" enabled="1" default="0" access="0" value="organization" rank="87">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>organization</name_singular>
+              <name_plural>organizations</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="family" enabled="1" default="0" access="0" value="family" rank="88">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>family</name_singular>
+              <name_plural>families</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="entity_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Entity sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="entity_label_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Entity label types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="uf" enabled="1" default="0" access="0" value="uf" rank="91">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>use for</name_singular>
+              <name_plural>use for</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="alt" enabled="1" default="1" access="0" value="alt" rank="92">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>alternate</name_singular>
+              <name_plural>alternates</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="place_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Place types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="continent" enabled="1" default="0" access="0" value="continent" rank="94">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>continent</name_singular>
+              <name_plural>continents</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="country" enabled="1" default="1" access="0" value="country" rank="95">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>country</name_singular>
+              <name_plural>countries</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="state" enabled="1" default="0" access="0" value="state" rank="96">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>state/province</name_singular>
+              <name_plural>state/province</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="city" enabled="1" default="0" access="0" value="city" rank="97">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>city</name_singular>
+              <name_plural>cities</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="county" enabled="1" default="0" access="0" value="county" rank="98">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>county</name_singular>
+              <name_plural>counties</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="neighborhood" enabled="1" default="0" access="0" value="neighborhood" rank="99">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>neighborhood</name_singular>
+              <name_plural>neighborhoods</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="location" enabled="1" default="0" access="0" value="location" rank="100">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>location</name_singular>
+              <name_plural>locations</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="river" enabled="1" default="0" access="0" value="river" rank="101">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>river</name_singular>
+              <name_plural>rivers</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="socken" enabled="1" default="0" access="0" value="socken" rank="102">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>parish</name_singular>
+              <name_plural>parishes</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="other" enabled="1" default="0" access="0" value="other" rank="103">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>other feature</name_singular>
+              <name_plural>other features</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="place_label_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Place label type values</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="uf" enabled="1" default="0" access="0" value="uf" rank="105">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>use for</name_singular>
+              <name_plural>use for</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="alt" enabled="1" default="1" access="0" value="alt" rank="106">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>alternate</name_singular>
+              <name_plural>alternates</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="place_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Place sources</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="pbcore" enabled="1" default="1" access="0" value="pbcore" rank="108">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Coverage</name_singular>
+              <name_plural>Coverage</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="occurrence_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Occurrence Types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="intellectual_content" enabled="1" default="1" access="0"
+          value="intellectual_content" rank="110">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Intellectual Content</name_singular>
+              <name_plural>Intellectual Content</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="occurrence_label_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Occurrence label types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="uf" enabled="1" default="0" access="0" value="uf" rank="112">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>use for</name_singular>
+              <name_plural>use for</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="alt" enabled="1" default="1" access="0" value="alt" rank="113">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>alternate</name_singular>
+              <name_plural>alternates</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="occurrence_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Occurrence sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="collection_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Collection types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="local" enabled="1" default="1" access="0" value="local" rank="116">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Local collection</name_singular>
+              <name_plural>Local collections</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="external" enabled="1" default="0" access="0" value="external" rank="117">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>External collection</name_singular>
+              <name_plural>External collections</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="collection_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Collection sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="collection_label_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Collection label types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="uf" enabled="1" default="0" access="0" value="uf" rank="120">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>use for</name_singular>
+              <name_plural>use for</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="alt" enabled="1" default="1" access="0" value="alt" rank="121">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>alternate</name_singular>
+              <name_plural>alternates</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="storage_location_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Storage location types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="campus" enabled="1" default="1" access="0" value="campus" rank="123">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>campus</name_singular>
+              <name_plural>campuses</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="building" enabled="1" default="0" access="0" value="building" rank="124">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>building</name_singular>
+              <name_plural>buildings</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="floor" enabled="1" default="0" access="0" value="floor" rank="125">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>floor</name_singular>
+              <name_plural>floors</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="room" enabled="1" default="0" access="0" value="room" rank="126">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>room</name_singular>
+              <name_plural>rooms</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="cabinet" enabled="1" default="0" access="0" value="cabinet" rank="127">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>cabinet</name_singular>
+              <name_plural>cabinets</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="drawer" enabled="1" default="0" access="0" value="drawer" rank="128">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>drawer</name_singular>
+              <name_plural>drawers</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="shelf" enabled="1" default="0" access="0" value="shelf" rank="129">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>shelf</name_singular>
+              <name_plural>shelves</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="vault" enabled="1" default="0" access="0" rank="463" type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>vault</name_singular>
+              <name_plural>vaults</name_plural>
+              <description />
+            </label>
+          </labels>
+          <settings>
+            <setting name="show_source_for_preferred_labels">0</setting>
+            <setting name="show_source_for_nonpreferred_labels">0</setting>
+            <setting name="render_in_new_menu">1</setting>
+          </settings>
+        </item>
+        <item idno="column" enabled="1" default="0" access="0" rank="464" type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>column</name_singular>
+              <name_plural>columns</name_plural>
+              <description />
+            </label>
+          </labels>
+          <settings>
+            <setting name="show_source_for_preferred_labels">0</setting>
+            <setting name="show_source_for_nonpreferred_labels">0</setting>
+            <setting name="render_in_new_menu">1</setting>
+          </settings>
+        </item>
+      </items>
+    </list>
+    <list code="storage_location_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Storage location sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="storage_location_label_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Storage location label type values</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="uf" enabled="1" default="0" access="0" value="uf" rank="132">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>use for</name_singular>
+              <name_plural>use for</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="alt" enabled="1" default="1" access="0" value="alt" rank="133">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>alternate</name_singular>
+              <name_plural>alternates</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_representation_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object representation types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="front" enabled="1" default="1" access="0" value="front" rank="135">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>front</name_singular>
+              <name_plural>front</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="back" enabled="1" default="0" access="0" value="back" rank="136">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>back</name_singular>
+              <name_plural>back</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_representation_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object representation sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="tour_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Tour types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="full_length" enabled="1" default="0" access="0" value="full_length" rank="139">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>full tour</name_singular>
+              <name_plural>full tours</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="short" enabled="1" default="0" access="0" value="short" rank="140">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>short tour</name_singular>
+              <name_plural>short tours</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="tour_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Tour sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="tour_stop_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Tour stop types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="primary" enabled="1" default="0" access="0" value="primary" rank="143">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>primary stop</name_singular>
+              <name_plural>primary stops</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="secondary" enabled="1" default="0" access="0" value="secondary" rank="144">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>optional stop</name_singular>
+              <name_plural>optional stops</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="subjects_list" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Subject list</name>
+        </label>
+      </labels>
+    </list>
+    <list code="place_hierarchies" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Place hierarchies</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="pbcore" enabled="1" default="1" access="0" value="pbcore" rank="147">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>PBCore Coverage Authority</name_singular>
+              <name_plural>PBCore Coverage Authority</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="pbcore_title_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Title Types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1" access="0" value="option0" rank="149">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="150">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Album</name_singular>
+              <name_plural>Albums</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="151">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Collection</name_singular>
+              <name_plural>Collection</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="152">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Series</name_singular>
+              <name_plural>Series</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="153">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Episode</name_singular>
+              <name_plural>Episode</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="154">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Program</name_singular>
+              <name_plural>Program</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="155">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Segment</name_singular>
+              <name_plural>Segment</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option7" enabled="1" default="0" access="0" value="option7" rank="156">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Clip</name_singular>
+              <name_plural>Clip</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option8" enabled="1" default="0" access="0" value="option8" rank="157">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Miniseries</name_singular>
+              <name_plural>Miniseries</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option9" enabled="1" default="0" access="0" value="option9" rank="158">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Subseries</name_singular>
+              <name_plural>Subseries</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="pbcore_coverage_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Coverage Type</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="spatial" enabled="1" default="0" access="0" value="spatial" rank="160">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Spatial</name_singular>
+              <name_plural>Spatial</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="temporal" enabled="1" default="1" access="0" value="temporal" rank="161">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Temporal</name_singular>
+              <name_plural>Temporal</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="pbcore_description_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Description Type</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="none" enabled="1" default="1" access="0" value="none" rank="163">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="abstract" enabled="1" default="0" access="0" value="abstract" rank="164">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Abstract</name_singular>
+              <name_plural>Abstract</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="awards" enabled="1" default="0" access="0" value="awards" rank="165">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Awards</name_singular>
+              <name_plural>Awards</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="chapter" enabled="1" default="0" access="0" value="chapter" rank="166">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Chapter</name_singular>
+              <name_plural>Chapter</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="collection" enabled="1" default="0" access="0" value="collection" rank="167">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Collection</name_singular>
+              <name_plural>Collection</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="comments" enabled="1" default="0" access="0" value="comments" rank="168">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Comments</name_singular>
+              <name_plural>Comments</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="description" enabled="1" default="0" access="0" value="description" rank="169">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Description</name_singular>
+              <name_plural>Description</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="episode" enabled="1" default="0" access="0" value="episode" rank="170">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Episode Description</name_singular>
+              <name_plural>Episode Description</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="event" enabled="1" default="0" access="0" value="event" rank="171">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Event</name_singular>
+              <name_plural>Event</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="excerpt" enabled="1" default="0" access="0" value="excerpt" rank="172">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Excerpt</name_singular>
+              <name_plural>Excerpt</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="item" enabled="1" default="0" access="0" value="item" rank="173">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Item</name_singular>
+              <name_plural>Item</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="movement" enabled="1" default="0" access="0" value="movement" rank="174">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Movement</name_singular>
+              <name_plural>Movement</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="number" enabled="1" default="0" access="0" value="number" rank="175">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Number</name_singular>
+              <name_plural>Number</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="playlist" enabled="1" default="0" access="0" value="playlist" rank="176">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Playlist</name_singular>
+              <name_plural>Playlist</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="program" enabled="1" default="0" access="0" value="program" rank="177">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Program</name_singular>
+              <name_plural>Program</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="reviews" enabled="1" default="0" access="0" value="reviews" rank="178">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Reviews</name_singular>
+              <name_plural>Reviews</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="rundown" enabled="1" default="0" access="0" value="rundown" rank="179">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Rundown</name_singular>
+              <name_plural>Rundown</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="script" enabled="1" default="0" access="0" value="script" rank="180">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Script</name_singular>
+              <name_plural>Script</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="segment" enabled="1" default="0" access="0" value="segment" rank="181">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Segment</name_singular>
+              <name_plural>Segment</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="series" enabled="1" default="0" access="0" value="series" rank="182">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Series</name_singular>
+              <name_plural>Series</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="shotlist" enabled="1" default="0" access="0" value="shotlist" rank="183">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Shot List</name_singular>
+              <name_plural>Shot List</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="song" enabled="1" default="0" access="0" value="song" rank="184">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Song</name_singular>
+              <name_plural>Song</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="story" enabled="1" default="0" access="0" value="story" rank="185">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Story</name_singular>
+              <name_plural>Story</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="summary" enabled="1" default="0" access="0" value="summary" rank="186">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Summary</name_singular>
+              <name_plural>Summary</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="transcript" enabled="1" default="0" access="0" value="transcript" rank="187">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Transcript</name_singular>
+              <name_plural>Transcript</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="pbcore_relation_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Relation Type</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="189">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="1" access="0" value="option1" rank="190">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Has Format</name_singular>
+              <name_plural>Has Format</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="191">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Is Format Of</name_singular>
+              <name_plural>Is Format Of</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="192">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Has Part</name_singular>
+              <name_plural>Has Part</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="193">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Is Part Of</name_singular>
+              <name_plural>Is Part Of</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="194">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Has Version</name_singular>
+              <name_plural>Has Version</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="195">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Is Version Of</name_singular>
+              <name_plural>Is Version Of</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option7" enabled="1" default="0" access="0" value="option7" rank="196">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>References</name_singular>
+              <name_plural>References</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option8" enabled="1" default="0" access="0" value="option8" rank="197">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Is Referenced By</name_singular>
+              <name_plural>Is Referenced By</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option9" enabled="1" default="0" access="0" value="option9" rank="198">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Has Derivative</name_singular>
+              <name_plural>Derived From</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="instantiation_physical_types_moving" hierarchical="0" system="0" vocabulary="0"
+      defaultSort="1">
+      <labels>
+        <label locale="en_US">
+          <name>Physical Formats For Moving Images</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1" access="0" value="option0" rank="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="film_types" enabled="0" default="0" access="0" value="film_types" rank="2">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>FILM</name_singular>
+              <name_plural>FILM</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="3">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Film</name_singular>
+                  <name_plural>Film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="4">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>8mm film</name_singular>
+                  <name_plural>8mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="5">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>9.5mm film</name_singular>
+                  <name_plural>9.5mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="6">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Super 8mm film</name_singular>
+                  <name_plural>Super 8mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="7">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>16mm film</name_singular>
+                  <name_plural>16mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option7" enabled="1" default="0" access="0" value="option7" rank="8">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Super 16mm film</name_singular>
+                  <name_plural>Super 16mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option8" enabled="1" default="0" access="0" value="option8" rank="9">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>22mm film</name_singular>
+                  <name_plural>22mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option9" enabled="1" default="0" access="0" value="option9" rank="10">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>28mm film</name_singular>
+                  <name_plural>28mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option10" enabled="1" default="0" access="0" value="option10" rank="11">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>35mm film</name_singular>
+                  <name_plural>35mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option11" enabled="1" default="0" access="0" value="option11" rank="12">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>70mm film</name_singular>
+                  <name_plural>70mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="video_types" enabled="0" default="0" access="0" value="video_types" rank="13">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>VIDEO</name_singular>
+              <name_plural>VIDEO</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="videocassette" enabled="1" default="0" access="0" value="videocassette"
+              rank="14">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Videocassette</name_singular>
+                  <name_plural>Videocassette</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="open_reel_videotape" enabled="1" default="0" access="0"
+              value="open_reel_videotape" rank="15">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Open reel videotape</name_singular>
+                  <name_plural>Open reel videotape</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="optical_video_disc" enabled="1" default="0" access="0"
+              value="optical_video_disc" rank="16">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Optical video disc</name_singular>
+                  <name_plural>Optical video disc</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape" enabled="1" default="0" access="0"
+              value="one_inch_videotape" rank="17">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape</name_singular>
+                  <name_plural>1 inch videotape</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_1" enabled="1" default="0" access="0"
+              value="one_inch_videotape_1" rank="18">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: MVC-10</name_singular>
+                  <name_plural>1 inch videotape: MVC-10</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_2" enabled="1" default="0" access="0"
+              value="one_inch_videotape_2" rank="19">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: PI-3V</name_singular>
+                  <name_plural>1 inch videotape: PI-3V</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_3" enabled="1" default="0" access="0"
+              value="one_inch_videotape_3" rank="20">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: EV-200</name_singular>
+                  <name_plural>1 inch videotape: EV-200</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_4" enabled="1" default="0" access="0"
+              value="one_inch_videotape_4" rank="21">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: EL-3400</name_singular>
+                  <name_plural>1 inch videotape: EL-3400</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_5" enabled="1" default="0" access="0"
+              value="one_inch_videotape_5" rank="22">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: IVC-700</name_singular>
+                  <name_plural>1 inch videotape: IVC-700</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_6" enabled="1" default="0" access="0"
+              value="one_inch_videotape_6" rank="23">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: IVC-800</name_singular>
+                  <name_plural>1 inch videotape: IVC-800</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_7" enabled="1" default="0" access="0"
+              value="one_inch_videotape_7" rank="24">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: IVC-900</name_singular>
+                  <name_plural>1 inch videotape: IVC-900</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_8" enabled="1" default="0" access="0"
+              value="one_inch_videotape_8" rank="25">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: UV-340</name_singular>
+                  <name_plural>1 inch videotape: UV-340</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_9" enabled="1" default="0" access="0"
+              value="one_inch_videotape_9" rank="26">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: EV-210</name_singular>
+                  <name_plural>1 inch videotape: EV-210</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_10" enabled="1" default="0" access="0"
+              value="one_inch_videotape_10" rank="27">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: SMPTE Type A</name_singular>
+                  <name_plural>1 inch videotape: SMPTE Type A</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_11" enabled="1" default="0" access="0"
+              value="one_inch_videotape_11" rank="28">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: SMPTE Type B</name_singular>
+                  <name_plural>1 inch videotape: SMPTE Type B</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_12" enabled="1" default="0" access="0"
+              value="one_inch_videotape_12" rank="29">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: SMPTE Type C</name_singular>
+                  <name_plural>1 inch videotape: SMPTE Type C</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_13" enabled="1" default="0" access="0"
+              value="one_inch_videotape_13" rank="30">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: BVH-1000</name_singular>
+                  <name_plural>1 inch videotape: BVH-100</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_14" enabled="1" default="0" access="0"
+              value="one_inch_videotape_14" rank="31">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: HDV-1000</name_singular>
+                  <name_plural>1 inch videotape: HDV-1000</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_15" enabled="1" default="0" access="0"
+              value="one_inch_videotape_15" rank="32">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: HDD-1000</name_singular>
+                  <name_plural>2 inch videotape: HDD-1000</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape" enabled="1" default="0" access="0"
+              value="half_inch_videotape" rank="33">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape</name_singular>
+                  <name_plural>1/2 inch videotape</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_1" enabled="1" default="0" access="0"
+              value="half_inch_videotape_1" rank="34">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: CV</name_singular>
+                  <name_plural>1/2 inch videotape: CV</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_2" enabled="1" default="0" access="0"
+              value="half_inch_videotape_2" rank="35">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: EIAJ Type 1</name_singular>
+                  <name_plural>1/2 inch videotape: EIAJ Type 1</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_3" enabled="1" default="0" access="0"
+              value="half_inch_videotape_3" rank="11">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: Hawkeye</name_singular>
+                  <name_plural>1/2 inch videotape: Hawkeye</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_4" enabled="1" default="0" access="0"
+              value="half_inch_videotape_4" rank="36">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: Recam</name_singular>
+                  <name_plural>1/2 inch videotape: Recam</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_5" enabled="1" default="0" access="0"
+              value="half_inch_videotape_5" rank="37">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: V200</name_singular>
+                  <name_plural>1/2 inch videotape: V200</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_6" enabled="1" default="0" access="0"
+              value="half_inch_videotape_6" rank="38">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: VCR</name_singular>
+                  <name_plural>1/2 inch videotape: VCR</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="quarter_inch_videotape" enabled="1" default="0" access="0"
+              value="quarter_inch_videotape" rank="39">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/4 inch videotape</name_singular>
+                  <name_plural>1/4 inch videotape</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape" enabled="1" default="0" access="0"
+              value="two_inch_videotape" rank="40">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape</name_singular>
+                  <name_plural>2 inch videotape</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_1" enabled="1" default="0" access="0"
+              value="two_inch_videotape_1" rank="41">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: Quadruplex</name_singular>
+                  <name_plural>2 inch videotape: Quadruplex</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_2" enabled="1" default="0" access="0"
+              value="two_inch_videotape_2" rank="42">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: Octaplex</name_singular>
+                  <name_plural>2 inch videotape: Octaplex</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_3" enabled="1" default="0" access="0"
+              value="two_inch_videotape_3" rank="43">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: VR-1500</name_singular>
+                  <name_plural>2 inch videotape: VR-1500</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_4" enabled="1" default="0" access="0"
+              value="two_inch_videotape_4" rank="44">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: VR-1600</name_singular>
+                  <name_plural>2 inch videotape: VR-1600</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_5" enabled="1" default="0" access="0"
+              value="two_inch_videotape_5" rank="45">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: IVC-9000</name_singular>
+                  <name_plural>2 inch videotape: IVC-9000</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_6" enabled="1" default="0" access="0"
+              value="two_inch_videotape_6" rank="46">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: Helical SV-201</name_singular>
+                  <name_plural>2 inch videotape: Helical SV-201</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_7" enabled="1" default="0" access="0"
+              value="two_inch_videotape_7" rank="47">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: ACR 25</name_singular>
+                  <name_plural>2 inch videotape: ACR 25</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="betacam" enabled="1" default="0" access="0" value="betacam" rank="48">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betacam</name_singular>
+                  <name_plural>Betacam</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="betacam_1" enabled="1" default="0" access="0" value="betacam_1" rank="49">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betacam: SP</name_singular>
+                  <name_plural>Betacam: SP</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="betamax" enabled="1" default="0" access="0" value="betamax" rank="50">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betamax</name_singular>
+                  <name_plural>Betamax</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="betamax_1" enabled="1" default="0" access="0" value="betamax_1" rank="51">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betamax: Hi-Fi</name_singular>
+                  <name_plural>Betamax: Hi-Fi</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="betamax_2" enabled="1" default="0" access="0" value="betamax_2" rank="52">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betamax: ED</name_singular>
+                  <name_plural>Betamax: ED</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="betamax_3" enabled="1" default="0" access="0" value="betamax_3" rank="53">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betamax: Super</name_singular>
+                  <name_plural>Betamax: Super</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="blu_ray_disc" enabled="1" default="0" access="0" value="blu_ray_disc"
+              rank="54">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Blu-ray disc</name_singular>
+                  <name_plural>Blu-ray disc</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="catrivision" enabled="1" default="0" access="0" value="catrivision"
+              rank="12">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Catrivision</name_singular>
+                  <name_plural>Catrivision</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="d1" enabled="1" default="0" access="0" value="d1" rank="55">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D1</name_singular>
+                  <name_plural>D1</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="d2" enabled="1" default="0" access="0" value="d2" rank="56">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D2</name_singular>
+                  <name_plural>D2</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="d3" enabled="1" default="0" access="0" value="d3" rank="57">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D3</name_singular>
+                  <name_plural>D3</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="d5" enabled="1" default="0" access="0" value="d5" rank="58">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D5</name_singular>
+                  <name_plural>D5</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="d5_1" enabled="1" default="0" access="0" value="d5_1" rank="59">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D5: HD</name_singular>
+                  <name_plural>D5: HD</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="d6" enabled="1" default="0" access="0" value="d6" rank="60">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D6</name_singular>
+                  <name_plural>D6</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="d9" enabled="1" default="0" access="0" value="d9" rank="61">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D9</name_singular>
+                  <name_plural>D9</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="d9_1" enabled="1" default="0" access="0" value="d9_1" rank="62">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D9: HD</name_singular>
+                  <name_plural>D9: HD</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dct" enabled="1" default="0" access="0" value="dct" rank="63">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DCT</name_singular>
+                  <name_plural>DCT</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="digital_betacam" enabled="1" default="0" access="0" value="digital_betacam"
+              rank="64">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Digital Betacam</name_singular>
+                  <name_plural>Digital Betacam</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="digital8" enabled="1" default="0" access="0" value="digital8" rank="65">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Digital8</name_singular>
+                  <name_plural>Digital8</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dv" enabled="1" default="0" access="0" value="dv" rank="66">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DV</name_singular>
+                  <name_plural>DV</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcam" enabled="1" default="0" access="0" value="dvcam" rank="67">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCAM</name_singular>
+                  <name_plural>DVCAM</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcpro" enabled="1" default="0" access="0" value="dvcpro" rank="68">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCPRO</name_singular>
+                  <name_plural>DVCPRO</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcpro_1" enabled="1" default="0" access="0" value="dvcpro_1" rank="69">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCPRO: 25</name_singular>
+                  <name_plural>DVCPRO: 25</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcpro_2" enabled="1" default="0" access="0" value="dvcpro_2" rank="70">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCPRO: 50</name_singular>
+                  <name_plural>DVCPRO: 50</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcpro_3" enabled="1" default="0" access="0" value="dvcpro_3" rank="71">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCPRO: Progressive</name_singular>
+                  <name_plural>DVCPRO: Progressive</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcpro_4" enabled="1" default="0" access="0" value="dvcpro_4" rank="72">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCPRO: HD</name_singular>
+                  <name_plural>DVCPRO: HD</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd" enabled="1" default="0" access="0" value="dvd" rank="73">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD</name_singular>
+                  <name_plural>DVD</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd_1" enabled="1" default="0" access="0" value="dvd_1" rank="74">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD: DVD+R</name_singular>
+                  <name_plural>DVD: DVD+R</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd_2" enabled="1" default="0" access="0" value="dvd_2" rank="75">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD: DVD+R DL</name_singular>
+                  <name_plural>DVD: DVD+R DL</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd_3" enabled="1" default="0" access="0" value="dvd_3" rank="76">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD: DVD-R</name_singular>
+                  <name_plural>DVD: DVD-R</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd_4" enabled="1" default="0" access="0" value="dvd_4" rank="77">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD: DVD-RW</name_singular>
+                  <name_plural>DVD: DVD-RW</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd_5" enabled="1" default="0" access="0" value="dvd_5" rank="78">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD: DVD+RW</name_singular>
+                  <name_plural>DVD: DVD+RW</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="eiaj" enabled="1" default="0" access="0" value="eiaj" rank="79">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>EIAJ</name_singular>
+                  <name_plural>EIAJ</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="evd" enabled="1" default="0" access="0" value="evd" rank="80">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>EVD</name_singular>
+                  <name_plural>EVD</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="hdcam" enabled="1" default="0" access="0" value="hdcam" rank="81">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>HDCAM</name_singular>
+                  <name_plural>HDCAM</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="hdcam_1" enabled="1" default="0" access="0" value="hdcam_1" rank="82">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>HDCAM: SR</name_singular>
+                  <name_plural>HDCAM: SR</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="hdv" enabled="1" default="0" access="0" value="hdv" rank="83">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>HDV</name_singular>
+                  <name_plural>HDV</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="hi8" enabled="1" default="0" access="0" value="hi8" rank="84">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Hi8</name_singular>
+                  <name_plural>Hi8</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="laserdisc" enabled="1" default="0" access="0" value="laserdisc" rank="85">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>LaserDisc</name_singular>
+                  <name_plural>LaserDisc</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="laserdisc_1" enabled="1" default="0" access="0" value="laserdisc_1"
+              rank="86">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>LaserDisc: CAV</name_singular>
+                  <name_plural>LaserDisc: CAV</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="laserdisc_2" enabled="1" default="0" access="0" value="laserdisc_2"
+              rank="87">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>LaserDisc: CLV</name_singular>
+                  <name_plural>LaserDisc: CLV</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="laserdisc_3" enabled="1" default="0" access="0" value="laserdisc_3"
+              rank="88">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>LaserDisc: CAA</name_singular>
+                  <name_plural>LaserDisc: CAA</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="mii" enabled="1" default="0" access="0" value="mii" rank="89">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>MII</name_singular>
+                  <name_plural>MII</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="minidv" enabled="1" default="0" access="0" value="minidv" rank="90">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>MiniDV</name_singular>
+                  <name_plural>MiniDV</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="super_video_cd" enabled="1" default="0" access="0" value="super_video_cd"
+              rank="91">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Super Video CD</name_singular>
+                  <name_plural>Super Video CD</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="u_matic" enabled="1" default="0" access="0" value="u_matic" rank="92">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>U-matic</name_singular>
+                  <name_plural>U-matic</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="u_matic_1" enabled="1" default="0" access="0" value="u_matic_1" rank="93">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>U-matic: S</name_singular>
+                  <name_plural>U-matic: S</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="u_matic_2" enabled="1" default="0" access="0" value="u_matic_2" rank="94">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>U-matic: SP</name_singular>
+                  <name_plural>U-matic: SP</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="universal_media_disc" enabled="1" default="0" access="0"
+              value="universal_media_disc" rank="95">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Universal Media Disc</name_singular>
+                  <name_plural>Universal Media Disc</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="v_cord" enabled="1" default="0" access="0" value="v_cord" rank="96">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>V-Cord</name_singular>
+                  <name_plural>V-Cord</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="v_cord_1" enabled="1" default="0" access="0" value="v_cord_1" rank="97">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>V-Cord: I</name_singular>
+                  <name_plural>V-Cord: I</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="v_cord_2" enabled="1" default="0" access="0" value="v_cord_2" rank="98">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>V-Cord: II</name_singular>
+                  <name_plural>V-Cord: II</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="vhs" enabled="1" default="0" access="0" value="vhs" rank="99">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>VHS</name_singular>
+                  <name_plural>VHS</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="vhs_1" enabled="1" default="0" access="0" value="vhs_1" rank="100">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>VHS: S-VHS</name_singular>
+                  <name_plural>VHS: S-VHS</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="vhs_2" enabled="1" default="0" access="0" value="vhs_2" rank="101">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>VHS: W-VHS</name_singular>
+                  <name_plural>VHS: W-VHS</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="vhs_3" enabled="1" default="0" access="0" value="vhs_3" rank="102">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>VHS: VHS-C</name_singular>
+                  <name_plural>VHS: VHS-C</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="video8" enabled="1" default="0" access="0" value="video8" rank="103">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Video8</name_singular>
+                  <name_plural>Video8</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="vx" enabled="1" default="0" access="0" value="vx" rank="104">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>VX</name_singular>
+                  <name_plural>VX</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+      </items>
+    </list>
+    <list code="instantiation_physical_types_audio" hierarchical="0" system="0" vocabulary="0"
+      defaultSort="1">
+      <labels>
+        <label locale="en_US">
+          <name>Physical Formats For Audio</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1" access="0" value="option0" rank="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="open_reel_audiotape" enabled="1" default="0" access="0"
+          value="open_reel_audiotape" rank="2">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Open reel audiotape</name_singular>
+              <name_plural>Open reel audiotape</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="grooved_analog_disc" enabled="1" default="0" access="0"
+          value="grooved_analog_disc" rank="3">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Grooved analog disc</name_singular>
+              <name_plural>Grooved analog disc</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="one_inch_audio_tape" enabled="1" default="0" access="0"
+          value="one_inch_audio_tape" rank="4">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1 inch audio tape</name_singular>
+              <name_plural>1 inch audio tape</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="half_inch_audio_tape" enabled="1" default="0" access="0"
+          value="half_inch_audio_tape" rank="5">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1/2 inch audio tape</name_singular>
+              <name_plural>1/2 inch audio tape</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="quarter_inch_audio_cassette" enabled="1" default="0" access="0"
+          value="quarter_inch_audio_cassette" rank="6">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1/4 inch audio cassette</name_singular>
+              <name_plural>1/4 inch audio cassette</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="quarter_inch_audio_tape" enabled="1" default="0" access="0"
+          value="quarter_inch_audio_tape" rank="7">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1/4 inch audio tape</name_singular>
+              <name_plural>1/4 inch audio tape</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="two_inch_audio_tape" enabled="1" default="0" access="0"
+          value="two_inch_audio_tape" rank="8">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>2 inch audio tape</name_singular>
+              <name_plural>2 inch audio tape</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="8_track" enabled="1" default="0" access="0" value="8_track" rank="9">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>8-track</name_singular>
+              <name_plural>8-track</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="aluminum_disc" enabled="1" default="0" access="0" value="aluminum_disc"
+          rank="10">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Aluminum disc</name_singular>
+              <name_plural>Aluminum disc</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cassette" enabled="1" default="0" access="0" value="audio_cassette"
+          rank="11">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio cassette</name_singular>
+              <name_plural>Audio cassette</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cassette_1" enabled="1" default="0" access="0" value="audio_cassette_1"
+          rank="12">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio cassette: Type I</name_singular>
+              <name_plural>Audio cassette: Type I</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cassette_2" enabled="1" default="0" access="0" value="audio_cassette_2"
+          rank="13">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio cassette: Type II</name_singular>
+              <name_plural>Audio cassette: Type II</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cassette_3" enabled="1" default="0" access="0" value="audio_cassette_3"
+          rank="14">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio cassette: Type III</name_singular>
+              <name_plural>Audio cassette: Type III</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cassette_4" enabled="1" default="0" access="0" value="audio_cassette_4"
+          rank="15">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio cassette: Type IV</name_singular>
+              <name_plural>Audio cassette: Type IV</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cd" enabled="1" default="0" access="0" value="audio_cd" rank="16">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio CD</name_singular>
+              <name_plural>Audio CD</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="dat" enabled="1" default="0" access="0" value="dat" rank="17">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DAT</name_singular>
+              <name_plural>DAT</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="dds" enabled="1" default="0" access="0" value="dds" rank="18">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DDS</name_singular>
+              <name_plural>DDS</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="dtrs" enabled="1" default="0" access="0" value="dtrs" rank="19">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DTRS</name_singular>
+              <name_plural>DTRS</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="dtrs_1" enabled="1" default="0" access="0" value="dtrs_1" rank="20">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DTRS: DA-88</name_singular>
+              <name_plural>DTRS: DA-88</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="film_audio" enabled="1" default="0" access="0" value="film_audio" rank="21">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Film</name_singular>
+              <name_plural>Film</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="flexi_disc" enabled="1" default="0" access="0" value="flexi_disc" rank="21">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Flexi Disc</name_singular>
+              <name_plural>Flexi Disc</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="grooved_dictabelt" enabled="1" default="0" access="0" value="grooved_dictabelt"
+          rank="22">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Grooved Dictabelt</name_singular>
+              <name_plural>Grooved Dictabelt</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="lacquer_disc" enabled="1" default="0" access="0" value="lacquer_disc" rank="23">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Lacquer disc</name_singular>
+              <name_plural>Lacquer disc</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="magnetic_dictabelt" enabled="1" default="0" access="0"
+          value="magnetic_dictabelt" rank="24">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Magnetic Dictabelt</name_singular>
+              <name_plural>Magnetic Dictabelt</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="mini_cassette" enabled="1" default="0" access="0" value="mini_cassette"
+          rank="25">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mini-cassette</name_singular>
+              <name_plural>Mini-cassette</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="pcm_betamax" enabled="1" default="0" access="0" value="pcm_betamax" rank="26">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>PCM Betamax</name_singular>
+              <name_plural>PCM Betamax</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="pcm_u_matic" enabled="1" default="0" access="0" value="pcm_u_matic" rank="27">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>PCM U-matic</name_singular>
+              <name_plural>PCM U-matic</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="pcm_vhs" enabled="1" default="0" access="0" value="pcm_vhs" rank="28">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>PCM VHS</name_singular>
+              <name_plural>PCM VHS</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="piano_roll" enabled="1" default="0" access="0" value="piano_roll" rank="29">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Piano roll</name_singular>
+              <name_plural>Piano roll</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="plastic_cylinder" enabled="1" default="0" access="0" value="plastic_cylinder"
+          rank="30">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Plastic cylinder</name_singular>
+              <name_plural>Plastic cylinder</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="shellac_disc" enabled="1" default="0" access="0" value="shellac_disc" rank="31">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Shellac disc</name_singular>
+              <name_plural>Shellac disc</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="super_audio_cd" enabled="1" default="0" access="0" value="super_audio_cd"
+          rank="32">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Super Audio CD</name_singular>
+              <name_plural>Super Audio CD</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="vinyl_recording" enabled="1" default="0" access="0" value="vinyl_recording"
+          rank="33">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Vinyl recording</name_singular>
+              <name_plural>Vinyl recording</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="vinyl_recording_1" enabled="1" default="0" access="0" value="vinyl_recording_1"
+          rank="34">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Vinyl recording: EP</name_singular>
+              <name_plural>Vinyl recording: EP</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="vinyl_recording_2" enabled="1" default="0" access="0" value="vinyl_recording_2"
+          rank="35">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Vinyl recording: LP</name_singular>
+              <name_plural>Vinyl recording: LP</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="vinyl_recording_3" enabled="1" default="0" access="0" value="vinyl_recording_3"
+          rank="36">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Vinyl recording: 45</name_singular>
+              <name_plural>Vinyl recording: 45</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="vinyl_recording_4" enabled="1" default="0" access="0" value="vinyl_recording_4"
+          rank="37">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Vinyl recording: 78</name_singular>
+              <name_plural>Vinyl recording: 78</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="wax_cylinder" enabled="1" default="0" access="0" value="wax_cylinder" rank="38">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Wax cylinder</name_singular>
+              <name_plural>Wax cylinder</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="wire_recording" enabled="1" default="0" access="0" value="wire_recording"
+          rank="39">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Wire recording</name_singular>
+              <name_plural>Wire recording</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="instantiation_generations_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Generations Types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="348">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="a_b_rolls" enabled="1" default="0" access="0" value="a_b_rolls" rank="349">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>A-B rolls</name_singular>
+              <name_plural>A-B rolls</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="answer_print" enabled="1" default="0" access="0" value="answer_print" rank="350">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Answer print</name_singular>
+              <name_plural>Answer print</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="composite" enabled="1" default="0" access="0" value="composite" rank="351">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Composite</name_singular>
+              <name_plural>Composite</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="copy" enabled="1" default="0" access="0" value="copy" rank="352">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Copy</name_singular>
+              <name_plural>Copy</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="copy_access" enabled="1" default="0" access="0" value="copy_access" rank="353">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Copy: Access</name_singular>
+              <name_plural>Copy: Access</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="dub" enabled="1" default="0" access="0" value="dub" rank="354">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Dub</name_singular>
+              <name_plural>Dub</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="duplicate" enabled="1" default="0" access="0" value="duplicate" rank="355">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Duplicate</name_singular>
+              <name_plural>Duplicate</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="fine_cut" enabled="1" default="0" access="0" value="fine_cut" rank="356">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Fine cut</name_singular>
+              <name_plural>Fine cut</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="intermediate" enabled="1" default="0" access="0" value="intermediate" rank="357">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Intermediate</name_singular>
+              <name_plural>Intermediate</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="interpositive" enabled="1" default="0" access="0" value="interpositive"
+          rank="358">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Interpositive</name_singular>
+              <name_plural>Interpositive</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="internegative" enabled="1" default="0" access="0" value="internegative"
+          rank="359">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Internegative</name_singular>
+              <name_plural>Internegative</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="color_reversal_intermediate" enabled="1" default="0" access="0"
+          value="color_reversal_intermediate" rank="360">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Color reversal intermediate</name_singular>
+              <name_plural>Color reversal intermediate</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="kinescope" enabled="1" default="0" access="0" value="kinescope" rank="361">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Kinescope</name_singular>
+              <name_plural>Kinescope</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="line_cut" enabled="1" default="0" access="0" value="line_cut" rank="362">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Line cut</name_singular>
+              <name_plural>Line cut</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="magnetic_track" enabled="1" default="0" access="0" value="magnetic_track"
+          rank="363">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Magnetic Track</name_singular>
+              <name_plural>Magnetic Track</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="master" enabled="1" default="0" access="0" value="master" rank="364">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Master</name_singular>
+              <name_plural>Master</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="master_distribution" enabled="1" default="0" access="0"
+          value="master_distribution" rank="365">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Master: distribution</name_singular>
+              <name_plural>Master: distribution</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="master_production" enabled="1" default="0" access="0" value="master_production"
+          rank="366">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Master: production</name_singular>
+              <name_plural>Master: production</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="mezzanine" enabled="1" default="0" access="0" value="mezzanine" rank="367">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mezzanine</name_singular>
+              <name_plural>Mezzanine</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="negative" enabled="1" default="0" access="0" value="negative" rank="368">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Negative</name_singular>
+              <name_plural>Negative</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="optical_track" enabled="1" default="0" access="0" value="optical_track"
+          rank="369">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Optical Track</name_singular>
+              <name_plural>Optical Track</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="original" enabled="1" default="0" access="0" value="original" rank="370">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Original</name_singular>
+              <name_plural>Original</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="original_footage" enabled="1" default="0" access="0" value="original_footage"
+          rank="371">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Original footage</name_singular>
+              <name_plural>Original footage</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="original_recording" enabled="1" default="0" access="0"
+          value="original_recording" rank="372">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Original recording</name_singular>
+              <name_plural>Original recording</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="outs_and_trims" enabled="1" default="0" access="0" value="outs_and_trims"
+          rank="373">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Outs and trims</name_singular>
+              <name_plural>Outs and trims</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="picture_lock" enabled="1" default="0" access="0" value="picture_lock" rank="374">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Picture lock</name_singular>
+              <name_plural>Picture lock</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="positive" enabled="1" default="0" access="0" value="positive" rank="375">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Positive</name_singular>
+              <name_plural>Positive</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="preservation" enabled="1" default="0" access="0" value="preservation" rank="376">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Preservation</name_singular>
+              <name_plural>Preservation</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="print" enabled="1" default="0" access="0" value="print" rank="377">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Print</name_singular>
+              <name_plural>Print</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="proxy_file" enabled="1" default="0" access="0" value="proxy_file" rank="378">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Proxy file</name_singular>
+              <name_plural>Proxy file</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="reversal" enabled="1" default="0" access="0" value="reversal" rank="379">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Reversal</name_singular>
+              <name_plural>Reversal</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="rough_cut" enabled="1" default="0" access="0" value="rough_cut" rank="380">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Rough cut</name_singular>
+              <name_plural>Rough cut</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="separation_master" enabled="1" default="0" access="0" value="separation_master"
+          rank="381">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Separation master</name_singular>
+              <name_plural>Separation master</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="stock_footage" enabled="1" default="0" access="0" value="stock_footage"
+          rank="382">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Stock footage</name_singular>
+              <name_plural>Stock footage</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="submaster" enabled="1" default="0" access="0" value="submaster" rank="383">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Submaster</name_singular>
+              <name_plural>Submaster</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="transcription_disc" enabled="1" default="0" access="0"
+          value="transcription_disc" rank="384">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Transcription disc</name_singular>
+              <name_plural>Transcription disc</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="work_print" enabled="1" default="0" access="0" value="work_print" rank="385">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Work print</name_singular>
+              <name_plural>Work print</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="work_tapes" enabled="1" default="0" access="0" value="work_tapes" rank="386">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Work tapes</name_singular>
+              <name_plural>Work tapes</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="work_track" enabled="1" default="0" access="0" value="work_track" rank="387">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Work track</name_singular>
+              <name_plural>Work track</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="pbcore_dates_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>PBCore Date types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1" access="0" value="option0" rank="389">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="accepted" enabled="1" default="0" access="0" value="accepted" rank="390">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>accepted</name_singular>
+              <name_plural>accepted</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="available" enabled="1" default="0" access="0" value="available" rank="391">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>available</name_singular>
+              <name_plural>available</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="available_end" enabled="1" default="0" access="0" value="available_end"
+          rank="392">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>available end</name_singular>
+              <name_plural>available end</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="available_start" enabled="1" default="0" access="0" value="available_start"
+          rank="393">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>available start</name_singular>
+              <name_plural>available start</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="broadcast" enabled="1" default="0" access="0" value="broadcast" rank="394">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>broadcast</name_singular>
+              <name_plural>broadcast</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="captured" enabled="1" default="0" access="0" value="captured" rank="395">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>captured</name_singular>
+              <name_plural>captured</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="created" enabled="1" default="0" access="0" value="created" rank="396">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>created</name_singular>
+              <name_plural>created</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="copyright" enabled="1" default="0" access="0" value="copyright" rank="397">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>copyright</name_singular>
+              <name_plural>copyright</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="distributed" enabled="1" default="0" access="0" value="distributed" rank="398">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>distributed</name_singular>
+              <name_plural>distributed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="dubbed" enabled="1" default="0" access="0" value="dubbed" rank="399">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>dubbed</name_singular>
+              <name_plural>dubbed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="edited" enabled="1" default="0" access="0" value="edited" rank="400">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>edited</name_singular>
+              <name_plural>edited</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="encoded" enabled="1" default="0" access="0" value="encoded" rank="401">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>encoded</name_singular>
+              <name_plural>encoded</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="encrypted" enabled="1" default="0" access="0" value="encrypted" rank="402">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>encrypted</name_singular>
+              <name_plural>encrypted</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="event" enabled="1" default="0" access="0" value="event" rank="403">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>event</name_singular>
+              <name_plural>event</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="ingested" enabled="1" default="0" access="0" value="ingested" rank="404">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>ingested</name_singular>
+              <name_plural>ingested</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="issued" enabled="1" default="0" access="0" value="issued" rank="405">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>issued</name_singular>
+              <name_plural>issued</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="licensed" enabled="1" default="0" access="0" value="licensed" rank="406">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>licensed</name_singular>
+              <name_plural>licensed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="mastered" enabled="1" default="0" access="0" value="mastered" rank="407">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>mastered</name_singular>
+              <name_plural>mastered</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="migrated" enabled="1" default="0" access="0" value="migrated" rank="408">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>migrated</name_singular>
+              <name_plural>migrated</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="mixed" enabled="1" default="0" access="0" value="mixed" rank="409">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>mixed</name_singular>
+              <name_plural>mixed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="modified" enabled="1" default="0" access="0" value="modified" rank="410">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>modified</name_singular>
+              <name_plural>modified</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="normalized" enabled="1" default="0" access="0" value="normalized" rank="411">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>normalized</name_singular>
+              <name_plural>normalized</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="performed" enabled="1" default="0" access="0" value="performed" rank="412">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>performed</name_singular>
+              <name_plural>performed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="podcast" enabled="1" default="0" access="0" value="podcast" rank="413">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>podcast</name_singular>
+              <name_plural>podcast</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="published" enabled="1" default="0" access="0" value="published" rank="414">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>published</name_singular>
+              <name_plural>published</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="released" enabled="1" default="0" access="0" value="released" rank="415">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>released</name_singular>
+              <name_plural>released</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="restored" enabled="1" default="0" access="0" value="restored" rank="416">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>restored</name_singular>
+              <name_plural>restored</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="revised" enabled="1" default="0" access="0" value="revised" rank="417">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>revised</name_singular>
+              <name_plural>revised</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="tranferred" enabled="1" default="0" access="0" value="tranferred" rank="418">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>transferred</name_singular>
+              <name_plural>transferred</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="valid" enabled="1" default="0" access="0" value="valid" rank="419">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>valid</name_singular>
+              <name_plural>valid</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="validated" enabled="1" default="0" access="0" value="validated" rank="420">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>validated</name_singular>
+              <name_plural>validated</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="webcast" enabled="1" default="0" access="0" value="webcast" rank="421">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>webcast</name_singular>
+              <name_plural>webcast</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="instantiation_media_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Media Types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="film" enabled="1" default="0" access="0" value="film" rank="423">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> Film</name_singular>
+              <name_plural> Film</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="video_tape" enabled="1" default="0" access="0" value="Video Tape" rank="424">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Video Tape</name_singular>
+              <name_plural>Video Tape</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="video_disc" enabled="1" default="0" access="0" value="video_disc" rank="425">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Video Disc</name_singular>
+              <name_plural>Video Disc</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="digital_tape" enabled="1" default="0" access="0" value="digital_tape" rank="426"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Digital Tape</name_singular>
+              <name_plural>Digital Tape</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="digital_disc" enabled="1" default="0" access="0" value="digital_disc" rank="427"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Digital Disc</name_singular>
+              <name_plural>Digital Disc</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="digital_file" enabled="1" default="0" access="0" value="digital_file" rank="428"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Digital File</name_singular>
+              <name_plural>Digital File</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="asset_types" hierarchical="0" system="1" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Asset Type</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1" access="0" value="option0" rank="427">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="clip_type" enabled="1" default="0" access="0" value="clip_type" rank="430">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Clip</name_singular>
+              <name_plural>Clip</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="collection_type" enabled="1" default="0" access="0" value="collection_type"
+          rank="431">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Collection</name_singular>
+              <name_plural>Collection</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="compilation_type" enabled="1" default="0" access="0" value="compilation_type"
+          rank="432">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Compilation</name_singular>
+              <name_plural>Compilation</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="episode_type" enabled="1" default="0" access="0" value="episode_type" rank="433">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Episode</name_singular>
+              <name_plural>Episode</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="miniseries_type" enabled="1" default="0" access="0" value="miniseries_type"
+          rank="434">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Miniseries</name_singular>
+              <name_plural>Miniseries</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="program_type" enabled="1" default="0" access="0" value="program_type" rank="435">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Program</name_singular>
+              <name_plural>Program</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="segment_clip" enabled="1" default="0" access="0" value="segment_clip" rank="438">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Segment</name_singular>
+              <name_plural>Segment</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="series" enabled="1" default="0" access="0" value="series" rank="439">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Series</name_singular>
+              <name_plural>Series</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="season" enabled="1" default="0" access="0" value="season" rank="440">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Season</name_singular>
+              <name_plural>Season</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="subseries" enabled="1" default="0" access="0" value="subseries" rank="441">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Subseries</name_singular>
+              <name_plural>Subseries</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="monographic" enabled="1" default="0" access="0" value="monographic" rank="461"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Monographic</name_singular>
+              <name_plural>Monographic</name_plural>
+              <description>Complete content in one part or intended to be completed in a finite number of parts.</description>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="digital_file_format" hierarchical="0" system="1" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Digital File Format</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="DPX" enabled="1" default="0" access="0" rank="447" type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DPX</name_singular>
+              <name_plural>DPX</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="genre" hierarchical="0" system="1" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Genre</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="western" enabled="1" default="0" access="0" value="western" rank="458"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Western</name_singular>
+              <name_plural>Western</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="form" hierarchical="0" system="1" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Form</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="album" enabled="1" default="0" access="0" value="album" rank="428">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Album</name_singular>
+              <name_plural>Album</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="animation" enabled="1" default="0" access="0" value="animation" rank="429">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Animation</name_singular>
+              <name_plural>Animation</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="promo" enabled="1" default="0" access="0" value="promo" rank="436">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Promo</name_singular>
+              <name_plural>Promo</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="raw_footage" enabled="1" default="0" access="0" value="raw_footage" rank="437">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Raw Footage</name_singular>
+              <name_plural>Raw Footage</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="documentary" enabled="1" default="0" access="0" value="documentary" rank="460"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Documentary</name_singular>
+              <name_plural>Documentary</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="loan_status" hierarchical="0" system="1" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Loan Status</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="requested" enabled="1" default="0" access="0" value="requested" rank="466"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>requested</name_singular>
+              <name_plural>requested</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="approved" enabled="1" default="0" access="0" value="approved" rank="467"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>approved</name_singular>
+              <name_plural>approved</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="returned" enabled="1" default="0" access="0" value="returned" rank="468"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>returned</name_singular>
+              <name_plural>returned</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_purposes" hierarchical="0" system="1" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Object purposes</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1" access="0" value="option0" rank="470">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Archival copy</name_singular>
+              <name_plural>Archival copy</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="471">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Research copy</name_singular>
+              <name_plural>Research copy</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="472">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Conservation copy</name_singular>
+              <name_plural>Conservation copy</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="aspect_ratios" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Aspect ratios</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="474">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1.66:1</name_singular>
+              <name_plural>1.66:1</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="475">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1.85:1</name_singular>
+              <name_plural>1.85:1</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="476">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>16:10</name_singular>
+              <name_plural>16:10</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="477">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>16:9</name_singular>
+              <name_plural>16:9</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="478">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>16:9 (14:9 letterbox)</name_singular>
+              <name_plural>16:9 (14:9 letterbox)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="479">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1:1</name_singular>
+              <name_plural>1:1</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="480">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>2.35:1</name_singular>
+              <name_plural>2.35:1</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option7" enabled="1" default="0" access="0" value="option7" rank="481">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>2.39:1</name_singular>
+              <name_plural>2.39:1</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option8" enabled="1" default="0" access="0" value="option8" rank="482">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>2.75:1</name_singular>
+              <name_plural>2.75:1</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option9" enabled="1" default="0" access="0" value="option9" rank="483">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>3:2</name_singular>
+              <name_plural>3:2</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option10" enabled="1" default="0" access="0" value="option10" rank="484">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>4:3</name_singular>
+              <name_plural>4:3</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option11" enabled="1" default="0" access="0" value="option11" rank="485">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>4:3 (14:9 letterbox)</name_singular>
+              <name_plural>4:3 (14:9 letterbox)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option12" enabled="1" default="0" access="0" value="option12" rank="486">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>4:3 (16:9 anamorphic)</name_singular>
+              <name_plural>4:3 (16:9 anamorphic)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option13" enabled="1" default="0" access="0" value="option13" rank="487">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>4:3 (16:9 letterbox)</name_singular>
+              <name_plural>4:3 (16:9 letterbox)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option14" enabled="1" default="0" access="0" value="option14" rank="488">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>5:3</name_singular>
+              <name_plural>5:3</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option15" enabled="1" default="0" access="0" value="option15" rank="489">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>5:4</name_singular>
+              <name_plural>5:4</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option16" enabled="1" default="0" access="0" value="option16" rank="490">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>6:7</name_singular>
+              <name_plural>6:7</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option17" enabled="1" default="0" access="0" value="option17" rank="491">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>7:3 (Panavision or CinemaScope)</name_singular>
+              <name_plural>7:3 (Panavision or CinemaScope)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="apertures" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Apertures</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="493">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Academy 1.33:1</name_singular>
+              <name_plural>Academy 1.33:1</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="494">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Full Height</name_singular>
+              <name_plural>Full Height</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="495">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Full Screen</name_singular>
+              <name_plural>Full Screen</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="496">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Flat</name_singular>
+              <name_plural>Flat</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="497">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Anamorphic</name_singular>
+              <name_plural>Anamorphic</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="498">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>3D</name_singular>
+              <name_plural>3D</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="499">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Pan and scan</name_singular>
+              <name_plural>Pan and scan</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option7" enabled="1" default="0" access="0" value="option7" rank="500">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Pillarbox</name_singular>
+              <name_plural>Pillarbox</name_plural>
+              <description>Bars added at the sides</description>
+            </label>
+          </labels>
+        </item>
+        <item idno="option8" enabled="1" default="0" access="0" value="option8" rank="501">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Letterbox</name_singular>
+              <name_plural>Letterbox</name_plural>
+              <description>Bars added at the top and bottom.</description>
+            </label>
+          </labels>
+        </item>
+        <item idno="option9" enabled="1" default="0" access="0" value="option9" rank="502">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Windowbox</name_singular>
+              <name_plural>Windowbox</name_plural>
+              <description>Bars added at the side and the top and bottom.</description>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="bases" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Bases</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="504">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Acetate</name_singular>
+              <name_plural>Acetate</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="505">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Diacetate</name_singular>
+              <name_plural>Diacetate</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="506">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mainly safety</name_singular>
+              <name_plural>Mainly safety</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="507">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mainly nitrate</name_singular>
+              <name_plural>Mainly nitrate</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="508">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mixed</name_singular>
+              <name_plural>Mixed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="509">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mylar</name_singular>
+              <name_plural>Mylar</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="510">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Nitrate</name_singular>
+              <name_plural>Nitrate</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option7" enabled="1" default="0" access="0" value="option7" rank="511">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Polyester</name_singular>
+              <name_plural>Polyester</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option8" enabled="1" default="0" access="0" value="option8" rank="512">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>PVC</name_singular>
+              <name_plural>PVC</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option9" enabled="1" default="0" access="0" value="option9" rank="513">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Safety</name_singular>
+              <name_plural>Safety</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option10" enabled="1" default="0" access="0" value="option10" rank="514">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Vinyl</name_singular>
+              <name_plural>Vinyl</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="stock_types" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Stock types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="0" default="0" access="0" value="option0" rank="516">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>FILM</name_singular>
+              <name_plural>FILM</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option0_0" enabled="1" default="0" access="0" value="option0_0" rank="517">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Eastman Kodak</name_singular>
+                  <name_plural>Eastman Kodak</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option0_1" enabled="1" default="0" access="0" value="option0_1" rank="518">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Fuji</name_singular>
+                  <name_plural>Fuji</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option0_2" enabled="1" default="0" access="0" value="option0_2" rank="519">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Agfa</name_singular>
+                  <name_plural>Agfa</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="option1" enabled="0" default="0" access="0" value="option1" rank="520">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>VIDEO</name_singular>
+              <name_plural>VIDEO</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option1_0" enabled="1" default="0" access="0" value="option1_0" rank="521">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>3M</name_singular>
+                  <name_plural>3M</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option1_1" enabled="1" default="0" access="0" value="option1_1" rank="522">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Fuji</name_singular>
+                  <name_plural>Fuji</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option1_2" enabled="1" default="0" access="0" value="option1_2" rank="523">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Sony</name_singular>
+                  <name_plural>Sony</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="option2" enabled="0" default="0" access="0" value="option2" rank="524">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>AUDIO</name_singular>
+              <name_plural>AUDIO</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option2_0" enabled="1" default="0" access="0" value="option2_0" rank="525">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Ampex</name_singular>
+                  <name_plural>Ampex</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option2_1" enabled="1" default="0" access="0" value="option2_1" rank="526">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Scotch</name_singular>
+                  <name_plural>Scotch</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option2_2" enabled="1" default="0" access="0" value="option2_2" rank="527">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>3M</name_singular>
+                  <name_plural>3M</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="option3" enabled="0" default="0" access="0" value="option3" rank="528">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>OPTICAL</name_singular>
+              <name_plural>OPTICAL</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option3_0" enabled="1" default="0" access="0" value="option3_0" rank="529">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Maxell</name_singular>
+                  <name_plural>Maxell</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option3_1" enabled="1" default="0" access="0" value="option3_1" rank="530">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Memorex</name_singular>
+                  <name_plural>Memorex</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option3_2" enabled="1" default="0" access="0" value="option3_2" rank="531">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Philips</name_singular>
+                  <name_plural>Philips</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="option4" enabled="0" default="0" access="0" value="option4" rank="532">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DIGITAL TAPE</name_singular>
+              <name_plural>DIGITAL TAPE</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option4_0" enabled="1" default="0" access="0" value="option4_0" rank="533">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>HP</name_singular>
+                  <name_plural>HP</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option4_1" enabled="1" default="0" access="0" value="option4_1" rank="534">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Oracle</name_singular>
+                  <name_plural>Oracle</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="option5" enabled="0" default="0" access="0" value="option5" rank="535">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>HARD DRIVES</name_singular>
+              <name_plural>HARD DRIVES</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option5_0" enabled="1" default="0" access="0" value="option5_0" rank="536">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Hitachi</name_singular>
+                  <name_plural>Hitachi</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option5_1" enabled="1" default="0" access="0" value="option5_1" rank="537">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Seagate</name_singular>
+                  <name_plural>Seagate</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option5_2" enabled="1" default="0" access="0" value="option5_2" rank="538">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Toshiba</name_singular>
+                  <name_plural>Toshiba</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option5_3" enabled="1" default="0" access="0" value="option5_3" rank="539">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Western Digital</name_singular>
+                  <name_plural>Western Digital</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+      </items>
+    </list>
+    <list code="sound_fixation_types" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Sound fixation types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="541">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Needle sound</name_singular>
+              <name_plural>Needle sound</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="542">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Optical</name_singular>
+              <name_plural>Optical</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="543">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Magnetic</name_singular>
+              <name_plural>Magnetic</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="544">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Analog sound</name_singular>
+              <name_plural>Analog sound</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="545">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Digital</name_singular>
+              <name_plural>Digital</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="sound_types" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Sound types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="547">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Sound</name_singular>
+              <name_plural>Sound</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="548">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Silent</name_singular>
+              <name_plural>Silent</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="549">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mute</name_singular>
+              <name_plural>Mute</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="550">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Combined</name_singular>
+              <name_plural>Combined</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="551">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Combined as mute</name_singular>
+              <name_plural>Combined as mute</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="552">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Combined as sound</name_singular>
+              <name_plural>Combined as sound</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="553">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mixed</name_singular>
+              <name_plural>Mixed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option7" enabled="1" default="0" access="0" value="option7" rank="554">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Temporary</name_singular>
+              <name_plural>Temporary</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="sound_systems" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Sound systems</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="556">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Dolby SR</name_singular>
+              <name_plural>Dolby SR</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="557">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Dolby Digital</name_singular>
+              <name_plural>Dolby Digital</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="558">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mute</name_singular>
+              <name_plural>Mute</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="559">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Combined magnetic sound</name_singular>
+              <name_plural>Combined magnetic sound</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="560">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Combined optical sound</name_singular>
+              <name_plural>Combined optical sound</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="561">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>VA RCA Duplex</name_singular>
+              <name_plural>VA RCA Duplex</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="sound_channel_configurations" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Sound channel configurations</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="563">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mono</name_singular>
+              <name_plural>Mono</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="564">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Stereo</name_singular>
+              <name_plural>Stereo</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="color_types" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Color types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="566">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Color</name_singular>
+              <name_plural>Color</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="567">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Black and white</name_singular>
+              <name_plural>Black and white</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="568">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Tinted</name_singular>
+              <name_plural>Tinted</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="569">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Toned</name_singular>
+              <name_plural>Toned</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="570">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Sepia</name_singular>
+              <name_plural>Sepia</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="color_standards" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Color standards</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="572">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Pathécolor</name_singular>
+              <name_plural>Pathécolor</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="573">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Technicolor</name_singular>
+              <name_plural>Technicolor</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="574">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Kinemacolor</name_singular>
+              <name_plural>Kinemacolor</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="575">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Anscocolor</name_singular>
+              <name_plural>Anscocolor</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="576">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Ferraniacolor</name_singular>
+              <name_plural>Ferraniacolor</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="577">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Fujicolor</name_singular>
+              <name_plural>Fujicolor</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option7" enabled="1" default="0" access="0" value="option7" rank="578">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Kodachrome</name_singular>
+              <name_plural>Kodachrome</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option8" enabled="1" default="0" access="0" value="option8" rank="579">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Eastmancolor</name_singular>
+              <name_plural>Eastmancolor</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option9" enabled="1" default="0" access="0" value="option9" rank="580">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>RGB</name_singular>
+              <name_plural>RGB</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option10" enabled="1" default="0" access="0" value="option10" rank="581">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>YUV</name_singular>
+              <name_plural>YUV</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="condition_types" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Condition types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="583">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Emulsion scratches</name_singular>
+              <name_plural>Emulsion scratches</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="584">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Base scratches</name_singular>
+              <name_plural>Base scratches</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="585">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Perforation damage</name_singular>
+              <name_plural>Perforation damage</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="586">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Projector oil and dirt</name_singular>
+              <name_plural>Projector oil and dirt</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="587">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Warpage</name_singular>
+              <name_plural>Warpage</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="588">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Shrinkage</name_singular>
+              <name_plural>Shrinkage</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="589">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Color fading</name_singular>
+              <name_plural>Color fading</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="condition_levels" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Condition levels</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1" access="0" value="0" rank="591">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>0 (perfect)</name_singular>
+              <name_plural>0 (perfect)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="592">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1</name_singular>
+              <name_plural>1</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="593">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>2</name_singular>
+              <name_plural>2</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="594">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>3</name_singular>
+              <name_plural>3</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="595">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>4</name_singular>
+              <name_plural>4</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="5" rank="596">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>5 (critical)</name_singular>
+              <name_plural>5 (critical)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="deterioration_types" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Deterioration types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="598">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Acetate decomposition (vinegar syndrome)</name_singular>
+              <name_plural>Acetate decomposition (vinegar syndrome)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="599">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Polyurethane hydrolysis (sticky-shed syndrome)</name_singular>
+              <name_plural>Polyurethane hydrolysis (sticky-shed syndrome)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="resolutions" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Resolutions</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="601">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Standard definition</name_singular>
+              <name_plural>Standard definition</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="602">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>High definition</name_singular>
+              <name_plural>High definition</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="603">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>2k</name_singular>
+              <name_plural>2k</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="604">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>4k</name_singular>
+              <name_plural>4k</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="605">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>6k</name_singular>
+              <name_plural>6k</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="606">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>8k</name_singular>
+              <name_plural>8k</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="broadcast_standards" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Broadcast standards</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="608">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>NTSC</name_singular>
+              <name_plural>NTSC</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="609">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>PAL</name_singular>
+              <name_plural>PAL</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="610">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>SECAM</name_singular>
+              <name_plural>SECAM</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="frame_rates" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Frame rates</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="612">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>16fps</name_singular>
+              <name_plural>16fps</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="613">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>23.98fps</name_singular>
+              <name_plural>23.98fps</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="614">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>24fps</name_singular>
+              <name_plural>24fps</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="615">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>25fps</name_singular>
+              <name_plural>25fps</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="616">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>30fps</name_singular>
+              <name_plural>30fps</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="617">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>48fps</name_singular>
+              <name_plural>48fps</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="618">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Variable</name_singular>
+              <name_plural>Variable</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="languages" hierarchical="0" system="1" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Languages</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="eng" rank="620">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>English</name_singular>
+              <name_plural>English</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="fre" rank="621">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>French</name_singular>
+              <name_plural>French</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="ger" rank="622">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>German</name_singular>
+              <name_plural>German</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="spa" rank="623">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Spanish</name_singular>
+              <name_plural>Spanish</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="storage_formats" hierarchical="0" system="1" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Storage formats</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="0" default="0" access="0" value="option0" rank="625">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>ANALOG</name_singular>
+              <name_plural>ANALOG</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option0_0" enabled="1" default="0" access="0" value="option0_0" rank="626">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1000ft can</name_singular>
+                  <name_plural>1000ft can</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="option1" enabled="0" default="0" access="0" value="option1" rank="627">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DIGITAL</name_singular>
+              <name_plural>DIGITAL</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option1_0" enabled="1" default="0" access="0" value="option1_0" rank="628">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Hard Drive</name_singular>
+                  <name_plural>Hard Drive</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option1_1" enabled="1" default="0" access="0" value="option1_1" rank="629">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>LTO</name_singular>
+                  <name_plural>LTO</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+      </items>
+    </list>
+    <list code="units_dimensions" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Units of measure (dimensions)</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option1" enabled="1" default="0" access="0" rank="631" type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>ft</name_singular>
+              <name_plural>ft</name_plural>
+              <description>Feet</description>
+            </label>
+          </labels>
+        </item>
+        <item idno="option0" enabled="1" default="0" access="0" rank="632" type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>in</name_singular>
+              <name_plural>in</name_plural>
+              <description>Inches</description>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+  </lists>
+  <elementSets>
+    <metadataElement code="set_description" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Introduction</name>
+          <description>Narrative description for set. This is the primary text used when publicly presenting the set.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_sets</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">3</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="set_item_description" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Item description</name>
+          <description>Narrative description for item in this set. This is the primary text used when publicly presenting the item in the context of this set.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_set_items</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">3</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="set_presentation_type" datatype="List" list="set_presentation_types">
+      <labels>
+        <label locale="en_US">
+          <name>Presentation type</name>
+          <description>Determines how set is rendered when displayed to the public in the Pawtucket/Pawtucket2 front-end.</description>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_sets</table>
+          <type>public_presentation</type>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="set_item_is_primary" datatype="List" list="set_item_is_primary">
+      <labels>
+        <label locale="en_US">
+          <name>Is primary item for set?</name>
+          <description>The item marked as primary will be used to represent the set as a whole when included in a list of sets.</description>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_set_items</table>
+          <type>public_presentation</type>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="set_chron_date_element_code" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Chronology element code</name>
+          <description>Element code of date range element to be used when placing set items into chronological order.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_sets</table>
+          <type>public_presentation</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_authorization_date" datatype="DateRange">
+      <labels>
+        <label locale="en_US">
+          <name>Authorization date</name>
+          <description>The date when the loan was authorized.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">40</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_in_date" datatype="DateRange">
+      <labels>
+        <label locale="en_US">
+          <name>Loan in date</name>
+          <description>The date a loan will enter the institution.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">40</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <type>in</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_out_date" datatype="DateRange">
+      <labels>
+        <label locale="en_US">
+          <name>Loan out date</name>
+          <description>The date a loan will enter the institution.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">40</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <type>out</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_return_date" datatype="DateRange">
+      <labels>
+        <label locale="en_US">
+          <name>Loan return date</name>
+          <description>The date a loan is due back to the lending institution.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">40</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_renewal_date" datatype="DateRange">
+      <labels>
+        <label locale="en_US">
+          <name>Loan renewal application date</name>
+          <description>The date to apply for a renewal to the loan.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">40</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_conditions" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Loan conditions</name>
+          <description>A statement of the conditions on a loan.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">3</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_note" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Loan note</name>
+          <description>General information about the loan.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">3</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_purpose" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Loan purpose</name>
+          <description>General information about the purpose of loan.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">3</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="movement_method" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Movement method</name>
+          <description>The method used in the movement of an object.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_movements</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="movement_note" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Movement note</name>
+          <description>Additional information about the movement of an object or group of objects.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_movements</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="planned_removal_date" datatype="DateRange">
+      <labels>
+        <label locale="en_US">
+          <name>Planned removal date</name>
+          <description>The date an object is to be removed from its current location.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">40</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_movements</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="removal_date" datatype="DateRange">
+      <labels>
+        <label locale="en_US">
+          <name>Planned removal date</name>
+          <description>The date an object was actually removed from its current location.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">40</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_movements</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="movement_reason" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Reason for move</name>
+          <description>The purpose or reason for the movement of the object or group of objects.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_movements</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="tour_description" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Introduction</name>
+          <description>Narrative description for tour. This is the primary text used when publicly presenting the tour.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_tours</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">3</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="tour_stop_description" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Introduction</name>
+          <description>Narrative description for tour stop. This is the primary text used when publicly presenting the stop.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_tour_stops</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">3</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="tour_stop_georeference" datatype="Geocode">
+      <labels>
+        <label locale="en_US">
+          <name>Georeference</name>
+          <description>Location of this stop.</description>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_tour_stops</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="lcshFull" datatype="LCSH">
+      <labels>
+        <label locale="en_US">
+          <name>Library of Congress Subject Headings</name>
+          <description>Library of Congress Subject headings describing this object. To add a new heading simply type the first few letters of the heading and choose the desired one from the displayed list of possible matches.</description>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_object_representations</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_collections</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="geonames" datatype="GeoNames">
+      <labels>
+        <label locale="en_US">
+          <name>GeoNames</name>
+          <description>A Geographic lookup that takes search text, passes it to the GeoNames search service and provides a dropdown with search results (ordered by score). Selected geoname is stored as both text (name, country, continent and ID) and the service URL identifier.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_collections</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="georeference" datatype="Geocode">
+      <labels>
+        <label locale="en_US">
+          <name>Georeference</name>
+          <description>Coordinates documenting the location of the item</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">80</setting>
+        <setting name="fieldHeight">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="description" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Description</name>
+          <description>Narrative description. This is the primary text used to document the item.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_collections</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_storage_locations</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_object_lots</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="caption" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Caption</name>
+          <description>Short descriptive caption for item.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">2</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_object_representations</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_representation_annotations</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_set_items</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="address" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Address</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <elements>
+        <metadataElement code="line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Address line 1</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="address1" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Address line 1</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">70</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Address line 1</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="address2" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Address line 2</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">70</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="line3" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Address line 3</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="city" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>City</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">20</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="stateprovince" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>State</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">15</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="postalcode" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Postal code</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">10</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="country" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Country</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">15</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="telephone" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Telephone/fax</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="maxChars">65535</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="email" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Email address</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="maxChars">65535</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="biography" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Description</name>
+          <description>Narrative biography for entity. This is the primary text used to document the entity.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="biography_source" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Source of description</name>
+          <description>Source of entity biography. This should be a formal citation if possible. For informal sources a narrative description is acceptable.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">3</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="institution" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Institution</name>
+          <description>Name of the institution to which the collection belongs.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_collections</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreExtension" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Extension</name>
+          <description>pbcoreExtension is an extension element. Use this element as a wrapper containing a specific element from another standard.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="extension_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Extension element</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="extensionElement" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Extension element</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="extension_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Extension value</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="extensionValue" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Extension value</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="extension_line3" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Extension authority used</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="extensionAuthority" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Extension authority used</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreCoverage" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Coverage</name>
+          <description>coverage refers to either the geographic location or the time period covered by the asset’s intellectual content. For geographic locations (‘spatial’ descriptors), it is expressed by keywords such as place names (e.g. ‘Alaska’ or ‘Washington, DC’), numeric coordinates or geo-spatial data. For time-based events (‘temporal’ descriptors), it is expressed by using a date, period, era, or time-based event that is portrayed or covered in the intellectual content (e.g. ‘2007’ or ‘Victorian Era’). The PBCore metadata element coverage houses the actual spatial or temporal keywords. The companion element coverageType is used to identify the type of keywords that are being used.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pbCoverage_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Coverage</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pbCoverage_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Coverage</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="pbCoverage_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Coverage Details</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="coverageType" datatype="List" list="pbcore_coverage_types">
+              <labels>
+                <label locale="en_US">
+                  <name>Coverage Type</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="listWidth">40</setting>
+                <setting name="listHeight">200px</setting>
+                <setting name="doesNotTakeLocale">1</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="requireValue">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="implicitNullOption">0</setting>
+                <setting name="nullOptionText">Not set</setting>
+                <setting name="useDefaultWhenNull">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="render">1</setting>
+                <setting name="renderInSearchBuilder">1</setting>
+                <setting name="useSingular">0</setting>
+                <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+                <setting name="auto_shrink">0</setting>
+                <setting name="maxColumns">3</setting>
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="restrictToTypes" />
+                <setting name="currentSelectionDisplayFormat" />
+                <setting name="minimizeExistingValues">0</setting>
+                <setting name="deferHierarchyLoad">0</setting>
+                <setting name="separateDisabledValues">0</setting>
+                <setting name="hideDisabledValues">0</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="coverageSource" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Coverage Source</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="coverageRef" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Coverage Ref</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreIdentifier" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Additional PBCore Identifiers</name>
+          <description>pbcoreIdentifier is an identifier that can apply to the asset. This identifier should not be limited to a specific instantiation, but rather all instantiations of an asset. It can also hold a URL or URI that points to the asset. </description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pbcore_id" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Identifier</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="pbcore_id_source" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Identifier source</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationIdentifier" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Additional Instantiation Identifiers</name>
+          <description>instantiationIdentifier contains an unambiguous reference or identifier for a particular instantiation of an asset.</description>
+        </label>
+        <label locale="en_US">
+          <name>Additional identifiers</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="instantiation_id" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Identifier</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="instantiation_id_source" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Identifier source</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreTitle" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Additional Titles</name>
+          <description>pbcoreTitle is a name or label relevant to the asset. There may be many types of titles an asset may have, such as a series title, episode title, segment title, or project title, therefore the element is repeatable.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pbTitle_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Title</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pbTitle_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Title</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="pbTitle_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Title Details</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pbTitleType" datatype="List" list="pbcore_title_types">
+              <labels>
+                <label locale="en_US">
+                  <name>Title Type</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="listWidth">40</setting>
+                <setting name="listHeight">200px</setting>
+                <setting name="doesNotTakeLocale">1</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="requireValue">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="implicitNullOption">0</setting>
+                <setting name="nullOptionText">Not set</setting>
+                <setting name="useDefaultWhenNull">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="render">1</setting>
+                <setting name="renderInSearchBuilder">1</setting>
+                <setting name="useSingular">0</setting>
+                <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+                <setting name="auto_shrink">0</setting>
+                <setting name="maxColumns">3</setting>
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="restrictToTypes" />
+                <setting name="currentSelectionDisplayFormat" />
+                <setting name="minimizeExistingValues">0</setting>
+                <setting name="deferHierarchyLoad">0</setting>
+                <setting name="separateDisabledValues">0</setting>
+                <setting name="hideDisabledValues">0</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbTitleSource" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Title Source</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbTitleRef" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Title Ref</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreDescription" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Description</name>
+          <description>pbcoreDescription is an element that uses free-form text or a narrative to report general notes, abstracts, or summaries about the intellectual content of an asset. The information may be in the form of an individual program description, anecdotal interpretations, or brief content reviews. The description may also consist of outlines, lists, bullet points, rundowns, edit decision lists, indexes, or tables of content.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pBdescription_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Description</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pBdescription_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Description</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">5</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="pBdescription_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Description Details</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pbdescriptionType" datatype="List"
+              list="pbcore_description_types">
+              <labels>
+                <label locale="en_US">
+                  <name>Description Type</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="listWidth">40</setting>
+                <setting name="listHeight">200px</setting>
+                <setting name="doesNotTakeLocale">1</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="requireValue">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="implicitNullOption">0</setting>
+                <setting name="nullOptionText">Not set</setting>
+                <setting name="useDefaultWhenNull">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="render">1</setting>
+                <setting name="renderInSearchBuilder">1</setting>
+                <setting name="useSingular">0</setting>
+                <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+                <setting name="auto_shrink">0</setting>
+                <setting name="maxColumns">3</setting>
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="restrictToTypes" />
+                <setting name="currentSelectionDisplayFormat" />
+                <setting name="minimizeExistingValues">0</setting>
+                <setting name="deferHierarchyLoad">0</setting>
+                <setting name="separateDisabledValues">0</setting>
+                <setting name="hideDisabledValues">0</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbdescriptionSource" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Description Source</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbdescriptionRef" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Description Ref</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="primary_inst_id_source" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Primary Identifier Source</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="primary_pbcore_id_source" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Primary Identifier Source</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="primary_title_details" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Primary Title Details</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pbPrimaryTitleType" datatype="List" list="pbcore_title_types">
+          <labels>
+            <label locale="en_US">
+              <name>Title Type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="render">1</setting>
+            <setting name="renderInSearchBuilder">1</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="pbPrimaryTitleSource" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Title Source</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">255</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="pbPrimaryTitleRef" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Title Ref</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">255</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreAssetType" datatype="List" list="asset_types">
+      <labels>
+        <label locale="en_US">
+          <name>Asset Type</name>
+          <description>A broad definition of the type or description level of the intellectual content being described. </description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+        <setting name="restrictToTypes">concept</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreGenre" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Form/Genre</name>
+          <description>Describes the Form or Genre. Form describes the format and/or purpose of a Work, e.g., “non-fiction”, “short” and “animation”. Genre describes categories of Works, characterized by similar plots, themes, settings, situations, and characters. Examples of genres are “westerns” and “thrillers”.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pbGenre_line1" datatype="List" list="genre">
+          <labels>
+            <label locale="en_US">
+              <name>Genre</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes">concept</setting>
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="form" datatype="List" list="form">
+          <labels>
+            <label locale="en_US">
+              <name>Form</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes">concept</setting>
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreAudienceLevel" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Audience Level</name>
+          <description>Identifies a type of audience, viewer, or listener for whom the media item is primarily designed or educationally useful.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreAudienceRating" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Audience Rating</name>
+          <description>Designates the type of users for whom the intellectual content of a media item is intended or judged appropriate. This element differs from the element pbcoreAudienceLevel in that it utilizes standard ratings that have been crafted by the broadcast television and film industries and that are used as flags for audience or age-appropriate materials.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreRelation" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Relation</name>
+          <description>The descriptor relationType identifies the type of work bond between a media item you are cataloging and some other related media item.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="relationType" datatype="List" list="pbcore_relation_types">
+          <labels>
+            <label locale="en_US">
+              <name>Relation Type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="render">1</setting>
+            <setting name="renderInSearchBuilder">1</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="relation" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Relation</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">60</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">1</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="rightsSummary_asset" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Rights Summary</name>
+          <description>rightsSummary is used as a general free-text element to identify information about copyrights and property rights held in and over an asset or instantiation, whether they are open access or restricted in some way. If dates, times and availability periods are associated with a right, include them. End user permissions, constraints and obligations may also be identified as needed</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">5</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="rightsLink_asset" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Rights Link</name>
+          <description>rightsLink is a URI pointing to a declaration of rights.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="rightsSummary_instantiation" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Rights Summary</name>
+          <description>rightsSummary is used as a general free-text element to identify information about copyrights and property rights held in and over an asset or instantiation, whether they are open access or restricted in some way. If dates, times and availability periods are associated with a right, include them. End user permissions, constraints and obligations may also be identified as needed</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">5</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="rightsLink_instantiation" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Rights Link</name>
+          <description>rightsLink is a URI pointing to a declaration of rights.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationPhysAudio" datatype="List"
+      list="instantiation_physical_types_audio">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Physical for Audio</name>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio_analog</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationPhysMovingImages" datatype="List"
+      list="instantiation_physical_types_moving">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Physical for Moving Image</name>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_analog</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDigMovingImages" datatype="List" list="digital_file_format">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Digital for Moving Image</name>
+        </label>
+        <label locale="en_US">
+          <name>Digital file format</name>
+          <description>File format for digital moving images.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+        <setting name="restrictToTypes">concept</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDigAudio" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Digital for Audio</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationLocation" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Storage Path</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">2</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationGenerations" datatype="List"
+      list="instantiation_generations_types">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Generations</name>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationTimeStart" datatype="TimeCode">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Time Start</name>
+          <description>instantiationTimeStart describes the point at which playback begins for a time-based instantiation. It is likely that the content on a tape may begin an arbitrary amount of time after the beginning of the instantiation.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">60</setting>
+        <setting name="fieldHeight">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_image</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDuration" datatype="TimeCode">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Duration</name>
+          <description>The element instantiationDuration provides a timestamp for the overall length or duration of a time-based media item. It represents the playback time. Best practice is to use a timestamp format such as HH:MM:SS[:|;]FF or HH:MM:SS.mmm or S.mmm.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">60</setting>
+        <setting name="fieldHeight">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_image</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDataRate" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Data Rate</name>
+          <description>The amount of data in a digital media file that is encoded, delivered or distributed, for every second of time.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="instantiationDataRate_text" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Instantiation Data Rate</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="instantiationDataRate_units" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Units of Measure</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationFileSize" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation File Size</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="instantiationFileSize_text" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Instantiation File Size</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="instantiationFileSize_units" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Units of Measure</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationTracks" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Tracks</name>
+          <description>The element instantiationTracks is simply intended to indicate the number and type of tracks that are found in a media item, whether it is analog or digital. (e.g. 1 video track, 2 audio tracks, 1 text track, 1 sprite track, etc.) Other configuration information specific to these identified tracks should be described using instantiationChannelConfiguration.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_image</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationLanguage" datatype="List" list="languages">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Language</name>
+          <description>instantiationLanguage identifies the primary language of the tracks’ audio or text. Languages must be indicated using 3-letter codes standardized in ISO 639-2 or 639-3. If an instantiation includes more than one language, the element can be repeated. Alternately, both languages can be expressed in one element by separating two three-letter codes with a semicolon, i.e. eng;fre.</description>
+        </label>
+        <label locale="en_US">
+          <name>Language</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+        <setting name="restrictToTypes">concept</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationEssenceTrack" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Essence Track</name>
+          <description>instantiationEssenceTrack is an XML container element that allows for grouping of related essenceTrack elements and their repeated use. Use instantiationEssenceTrack element to describe the individual streams that comprise an instantiation, such as audio, video, timecode, etc.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="essence_line01" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Type</name>
+              <description>essenceTrackType refers to the media type of the decoded data. Tracks may possibly be of these types: video, audio, caption, metadata, image, etc.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackType" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Type</name>
+                  <description>essenceTrackType refers to the media type of the decoded data. Tracks may possibly be of these types: video, audio, caption, metadata, image, etc.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line02" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Identifier</name>
+              <description>essenceTrackIdentifier is an identifier of the track. Several audiovisual containers include such identifier schema to identify each track, such as MPEG2 PIDs or QuickTime Track ids</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackIdentifier" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Identifier</name>
+                  <description>essenceTrackIdentifier is an identifier of the track. Several audiovisual containers include such identifier schema to identify each track, such as MPEG2 PIDs or QuickTime Track ids</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line03" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Identifier Source</name>
+              <description>the name of the software or tool that provided the Track Identifier</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackIdentifierSource" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Identifier Source</name>
+                  <description>the name of the software or tool that provided the Track Identifier</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line04" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Standard</name>
+              <description>essenceTrackStandard should be be used with file-based instantiations to describe the broadcast standard of the video signal (e.g. NTSC, PAL) or to further clarify the standard of the essenceTrackEncoding format.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackStandard" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Standard</name>
+                  <description>essenceTrackStandard should be be used with file-based instantiations to describe the broadcast standard of the video signal (e.g. NTSC, PAL) or to further clarify the standard of the essenceTrackEncoding format.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line05" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Encoding</name>
+              <description>essenceTrackEncoding identifies how the actual information in an instantiation is compressed, interpreted, or formulated using a particular scheme. Identifying the encoding used is beneficial for a number of reasons, including as a way to achieve reversible compression; for the construction of document indices to facilitate searching and access; or for efficient distribution of the information across data networks with differing bandwidths or pipeline capacities. Human-readable encoding value should be placed here.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackEncoding" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Encoding</name>
+                  <description>essenceTrackEncoding identifies how the actual information in an instantiation is compressed, interpreted, or formulated using a particular scheme. Identifying the encoding used is beneficial for a number of reasons, including as a way to achieve reversible compression; for the construction of document indices to facilitate searching and access; or for efficient distribution of the information across data networks with differing bandwidths or pipeline capacities. Human-readable encoding value should be placed here.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line06" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Data Rate</name>
+              <description>essenceTrackDataRate measures the amount of data used per time interval for encoded data. The data rate can be calculated by dividing the total data size of the track's encoded data by a time unit.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackDataRate_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Data Rate</name>
+                  <description>essenceTrackDataRate measures the amount of data used per time interval for encoded data. The data rate can be calculated by dividing the total data size of the track's encoded data by a time unit.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackDataRate_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line07" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Time Start</name>
+              <description>essenceTrackTimeStart provides a time stamp for the beginning point of playback for a time-based essence track. It is likely that the content on a tape may begin an arbitrary amount of time after the beginning of the instantiation.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackTimeStart" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Time Start</name>
+                  <description>essenceTrackTimeStart provides a time stamp for the beginning point of playback for a time-based essence track. It is likely that the content on a tape may begin an arbitrary amount of time after the beginning of the instantiation.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line08" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Duration</name>
+              <description>essenceTrackDuration provides a timestamp for the overall length or duration of a track. It represents the track playback time</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackDuration" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Duration</name>
+                  <description>essenceTrackDuration provides a timestamp for the overall length or duration of a track. It represents the track playback time</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line09" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Bit Depth</name>
+              <description>essenceTrackBitDepth specifies how much data is sampled when information is digitized, encoded, or converted for an instantiation (specifically, audio, video, or image). Bit depth is measured in bits and generally implies an arbitrary perception of quality during playback of an instantiation (the higher the bit depth, the greater the fidelity).</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackBitDepth_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Bit Depth</name>
+                  <description>essenceTrackBitDepth specifies how much data is sampled when information is digitized, encoded, or converted for an instantiation (specifically, audio, video, or image). Bit depth is measured in bits and generally implies an arbitrary perception of quality during playback of an instantiation (the higher the bit depth, the greater the fidelity).</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackBitDepth_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line10" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Sampling Rate</name>
+              <description>essenceTrackSamplingRate measures how often data is sampled when information from the audio portion from an instantiation is digitized. For a digital audio signal, the sampling rate is measured in kilohertz and is an indicator of the perceived playback quality of the media item (the higher the sampling rate, the greater the fidelity).</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackSamplingRate_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Sampling Rate</name>
+                  <description>essenceTrackSamplingRate measures how often data is sampled when information from the audio portion from an instantiation is digitized. For a digital audio signal, the sampling rate is measured in kilohertz and is an indicator of the perceived playback quality of the media item (the higher the sampling rate, the greater the fidelity).</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackSamplingRate_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Sampling Rate</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line11" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Playback Speed</name>
+              <description>essenceTrackPlaybackSpeed specifies the rate of units against time at which the media track should be rendered for human consumption. e.g., 15ips (inches per second).</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackPlaybackSpeed_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Playback Speed</name>
+                  <description>essenceTrackPlaybackSpeed specifies the rate of units against time at which the media track should be rendered for human consumption. e.g., 15ips (inches per second).</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackPlaybackSpeed_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line12" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Frame Size</name>
+              <description>essenceTrackFrameSize measures the width and height of the encoded video or image track. The frame size refers to the size of the encoded pixels and not the size of the displayed image. It may be expressed as combination of pixels measured horizontally vs. the number of pixels of image/resolution data stacked vertically (interlaced and progressive scan).</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackFrameSize_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Frame Size</name>
+                  <description>essenceTrackFrameSize measures the width and height of the encoded video or image track. The frame size refers to the size of the encoded pixels and not the size of the displayed image. It may be expressed as combination of pixels measured horizontally vs. the number of pixels of image/resolution data stacked vertically (interlaced and progressive scan).</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackFrameSize_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line13" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Aspect Ratio</name>
+              <description>essenceTrackAspectRatio indicates the ratio of horizontal to vertical proportions in the display of a static image or moving image.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackAspectRatio_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Aspect Ratio</name>
+                  <description>essenceTrackAspectRatio indicates the ratio of horizontal to vertical proportions in the display of a static image or moving image.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackAspectRatio_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line14" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Frame Rate</name>
+              <description>essenceTrackFrameRate is relevant to tracks of video track type only. The frame rate is calculated by dividing the total number of frames by the duration of the video track. By default measure frame rate in frames per second expressed as fps as a unit of measure. e.g., 24 fps.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackFrameRate_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Frame Rate</name>
+                  <description>essenceTrackFrameRate is relevant to tracks of video track type only. The frame rate is calculated by dividing the total number of frames by the duration of the video track. By default measure frame rate in frames per second expressed as fps as a unit of measure. e.g., 24 fps.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackFrameRate_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line15" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Language</name>
+              <description>essenceTrackLanguage identifies the primary language of the tracks’ audio or text. Languages must be indicated using 3-letter codes standardized in ISO 639-2 or 639-3. If an instantiation includes more than one language, the element can be repeated. Alternately, both languages can be expressed in one element by separating two three-letter codes with a semicolon, i.e. eng;fre.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackLanguage" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Language</name>
+                  <description>essenceTrackLanguage identifies the primary language of the tracks’ audio or text. Languages must be indicated using 3-letter codes standardized in ISO 639-2 or 639-3. If an instantiation includes more than one language, the element can be repeated. Alternately, both languages can be expressed in one element by separating two three-letter codes with a semicolon, i.e. eng;fre.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line16" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Annotation</name>
+              <description>essenceTrackAnnotation can store any supplementary information about a track or the metadata used to describe it. It clarifies element values, terms, descriptors, and vocabularies that may not be otherwise sufficiently understood.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackAnnotation_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Annotation</name>
+                  <description>essenceTrackAnnotation can store any supplementary information about a track or the metadata used to describe it. It clarifies element values, terms, descriptors, and vocabularies that may not be otherwise sufficiently understood.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">3</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackAnnotation_type" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Annotation Type</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">250</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_image</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">250</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreSubject" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Subject</name>
+          <description>pbcoreSubject is used to assign topic headings or keywords that portray the intellectual content of the asset. A subject is expressed by keywords, key phrases, or even specific classification codes. Controlled vocabularies, authorities, formal classification codes, as well as folksonomies and user-generated tags, may be employed when assigning descriptive subject terms.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pbSubject_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Subject</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pbSubject_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Subject</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="pbSubject_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Subject Details</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pbSubjectType" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Subject Type</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbSubjectSource" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Subject Source</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbSubjectRef" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Subject Ref</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreAnnotation" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Annotation</name>
+          <description>pbcoreAnnotation allows the addition of any supplementary information about the metadata used to describe the PBCore record. pbcoreAnnotation clarifies element values, terms, descriptors, and vocabularies that may not be otherwise sufficiently understood.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pbAnnotation_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Annotation</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pbAnnotation_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Annotation</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">5</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="pbAnnotation_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Annotation Type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pbAnnotationType" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Annotation Type</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationAnnotation" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Annotation</name>
+          <description>instantiationAnnotation is used to add any supplementary information about an instantiation of the instantiation or the metadata used to describe it. It clarifies element values, terms, descriptors, and vocabularies that may not be otherwise sufficiently understood.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="instAnnotation_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Annotation</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="instAnnotation_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Annotation</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">5</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="instAnnotation_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Annotation Type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="instAnnotationType" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Annotation Type</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreDate" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Asset Date</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pbcoreDates_value" datatype="DateRange">
+          <labels>
+            <label locale="en_US">
+              <name>Date</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="dateFormat" />
+            <setting name="dateRangeBoundaries" />
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="useDatePicker">0</setting>
+            <setting name="datePickerDateFormat">yy-mm-dd</setting>
+            <setting name="mustNotBeBlank">0</setting>
+            <setting name="isLifespan">0</setting>
+            <setting name="default_text" />
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">,</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="pbCoreDates_types" datatype="List" list="pbcore_dates_types">
+          <labels>
+            <label locale="en_US">
+              <name>Type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="render">1</setting>
+            <setting name="renderInSearchBuilder">1</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDate" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Date</name>
+        </label>
+        <label locale="en_US">
+          <name>Date</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="instantiationDates_value" datatype="DateRange">
+          <labels>
+            <label locale="en_US">
+              <name>Date</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="dateFormat" />
+            <setting name="dateRangeBoundaries" />
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="useDatePicker">0</setting>
+            <setting name="datePickerDateFormat">yy-mm-dd</setting>
+            <setting name="mustNotBeBlank">0</setting>
+            <setting name="isLifespan">0</setting>
+            <setting name="default_text" />
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">,</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="instantiationDates_types" datatype="List" list="pbcore_dates_types">
+          <labels>
+            <label locale="en_US">
+              <name>Type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="render">1</setting>
+            <setting name="renderInSearchBuilder">1</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationStandard" datatype="List" list="broadcast_standards">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Standard</name>
+          <description>If the instantiation is a physical item, instantiationStandard can be used to refer to the broadcast standard of the video signal (e.g. NTSC, PAL), or the audio encoding (e.g. Dolby A, vertical cut). If the instantiation is a digital item, instantiationStandard should be used to express the container format of the digital file (e.g. MXF).</description>
+        </label>
+        <label locale="en_US">
+          <name>Broadcast standard</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+        <setting name="restrictToTypes">concept</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationAlternativeModes" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Alternative Modes</name>
+          <description>instantiationAlternativeModes is a catch-all metadata element that identifies equivalent alternatives to the primary visual, sound or textual information that exists in an instantiation. These are modes that offer alternative ways to see, hear, and read the content of an instantiation. Examples include DVI (Descriptive Video Information), SAP (Supplementary Audio Program), ClosedCaptions, OpenCaptions, Subtitles, Language Dubs, and Transcripts. For each instance of available alternativeModes, the mode and its associated language should be identified together, if applicable. Examples include ‘SAP in English,’ ‘SAP in Spanish,’ ‘Subtitle in French,’ ‘OpenCaption in Arabic.’</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDimensions" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Dimensions</name>
+          <description>Specifies either the dimensions of a physical instantiation, or high-level visual dimensions.
+
+Best Practice: For physical dimensions, usage examples might be 7″ for an audio reel. When describing visual dimensions, use this for high-level descriptors such as 1080p.</description>
+        </label>
+        <label locale="en_US">
+          <name>Dimensions</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="instantiationDimensions_text" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Instantiation Dimensions</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="instantiationDimensions_units" datatype="List"
+          list="units_dimensions">
+          <labels>
+            <label locale="en_US">
+              <name>Units of measure</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="listWidth">10</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes">concept</setting>
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="entity_attributes" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Entity Attributes</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="entitySource" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Entity Source</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">50</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">255</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="entityRef" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Entity Ref</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">50</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">255</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="acquisition_date" datatype="DateRange">
+      <labels>
+        <label locale="en_US">
+          <name>Acquisition Date</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="useDatePicker">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_object_lots</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">0</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="storage_format" datatype="List" list="storage_formats">
+      <labels>
+        <label locale="en_US">
+          <name>Storage Format</name>
+          <description>For Analog: 1000 ft can, etc. For Digital: Hard Drive, LTO, etc.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+        <setting name="restrictToTypes">concept</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="frame_rate" datatype="List" list="frame_rates">
+      <labels>
+        <label locale="en_US">
+          <name>Frame rate</name>
+          <description>The native frames per second rate. Information related to the frame rate used during a digitization process is added to Transfer Speed.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="resolution" datatype="List" list="resolutions">
+      <labels>
+        <label locale="en_US">
+          <name>Resolution</name>
+          <description>E.g., Standard Definition, High Definition, 2k, 4k, 6k, 8k</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="overall_condition" datatype="List" list="condition_levels">
+      <labels>
+        <label locale="en_US">
+          <name>Overall Condition</name>
+          <description>High-level description of the condition of the Object and its Components, where relevant. </description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+        <setting name="restrictToTypes">concept</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="object_purpose" datatype="List" list="object_purposes">
+      <labels>
+        <label locale="en_US">
+          <name>Object purpose</name>
+          <description>Describes purpose or function of the Object, e.g., Archival copy, Research copy, Conservation copy, etc.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="barcode" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Barcode</name>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">0</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="deterioration" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Deterioration</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="lineBreakAfterNumberOfElements">2</setting>
+        <setting name="canBeUsedInSearchForm">0</setting>
+        <setting name="canBeUsedInDisplay">0</setting>
+      </settings>
+      <elements>
+        <metadataElement code="deterioration_level" datatype="List" list="condition_levels">
+          <labels>
+            <label locale="en_US">
+              <name>Deterioration level</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="deterioration_type" datatype="List" list="deterioration_types">
+          <labels>
+            <label locale="en_US">
+              <name>Deterioration type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="deterioration_notes" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Deterioration notes</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">90</setting>
+            <setting name="fieldHeight">5</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio_analog</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">0</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_analog</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">0</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="condition" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Condition</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="lineBreakAfterNumberOfElements">2</setting>
+        <setting name="canBeUsedInSearchForm">0</setting>
+        <setting name="canBeUsedInDisplay">0</setting>
+      </settings>
+      <elements>
+        <metadataElement code="condition_type" datatype="List" list="condition_types">
+          <labels>
+            <label locale="en_US">
+              <name>Condition type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="condition_level" datatype="List" list="condition_levels">
+          <labels>
+            <label locale="en_US">
+              <name>Condition level</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="condition_notes" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Condition notes</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">90</setting>
+            <setting name="fieldHeight">5</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">0</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="specific_component_number" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Specific Component Number</name>
+          <description>Denotes the actual component number.</description>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">0</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_status" datatype="List" list="loan_status">
+      <labels>
+        <label locale="en_US">
+          <name>Loan Status</name>
+          <description>Indicates the status of the loan, e.g., "Requested", "Approved", "Returned"</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+        <setting name="restrictToTypes">concept</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">0</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="carrier_type" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Carrier type</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="instantiationMediaType" datatype="List"
+          list="instantiation_media_types">
+          <labels>
+            <label locale="en_US">
+              <name>Instantiation Media Type</name>
+            </label>
+            <label locale="en_US">
+              <name>General carrier type</name>
+              <description>The broad media type of the Object. Recording this high-level information will enable simple searching for only film, video, digital, etc. elements rather than searching by all possible formats and carriers.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes">concept</setting>
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="specific_carrier_type" datatype="List"
+          list="instantiation_physical_types_moving">
+          <labels>
+            <label locale="en_US">
+              <name>Specific carrier type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="material_characteristics" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Material characteristics</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="base" datatype="List" list="bases">
+          <labels>
+            <label locale="en_US">
+              <name>Base</name>
+              <description>The physical material or video format, e.g., describing the flexible transparent material that supports a film object’s emulsion or a magnetic track, (e.g., acetate, nitrate, CTA, etc.). </description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="stock_type" datatype="List" list="stock_types">
+          <labels>
+            <label locale="en_US">
+              <name>Stock type</name>
+              <description>Describes the specific stock/brand on which the Item is captured, for example, Eastman Kodak, Fuji, 3M, etc. This element should be used for all media: film, video, audio, optical, digital tape, external hard drives.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="stock_batch" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Stock batch</name>
+              <description>The stock batch number or edge code of the media the Item is captured on. This can be a video, audio, optical media, or digital tape stock. Identifying the batch number can assist in identifying problems related to specific manufactured batches</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_analog</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio_analog</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="projection_characteristics" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Projection characteristics</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="aspect_ratio" datatype="List" list="aspect_ratios">
+          <labels>
+            <label locale="en_US">
+              <name>Aspect ratio</name>
+              <description>The projected image area visible on screen, expressed as a value of width to height (the value of height always being “1”), e.g., 2.34:1, 2.39:1.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="aperture" datatype="List" list="apertures">
+          <labels>
+            <label locale="en_US">
+              <name>Aperture</name>
+              <description>The actual exposed image or picture area as it appears on the moving image itself, e.g., Academy, Full screen, Widescreen, etc. The image format does not necessarily bear any relation to the projection ratio (aspect ratio) of the moving image.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_image</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="sound_characteristics" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Sound characteristics</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="lineBreakAfterNumberOfElements">2</setting>
+      </settings>
+      <elements>
+        <metadataElement code="instantiationChanConf" datatype="List"
+          list="sound_channel_configurations">
+          <labels>
+            <label locale="en_US">
+              <name>Sound channel configuration</name>
+              <description>The element instantiationChannelConfiguration is designed to indicate, at a general narrative level, the arrangement or configuration of specific channels or layers of information within an instantiation’s tracks. Examples are 2-track mono, 8- track stereo, or video track with alpha channel.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">100</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="sound_type" datatype="List" list="sound_types">
+          <labels>
+            <label locale="en_US">
+              <name>Sound type</name>
+              <description>Indicate the presence or absence of sound, e.g.,. “sound,” “silent,” “mute”. </description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes">concept</setting>
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="sound_system" datatype="List" list="sound_systems">
+          <labels>
+            <label locale="en_US">
+              <name>Sound system</name>
+              <description>Describes the technical or proprietary system used to record the sound, e.g., Dolby SR, Dolby Digital, etc. </description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="sound_fixation_type" datatype="List" list="sound_fixation_types">
+          <labels>
+            <label locale="en_US">
+              <name>Sound fixation type</name>
+              <description>The name of the physical principle of sound recording, e.g., “Needle,”, “Optical,” “Magnetic,” etc. </description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="color_characteristics" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Color characteristics</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="instantiationColors" datatype="List" list="color_types">
+          <labels>
+            <label locale="en_US">
+              <name>Color type</name>
+              <description>Indicates the overall color, grayscale, or black and white nature of the presentation of an instantiation, as a single occurrence or combination of occurrences in or throughout the instantiation.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">100</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="color_standard" datatype="List" list="color_standards">
+          <labels>
+            <label locale="en_US">
+              <name>Color standard</name>
+              <description>The system or process by which color is fixed on the carrier or as part of the digital encoding, e.g., Pathécolor, Technicolor, etc.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+  </elementSets>
+  <userInterfaces>
+    <userInterface code="loan_cataloguers_ui" type="ca_loans">
+      <labels>
+        <label locale="en_US">
+          <name>Loan editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="status4">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Record Status</setting>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_status2">
+              <bundle>ca_loans.loan_status</bundle>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Short description of loan</setting>
+                <setting name="add_label" locale="en_US">Add short description</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_authorization_date">
+              <bundle>ca_loans.loan_authorization_date</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_in_date">
+              <bundle>ca_loans.loan_in_date</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_out_date">
+              <bundle>ca_loans.loan_out_date</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_return_date">
+              <bundle>ca_loans.loan_return_date</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_renewal_date">
+              <bundle>ca_loans.loan_renewal_date</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_conditions">
+              <bundle>ca_loans.loan_conditions</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_note">
+              <bundle>ca_loans.loan_note</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_purpose">
+              <bundle>ca_loans.loan_purpose</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="history_tracking_chronology13">
+              <bundle>history_tracking_chronology</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_movements">
+              <bundle>ca_movements</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_storage_locations5">
+              <bundle>ca_storage_locations</bundle>
+            </placement>
+            <placement code="ca_object_representations4">
+              <bundle>ca_object_representations</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="movement_cataloguers_ui" type="ca_movements">
+      <labels>
+        <label locale="en_US">
+          <name>Movement editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Short description of movement</setting>
+                <setting name="add_label" locale="en_US">Add short description</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_planned_removal_date">
+              <bundle>ca_movements.planned_removal_date</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_removal_date">
+              <bundle>ca_movements.removal_date</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_movement_method">
+              <bundle>ca_movements.movement_method</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_movement_reason">
+              <bundle>ca_movements.movement_reason</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_movement_note">
+              <bundle>ca_movements.movement_note</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_objects9">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="restrict_to_types">moving_analog</setting>
+                <setting name="restrict_to_types">moving_component</setting>
+                <setting name="restrict_to_types">moving_digital</setting>
+                <setting name="restrict_to_types">moving_component</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_storage_locations10">
+              <bundle>ca_storage_locations</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_object_lots">
+              <bundle>ca_object_lots</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="list_cataloguers_ui" type="ca_lists">
+      <labels>
+        <label locale="en_US">
+          <name>List editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="list_code">
+              <bundle>list_code</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="default_sort">
+              <bundle>default_sort</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="is_hierarchical">
+              <bundle>is_hierarchical</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="is_system_list">
+              <bundle>is_system_list</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="use_as_vocabulary">
+              <bundle>use_as_vocabulary</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="list_item_cataloguers_ui" type="ca_list_items">
+      <labels>
+        <label locale="en_US">
+          <name>List item editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hier_location">
+              <bundle>hierarchy_location</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse">dont_force</setting>
+                <setting name="open_hierarchy">1</setting>
+                <setting name="auto_shrink">0</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="item_value">
+              <bundle>item_value</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="is_enabled">
+              <bundle>is_enabled</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="is_default">
+              <bundle>is_default</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="rank">
+              <bundle>rank</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="color">
+              <bundle>color</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="icon">
+              <bundle>icon</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_settings">
+              <bundle>settings</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="related" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Related list items</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_list_items">
+              <bundle>ca_list_items</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="relationship_types_config_ui" type="ca_relationship_types">
+      <labels>
+        <label locale="en_US">
+          <name>Relationship types configuration editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Relationship names</setting>
+                <setting name="add_label" locale="en_US">Add relationship name</setting>
+              </settings>
+            </placement>
+            <placement code="type_code">
+              <bundle>type_code</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="is_default">
+              <bundle>is_default</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="sub_type_left_id">
+              <bundle>sub_type_left_id</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="include_subtypes_left">
+              <bundle>include_subtypes_left</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="sub_type_right_id">
+              <bundle>sub_type_right_id</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="include_subtypes_right">
+              <bundle>include_subtypes_right</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="rank">
+              <bundle>rank</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="hierarchy_location">
+              <bundle>hierarchy_location</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse">dont_force</setting>
+                <setting name="open_hierarchy">1</setting>
+                <setting name="auto_shrink">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="set_cataloguers_ui" type="ca_sets">
+      <labels>
+        <label locale="en_US">
+          <name>Set editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="set_info" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Set info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Set title</setting>
+                <setting name="add_label" locale="en_US">Add title</setting>
+              </settings>
+            </placement>
+            <placement code="set_code">
+              <bundle>set_code</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_set_description">
+              <bundle>ca_sets.set_description</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_users">
+              <bundle>ca_users</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_user_groups">
+              <bundle>ca_user_groups</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="items" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Items</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_set_items">
+              <bundle>ca_set_items</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="set_item_cataloguers_ui" type="ca_set_items">
+      <labels>
+        <label locale="en_US">
+          <name>Set item editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Caption</setting>
+                <setting name="add_label" locale="en_US">Add caption</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_set_item_is_primary">
+              <bundle>ca_set_items.set_item_is_primary</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_set_item_description">
+              <bundle>ca_set_items.set_item_description</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="search_forms_config_ui" type="ca_search_forms">
+      <labels>
+        <label locale="en_US">
+          <name>Search forms configuration editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Form name</setting>
+                <setting name="add_label" locale="en_US">Add form name</setting>
+              </settings>
+            </placement>
+            <placement code="form_code">
+              <bundle>form_code</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="is_system">
+              <bundle>is_system</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_search_form_placements">
+              <bundle>ca_search_form_placements</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_settings">
+              <bundle>settings</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_search_form_type_restrictions">
+              <bundle>ca_search_form_type_restrictions</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_users">
+              <bundle>ca_users</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_user_groups">
+              <bundle>ca_user_groups</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="bundle_display_config_ui" type="ca_bundle_displays">
+      <labels>
+        <label locale="en_US">
+          <name>Display list configuration editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Display list name</setting>
+                <setting name="add_label" locale="en_US">Add display list name</setting>
+              </settings>
+            </placement>
+            <placement code="display_code">
+              <bundle>display_code</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="is_system">
+              <bundle>is_system</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="settings">
+              <bundle>settings</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_bundle_display_type_restrictions">
+              <bundle>ca_bundle_display_type_restrictions</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_users">
+              <bundle>ca_users</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_user_groups">
+              <bundle>ca_user_groups</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="placements" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Display list</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_bundle_display_placements">
+              <bundle>ca_bundle_display_placements</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="metadata_alert_rule_config_ui" type="ca_metadata_alert_rules">
+      <labels>
+        <label locale="en_US">
+          <name>Metadata alert rule editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Metadata alert rule name</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+            <placement code="ca_metadata_alert_triggers">
+              <bundle>ca_metadata_alert_triggers</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_users">
+              <bundle>ca_users</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="label" locale="en_US">Recipient users</setting>
+                <setting name="add_label" locale="en_US">Add user</setting>
+              </settings>
+            </placement>
+            <placement code="ca_user_groups">
+              <bundle>ca_user_groups</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="label" locale="en_US">Recipient user groups</setting>
+                <setting name="add_label" locale="en_US">Add group</setting>
+              </settings>
+            </placement>
+            <placement code="ca_metadata_alert_rule_type_restrictions">
+              <bundle>ca_metadata_alert_rule_type_restrictions</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="code">
+              <bundle>code</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="tour_editor_ui" type="ca_tours">
+      <labels>
+        <label locale="en_US">
+          <name>Tour editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Tour title</setting>
+                <setting name="add_label" locale="en_US">Add title</setting>
+              </settings>
+            </placement>
+            <placement code="tour_code">
+              <bundle>tour_code</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_tour_description">
+              <bundle>ca_tours.tour_description</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="icon">
+              <bundle>icon</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="color">
+              <bundle>color</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="tour_stop_editor_ui" type="ca_tour_stops">
+      <labels>
+        <label locale="en_US">
+          <name>Tour stop editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Tour stop title</setting>
+                <setting name="add_label" locale="en_US">Add title</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_tour_stop_description">
+              <bundle>ca_tour_stops.tour_stop_description</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_tour_stop_georeference">
+              <bundle>ca_tour_stops.tour_stop_georeference</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="icon">
+              <bundle>icon</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="color">
+              <bundle>color</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+            <placement code="ca_occurrences">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_collections">
+              <bundle>ca_collections</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="useHierarchicalBrowser">0</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+            <placement code="ca_tour_stops">
+              <bundle>ca_tour_stops</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="keywords" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Keywords</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_list_items">
+              <bundle>ca_list_items</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="site_page_editor_ui" type="ca_site_pages">
+      <labels>
+        <label locale="en_US">
+          <name>Site page editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="title">
+              <bundle>title</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="path">
+              <bundle>path</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="description">
+              <bundle>ca_site_pages.description</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_site_pages_content">
+              <bundle>ca_site_pages_content</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="keywords">
+              <bundle>keywords</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_representation_ui" type="ca_object_representations">
+      <labels>
+        <label locale="en_US">
+          <name>Object representation editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Title</setting>
+                <setting name="add_label" locale="en_US">Add Title</setting>
+              </settings>
+            </placement>
+            <placement code="media">
+              <bundle>media</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_caption">
+              <bundle>ca_object_representations.caption</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="annotations" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Annotations</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_representation_annotations">
+              <bundle>ca_representation_annotations</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="data_dictionary" type="ca_metadata_dictionary_entries">
+      <labels>
+        <label locale="en_US">
+          <name>Data dictionary editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="0" color="000000">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels1">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="bundle_name4">
+              <bundle>bundle_name</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="table_num4">
+              <bundle>table_num</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_metadata_dictionary_rules6">
+              <bundle>ca_metadata_dictionary_rules</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="settings6">
+              <bundle>settings</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_object_ui" type="ca_objects">
+      <labels>
+        <label locale="en_US">
+          <name>Standard object editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic_pbcore" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+              </settings>
+            </placement>
+            <placement code="access" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Primary identifier</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationIdentifier">
+              <bundle>ca_objects.instantiationIdentifier</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_object_purpose7" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.object_purpose</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Title</setting>
+                <setting name="add_label" locale="en_US">Add Title</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationDate" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.instantiationDate</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationDigMovingImages">
+              <bundle>ca_objects.instantiationDigMovingImages</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationDigAudio" typeRestrictions="audio_digital">
+              <bundle>ca_objects.instantiationDigAudio</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="extent12">
+              <bundle>extent</bundle>
+            </placement>
+            <placement code="extent_units13" typeRestrictions="audio_analog,audio_digital,moving_analog,moving_component,moving_digital">
+              <bundle>extent_units</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationDimensions" typeRestrictions="audio_analog,audio_digital,moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.instantiationDimensions</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="description" locale="en_US">Specifies either the dimensions of a physical instantiation, or high-level visual dimensions.&#13;
+&#13;
+Best Practice: For physical dimensions, usage examples might be 7″ for an audio reel. When describing visual dimensions, use this for high-level descriptors such as 1080p.</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_carrier_type12">
+              <bundle>ca_objects.carrier_type</bundle>
+            </placement>
+            <placement code="ca_attribute_material_characteristics13">
+              <bundle>ca_objects.material_characteristics</bundle>
+            </placement>
+            <placement code="ca_attribute_specific_component_number20" typeRestrictions="moving_component">
+              <bundle>ca_objects.specific_component_number</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Actual Component Number</setting>
+                <setting name="add_label" locale="en_US">Actual Component Number</setting>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_storage_format9" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.storage_format</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_resolution19" typeRestrictions="moving_analog,moving_component">
+              <bundle>ca_objects.resolution</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_projection_characteristics18">
+              <bundle>ca_objects.projection_characteristics</bundle>
+            </placement>
+            <placement code="ca_attribute_sound_characteristics19">
+              <bundle>ca_objects.sound_characteristics</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationStandard" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.instantiationStandard</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationGenerations" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.instantiationGenerations</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="add_label" locale="en_US">Add instantiation generations</setting>
+                <setting name="label" locale="en_US">Element Type</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationFileSize" typeRestrictions="moving_digital,moving_component">
+              <bundle>ca_objects.instantiationFileSize</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="label" locale="en_US">File Size</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationDuration" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.instantiationDuration</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="label" locale="en_US">Duration</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_frame_rate16" typeRestrictions="moving_analog,moving_component">
+              <bundle>ca_objects.frame_rate</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationLanguage" typeRestrictions="audio_analog,audio_digital,moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.instantiationLanguage</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="add_label" locale="en_US">Add language</setting>
+                <setting name="label" locale="en_US">Language</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_overall_condition34" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.overall_condition</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="item_status_id38" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>item_status_id</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_deterioration39" typeRestrictions="moving_component">
+              <bundle>ca_objects.deterioration</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_condition40" typeRestrictions="moving_component">
+              <bundle>ca_objects.condition</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_objects_deaccession25" typeRestrictions="moving_component">
+              <bundle>ca_objects_deaccession</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationEssenceTrack" typeRestrictions="moving_digital,moving_component">
+              <bundle>ca_objects.instantiationEssenceTrack</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="add_label" locale="en_US">Add essence track</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_rightsSummary_instantiation" typeRestrictions="audio_analog,audio_digital,moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.rightsSummary_instantiation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="add_label" locale="en_US">Add instantiation rights summary</setting>
+                <setting name="label" locale="en_US">Rights Summary</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_rightsLink_instantiation" typeRestrictions="audio_analog,audio_digital,moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.rightsLink_instantiation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="add_label" locale="en_US">Add instantiation rights link</setting>
+                <setting name="label" locale="en_US">Rights Link</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationAnnotation" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.instantiationAnnotation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="add_label" locale="en_US">Add Object Notes</setting>
+                <setting name="label" locale="en_US">Object Notes</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationAnnotation47" typeRestrictions="moving_component">
+              <bundle>ca_objects.instantiationAnnotation</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Component Notes</setting>
+                <setting name="add_label" locale="en_US">Add Component Notes</setting>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_barcode44" typeRestrictions="moving_component">
+              <bundle>ca_objects.barcode</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_storage_locations30" typeRestrictions="moving_component">
+              <bundle>ca_storage_locations</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+            <placement code="ca_object_lots31">
+              <bundle>ca_object_lots</bundle>
+            </placement>
+            <placement code="ca_movements32" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_movements</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="restrict_to_relationship_types">part</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="restrict_to_types">movement</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">0</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationLocation" typeRestrictions="audio_digital,moving_digital,moving_component">
+              <bundle>ca_objects.instantiationLocation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="history_tracking_chronology48">
+              <bundle>history_tracking_chronology</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="media" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Media</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_object_representations">
+              <bundle>ca_object_representations</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="dontAllowRelationshipsToExistingRepresentations">0</setting>
+                <setting name="dontAllowAccessToImportDirectory">0</setting>
+                <setting name="dontShowPreferredLabel">0</setting>
+                <setting name="dontShowIdno">0</setting>
+                <setting name="dontShowStatus">0</setting>
+                <setting name="dontShowAccess">0</setting>
+                <setting name="dontShowTranscribe">0</setting>
+                <setting name="uiStyle">NEW_UI</setting>
+                <setting name="showBundlesForEditing">idno</setting>
+                <setting name="showBundlesForEditing">access</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="works" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Intellectual Content</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="label" locale="en_US">Related Intellectual Content</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="assets" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Instantiations</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="restrict_to_types">audio_analog</setting>
+                <setting name="restrict_to_types">audio_digital</setting>
+                <setting name="restrict_to_types">moving_analog</setting>
+                <setting name="restrict_to_types">moving_digital</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="label" locale="en_US">Related Instantiations</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="extension" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Extensions</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_attribute_pbcoreExtension">
+              <bundle>ca_objects.pbcoreExtension</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="add_label" locale="en_US">Add extension</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="screen_16_5" default="0" color="000000">
+          <labels>
+            <label locale="en_US">
+              <name>Components</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects_components_list1">
+              <bundle>ca_objects_components_list</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_entity_ui" type="ca_entities">
+      <labels>
+        <label locale="en_US">
+          <name>Standard entity editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Name</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_entity_attributes">
+              <bundle>ca_entities.entity_attributes</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="contact" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Contact info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_attribute_address">
+              <bundle>ca_entities.address</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_telephone">
+              <bundle>ca_entities.telephone</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_email">
+              <bundle>ca_entities.email</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="label" locale="en_US">Related instantiation</setting>
+                <setting name="add_label" locale="en_US">Add instantiation</setting>
+              </settings>
+            </placement>
+            <placement code="ca_occurrences">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="label" locale="en_US">Related intellectual content</setting>
+                <setting name="add_label" locale="en_US">Add intellectual content</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+            <placement code="ca_collections">
+              <bundle>ca_collections</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="useHierarchicalBrowser">0</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="keywords" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Keywords</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_list_items">
+              <bundle>ca_list_items</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+                <setting name="add_label" locale="en_US">Add term</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_lcshFull">
+              <bundle>ca_entities.lcshFull</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_place_ui" type="ca_places">
+      <labels>
+        <label locale="en_US">
+          <name>Standard place editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="place" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Place</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="source_id">
+              <bundle>source_id</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Name</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="location" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Location</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_location">
+              <bundle>hierarchy_location</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse">dont_force</setting>
+                <setting name="open_hierarchy">1</setting>
+                <setting name="auto_shrink">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_georeference">
+              <bundle>ca_places.georeference</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_geonames">
+              <bundle>ca_places.geonames</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="label" locale="en_US">Related instantiation</setting>
+              </settings>
+            </placement>
+            <placement code="ca_assets">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="label" locale="en_US">Related intellectual content</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+            <placement code="ca_collections">
+              <bundle>ca_collections</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="useHierarchicalBrowser">0</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="keywords" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Keywords</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_list_items">
+              <bundle>ca_list_items</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+                <setting name="add_label" locale="en_US">Add term</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_lcshFull">
+              <bundle>ca_places.lcshFull</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_occurrences_ui" type="ca_occurrences">
+      <labels>
+        <label locale="en_US">
+          <name>Standard occurrences editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="content" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="idno4">
+              <bundle>idno</bundle>
+            </placement>
+            <placement code="ca_attribute_pbcoreAssetType">
+              <bundle>ca_occurrences.pbcoreAssetType</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="label" locale="en_US">Content Type</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_pbcoreDate">
+              <bundle>ca_occurrences.pbcoreDate</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="label" locale="en_US">Date</setting>
+                <setting name="add_label" locale="en_US">Add Date</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_pbcoreIdentifier">
+              <bundle>ca_occurrences.pbcoreIdentifier</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="label" locale="en_US">Additional Identifiers</setting>
+                <setting name="add_label" locale="en_US">Add Additional Identifiers</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Primary Title</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_primary_title_details">
+              <bundle>ca_occurrences.primary_title_details</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_pbcoreTitle">
+              <bundle>ca_occurrences.pbcoreTitle</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="add_label" locale="en_US">Add Title</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_pbcoreDescription">
+              <bundle>ca_occurrences.pbcoreDescription</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_pbcoreGenre">
+              <bundle>ca_occurrences.pbcoreGenre</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_pbcoreSubject">
+              <bundle>ca_occurrences.pbcoreSubject</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_pbcoreAnnotation">
+              <bundle>ca_occurrences.pbcoreAnnotation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="add_label" locale="en_US">Add Notes</setting>
+                <setting name="label" locale="en_US">Notes</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="intellectual" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Intellectual Property</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_contributors">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="restrict_to_relationship_types">actor</setting>
+                <setting name="restrict_to_relationship_types">artist</setting>
+                <setting name="restrict_to_relationship_types">artistic_director</setting>
+                <setting name="restrict_to_relationship_types">author</setting>
+                <setting name="restrict_to_relationship_types">broadcast_engineer</setting>
+                <setting name="restrict_to_relationship_types">camera_operator</setting>
+                <setting name="restrict_to_relationship_types">caption_writer</setting>
+                <setting name="restrict_to_relationship_types">casting_director</setting>
+                <setting name="restrict_to_relationship_types">choreographer</setting>
+                <setting name="restrict_to_relationship_types">cinematographer</setting>
+                <setting name="restrict_to_relationship_types">co_producer</setting>
+                <setting name="restrict_to_relationship_types">composer</setting>
+                <setting name="restrict_to_relationship_types">costume_designer</setting>
+                <setting name="restrict_to_relationship_types">creator</setting>
+                <setting name="restrict_to_relationship_types">describer</setting>
+                <setting name="restrict_to_relationship_types">director</setting>
+                <setting name="restrict_to_relationship_types">director_of_photography</setting>
+                <setting name="restrict_to_relationship_types">editor</setting>
+                <setting name="restrict_to_relationship_types">executive_producer</setting>
+                <setting name="restrict_to_relationship_types">filmmaker</setting>
+                <setting name="restrict_to_relationship_types">foley_artist</setting>
+                <setting name="restrict_to_relationship_types">graphic_designer</setting>
+                <setting name="restrict_to_relationship_types">graphic_editor</setting>
+                <setting name="restrict_to_relationship_types">guest</setting>
+                <setting name="restrict_to_relationship_types">host</setting>
+                <setting name="restrict_to_relationship_types">interviewee</setting>
+                <setting name="restrict_to_relationship_types">interviewer</setting>
+                <setting name="restrict_to_relationship_types">lighting_technician</setting>
+                <setting name="restrict_to_relationship_types">make_up_artist</setting>
+                <setting name="restrict_to_relationship_types">moderator</setting>
+                <setting name="restrict_to_relationship_types">music_supervisor</setting>
+                <setting name="restrict_to_relationship_types">musician</setting>
+                <setting name="restrict_to_relationship_types">narrator</setting>
+                <setting name="restrict_to_relationship_types">panelist</setting>
+                <setting name="restrict_to_relationship_types">performer</setting>
+                <setting name="restrict_to_relationship_types">performing_group</setting>
+                <setting name="restrict_to_relationship_types">photographer</setting>
+                <setting name="restrict_to_relationship_types">producer</setting>
+                <setting name="restrict_to_relationship_types">production_unit</setting>
+                <setting name="restrict_to_relationship_types">recording_engineer</setting>
+                <setting name="restrict_to_relationship_types">reporter</setting>
+                <setting name="restrict_to_relationship_types">set_designer</setting>
+                <setting name="restrict_to_relationship_types">sound_designer</setting>
+                <setting name="restrict_to_relationship_types">sound_editor</setting>
+                <setting name="restrict_to_relationship_types">speaker</setting>
+                <setting name="restrict_to_relationship_types">technical_director</setting>
+                <setting name="restrict_to_relationship_types">video_engineer</setting>
+                <setting name="restrict_to_relationship_types">vocalist</setting>
+                <setting name="restrict_to_relationship_types">voiceover_artist</setting>
+                <setting name="restrict_to_relationship_types">writer</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="label" locale="en_US">Creators and Contributors</setting>
+                <setting name="add_label" locale="en_US">Add creators</setting>
+              </settings>
+            </placement>
+            <placement code="ca_publishers">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="restrict_to_relationship_types">publisher</setting>
+                <setting name="restrict_to_relationship_types">distributor</setting>
+                <setting name="restrict_to_relationship_types">presenter</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="label" locale="en_US">Publishers</setting>
+                <setting name="add_label" locale="en_US">Add publishers</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_rightsSummary_asset">
+              <bundle>ca_occurrences.rightsSummary_asset</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_rightsLink_asset">
+              <bundle>ca_occurrences.rightsLink_asset</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="assets" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Instantiations</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="label" locale="en_US">Related Instantiations</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="extension" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Extensions</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_attribute_pbcoreExtension">
+              <bundle>ca_occurrences.pbcoreExtension</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="add_label" locale="en_US">Add extension</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="related_assets" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Intellectual Content</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_occurrences">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="label" locale="en_US">Related Intellectual Content</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_collection_ui" type="ca_collections">
+      <labels>
+        <label locale="en_US">
+          <name>Collection editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_location">
+              <bundle>hierarchy_location</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse">dont_force</setting>
+                <setting name="open_hierarchy">1</setting>
+                <setting name="auto_shrink">0</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Title</setting>
+                <setting name="add_label" locale="en_US">Add Title</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_institution">
+              <bundle>ca_collections.institution</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_description">
+              <bundle>ca_collections.description</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="label" locale="en_US">Related Instantiations</setting>
+              </settings>
+            </placement>
+            <placement code="ca_occurrences">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="label" locale="en_US">Related Intellectual Content</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+            <placement code="ca_collections">
+              <bundle>ca_collections</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="useHierarchicalBrowser">0</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="keywords" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Keywords</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_list_items">
+              <bundle>ca_list_items</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+                <setting name="add_label" locale="en_US">Add term</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_storage_locations_ui" type="ca_storage_locations">
+      <labels>
+        <label locale="en_US">
+          <name>Storage locations editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_navigation">
+              <bundle>hierarchy_navigation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse">dont_force</setting>
+                <setting name="open_hierarchy">1</setting>
+                <setting name="auto_shrink">0</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Name</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_description">
+              <bundle>ca_storage_locations.description</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_objects6">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="restrict_to_types">moving_component</setting>
+                <setting name="restrict_to_types">moving_component</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_movements7">
+              <bundle>ca_movements</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="location" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Location</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_location">
+              <bundle>hierarchy_navigation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse">dont_force</setting>
+                <setting name="open_hierarchy">1</setting>
+                <setting name="auto_shrink">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="contents" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Contents</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_navigation">
+              <bundle>hierarchy_navigation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse">dont_force</setting>
+                <setting name="open_hierarchy">1</setting>
+                <setting name="auto_shrink">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_navigation">
+              <bundle>hierarchy_navigation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse">dont_force</setting>
+                <setting name="open_hierarchy">1</setting>
+                <setting name="auto_shrink">0</setting>
+              </settings>
+            </placement>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_object_lots_ui" type="ca_object_lots">
+      <labels>
+        <label locale="en_US">
+          <name>Object lots editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Lot title</setting>
+                <setting name="add_label" locale="en_US">Add lot title</setting>
+              </settings>
+            </placement>
+            <placement code="idno_stub">
+              <bundle>idno_stub</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Lot number</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_acquisition_date3">
+              <bundle>ca_object_lots.acquisition_date</bundle>
+            </placement>
+            <placement code="lot_status_id">
+              <bundle>lot_status_id</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_description">
+              <bundle>ca_object_lots.description</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="extent">
+              <bundle>extent</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="extent_units">
+              <bundle>extent_units</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_objects2">
+              <bundle>ca_objects</bundle>
+            </placement>
+            <placement code="ca_object_representations4">
+              <bundle>ca_object_representations</bundle>
+            </placement>
+            <placement code="ca_object_lots4">
+              <bundle>ca_object_lots</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="contents" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Contents</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Alternate lot titles</setting>
+                <setting name="add_label" locale="en_US">Add lot title</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_representation_annotation_ui" type="ca_representation_annotations">
+      <labels>
+        <label locale="en_US">
+          <name>Representation annotation editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Title</setting>
+                <setting name="add_label" locale="en_US">Add Title</setting>
+              </settings>
+            </placement>
+            <placement code="ca_representation_annotation_properties">
+              <bundle>ca_representation_annotation_properties</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="keywords" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Keywords</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_list_items">
+              <bundle>ca_list_items</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="ui_editor" type="ca_editor_uis" color="000000">
+      <labels>
+        <label locale="en_US">
+          <name>UI Editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic_24" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="editor_code">
+              <bundle>editor_code</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="color">
+              <bundle>color</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_editor_ui_type_restrictions">
+              <bundle>ca_editor_ui_type_restrictions</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_editor_ui_screens">
+              <bundle>ca_editor_ui_screens</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="is_system_ui">
+              <bundle>is_system_ui</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_users">
+              <bundle>ca_users</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_user_groups">
+              <bundle>ca_user_groups</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_user_roles">
+              <bundle>ca_user_roles</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="ui_screen_editor" type="ca_editor_ui_screens" color="CC0000">
+      <labels>
+        <label locale="en_US">
+          <name>UI Screen Editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic_25" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="color">
+              <bundle>color</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="is_default">
+              <bundle>is_default</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_editor_ui_screen_type_restrictions">
+              <bundle>ca_editor_ui_screen_type_restrictions</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_editor_ui_bundle_placements">
+              <bundle>ca_editor_ui_bundle_placements</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_users">
+              <bundle>ca_users</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_user_groups">
+              <bundle>ca_user_groups</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_user_roles">
+              <bundle>ca_user_roles</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_object_component_ui" type="ca_objects"
+      typeRestrictions="moving_component,moving_component" includeSubtypes="0">
+      <labels>
+        <label locale="en_US">
+          <name>Standard object component editor</name>
+        </label>
+      </labels>
+      <userAccess>
+        <permission user="herosen" access="edit" />
+      </userAccess>
+      <screens>
+        <screen idno="screen_26_0" default="0" color="000000">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="status1">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+              </settings>
+            </placement>
+            <placement code="idno2">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="usewysiwygeditor">1</setting>
+                <setting name="label" locale="en_US">Primary Identifier</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationIdentifier3">
+              <bundle>ca_objects.instantiationIdentifier</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Additional Identifiers</setting>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels4">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="use_list_format">lookup</setting>
+                <setting name="label" locale="en_US">Title</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_material_characteristics5">
+              <bundle>ca_objects.material_characteristics</bundle>
+            </placement>
+            <placement code="extent8">
+              <bundle>extent</bundle>
+            </placement>
+            <placement code="extent_units9">
+              <bundle>extent_units</bundle>
+            </placement>
+            <placement code="ca_attribute_specific_component_number10">
+              <bundle>ca_objects.specific_component_number</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Actual Component Number</setting>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_deterioration11" typeRestrictions="moving_component">
+              <bundle>ca_objects.deterioration</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_condition12">
+              <bundle>ca_objects.condition</bundle>
+            </placement>
+            <placement code="ca_objects_deaccession13">
+              <bundle>ca_objects_deaccession</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationEssenceTrack14" typeRestrictions="moving_component">
+              <bundle>ca_objects.instantiationEssenceTrack</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationAnnotation14">
+              <bundle>ca_objects.instantiationAnnotation</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Component Notes</setting>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_barcode15">
+              <bundle>ca_objects.barcode</bundle>
+            </placement>
+            <placement code="ca_storage_locations16">
+              <bundle>ca_storage_locations</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="showCurrentOnly">0</setting>
+                <setting name="policy">current_location</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+            <placement code="ca_objects18">
+              <bundle>ca_objects</bundle>
+            </placement>
+            <placement code="ca_object_lots17">
+              <bundle>ca_object_lots</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_movements18">
+              <bundle>ca_movements</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationLocation20" typeRestrictions="moving_component">
+              <bundle>ca_objects.instantiationLocation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="history_tracking_chronology19">
+              <bundle>history_tracking_chronology</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+  </userInterfaces>
+  <relationshipTypes>
+    <relationshipTable name="ca_representation_annotations_x_entities">
+      <types>
+        <type code="depicts" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="describes" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>describes</typename>
+              <typename_reverse>is described by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_representation_annotations_x_objects">
+      <types>
+        <type code="depicts" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="illustrated" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is illustrated by</typename>
+              <typename_reverse>illustrates</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_representation_annotations_x_occurrences">
+      <types>
+        <type code="depicts" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="describes" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>describes</typename>
+              <typename_reverse>is described by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_representation_annotations_x_places">
+      <types>
+        <type code="depicts" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="describes" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>describes</typename>
+              <typename_reverse>is described by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_representation_annotations_x_vocabulary_terms">
+      <types>
+        <type code="describes" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_collections_x_collections">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_collections_x_vocabulary_terms">
+      <types>
+        <type code="described" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_entities_x_collections">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_entities_x_occurrences">
+      <types>
+        <type code="actor" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is actor in</typename>
+              <typename_reverse>has as actor</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="artist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is artist of</typename>
+              <typename_reverse>has as artist</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="artistic_director" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is artistic director of</typename>
+              <typename_reverse>has as artistic director</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="assoicate_producer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is associate producer of</typename>
+              <typename_reverse>has as assoicate producer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="author" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is author of</typename>
+              <typename_reverse>has as author</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="broadcast_engineer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is broadcast engineer of</typename>
+              <typename_reverse>has as broadcast engineer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="camera_operator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is camera operator of</typename>
+              <typename_reverse>has as camera operator</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="caption_writer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is caption writer of</typename>
+              <typename_reverse>has as caption writer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="casting_director" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is casting director of</typename>
+              <typename_reverse>has as casting director</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="choreographer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is choreographer of</typename>
+              <typename_reverse>has as choreographer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="cinematographer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is cinematographer of</typename>
+              <typename_reverse>has as cinematographer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="co_producer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is co-producer of</typename>
+              <typename_reverse>has as co-producer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="commentator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is commentator of</typename>
+              <typename_reverse>has as commentator</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="composer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is composer of</typename>
+              <typename_reverse>has as composer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="concept_artist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is concept artist of</typename>
+              <typename_reverse>has as concept artist</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="conductor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is conductor of</typename>
+              <typename_reverse>has as conductor</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="costume_designer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is costume designer of</typename>
+              <typename_reverse>has as costume designer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="creator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is creator of</typename>
+              <typename_reverse>has as creator</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="describer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is describer of</typename>
+              <typename_reverse>has as describer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="director" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is director of</typename>
+              <typename_reverse>has as director</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="director_of_photography" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is director of photography of</typename>
+              <typename_reverse>has as director of photography</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="editor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is editor of</typename>
+              <typename_reverse>has as editor</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="executive_producer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is executive producer of</typename>
+              <typename_reverse>has as executive producer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="filmmaker" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is filmmaker of</typename>
+              <typename_reverse>has as filmmaker</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="foley_artist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is foley artist of</typename>
+              <typename_reverse>has as foley artist</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="graphic_designer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is graphic designer of</typename>
+              <typename_reverse>has as graphic designer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="graphic_editor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is graphic editor of</typename>
+              <typename_reverse>has as graphic editor</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="guest" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is guest of</typename>
+              <typename_reverse>has as guest</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="host" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is host of</typename>
+              <typename_reverse>has as host</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="interviewee" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is interviewee of</typename>
+              <typename_reverse>has as interviewee</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="interviewer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is interviewer of</typename>
+              <typename_reverse>has as interviewer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="lighting_technician" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is lighting technican of</typename>
+              <typename_reverse>has as lighting technician</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="make_up_artist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is make-up artist of</typename>
+              <typename_reverse>has as make-up artist</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="moderator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is moderator of</typename>
+              <typename_reverse>has as moderator</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="music_supervisor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is music supervisor of</typename>
+              <typename_reverse>has as music supervisor</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="musician" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is musician of</typename>
+              <typename_reverse>has as musician</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="narrator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is narrator of</typename>
+              <typename_reverse>has as narrator</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="panelist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is panelist of</typename>
+              <typename_reverse>has as panelist</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="performer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is performer of</typename>
+              <typename_reverse>has as performer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="performing_group" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is performing group of</typename>
+              <typename_reverse>has as performing group</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="photographer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is photographer of</typename>
+              <typename_reverse>has as photographer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="producer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is producer of</typename>
+              <typename_reverse>has as producer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="production_unit" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is production unit of</typename>
+              <typename_reverse>has as production unit</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="recording_engineer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is recording engineer of</typename>
+              <typename_reverse>has as recording engineer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="reporter" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is reporter of</typename>
+              <typename_reverse>has as reporter</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="set_designer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is set designer of</typename>
+              <typename_reverse>has as set designer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="sound_designer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is sound designer of</typename>
+              <typename_reverse>has as sound designer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="sound_editor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is sound editor of</typename>
+              <typename_reverse>has as sound editor</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="speaker" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is speaker of</typename>
+              <typename_reverse>has as speaker</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="technical_director" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is technical director of</typename>
+              <typename_reverse>has as technical director</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="video_engineer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is video engineer of</typename>
+              <typename_reverse>has as video engineer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="vocalist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is vocalist of</typename>
+              <typename_reverse>has as vocalist</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="voiceover_artist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is voiceover artist of</typename>
+              <typename_reverse>has as voiceover artist</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="writer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is writer of</typename>
+              <typename_reverse>has as writer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="publisher" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is publisher of</typename>
+              <typename_reverse>has as publisher</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="distributor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is distributor of</typename>
+              <typename_reverse>has as distributor</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="presenter" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is presenter of</typename>
+              <typename_reverse>has presenter by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_entities_x_places">
+      <types>
+        <type code="birthplace" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>was born at</typename>
+              <typename_reverse>was birthplace of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="residence" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>resided at</typename>
+              <typename_reverse>was residence of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="workplace" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>worked at</typename>
+              <typename_reverse>was workplace of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="ownership" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>owned</typename>
+              <typename_reverse>was owned by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="built_by" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>built</typename>
+              <typename_reverse>was built by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_entities_x_vocabulary_terms">
+      <types>
+        <type code="described" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_entities_x_entities">
+      <types>
+        <type code="related" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="child" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is child of</typename>
+              <typename_reverse>is parent of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="spouse" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is spouse of</typename>
+              <typename_reverse>is spouse of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_list_items_x_list_items">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_collections">
+      <types>
+        <type code="part_of" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is part of</typename>
+              <typename_reverse>contains</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_entities">
+      <types>
+        <type code="donor" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>was donated by</typename>
+              <typename_reverse>is donor of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="provider" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>was provided by</typename>
+              <typename_reverse>is provider of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_occurrences">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_places">
+      <types>
+        <type code="originates" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>originates from</typename>
+              <typename_reverse>is origination location of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_collections">
+      <types>
+        <type code="part_of" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is part of</typename>
+              <typename_reverse>contains</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_entities">
+      <types>
+        <type code="creator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>created by</typename>
+              <typename_reverse>is creator</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="publisher" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>published by</typename>
+              <typename_reverse>is publisher</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="contributor" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>contributed by</typename>
+              <typename_reverse>is contributor</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_objects">
+      <types>
+        <type code="clone" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Clone Of</typename>
+              <typename_reverse>Cloned To</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="dub" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Dub Of</typename>
+              <typename_reverse>Dubbed To</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="format" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Format Of</typename>
+              <typename_reverse>Has Format</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="part_of" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Part Of</typename>
+              <typename_reverse>Has Part</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="replaced" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Replaced By</typename>
+              <typename_reverse>Replaces</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="source" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Has Source</typename>
+              <typename_reverse>Is Source of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_occurrences">
+      <types>
+        <type code="manifestation" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has as intellectual content</typename>
+              <typename_reverse>is instantiation of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_places">
+      <types>
+        <type code="created" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>was created at</typename>
+              <typename_reverse>was creation location of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="located" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>was located at</typename>
+              <typename_reverse>was location of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="depicts" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="describes" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>describes</typename>
+              <typename_reverse>is described by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_vocabulary_terms">
+      <types>
+        <type code="described" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="depicts" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_occurrences_x_collections">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_occurrences_x_occurrences">
+      <types>
+        <type code="related" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Related To</typename>
+              <typename_reverse>Is Related To</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="derived" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Has Derivative</typename>
+              <typename_reverse>Derived From</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="reference" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>References</typename>
+              <typename_reverse>Is Referenced By</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="part_of" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Part Of</typename>
+              <typename_reverse>Has Part</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="version" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>Has Version</typename>
+              <typename_reverse>Is Version Of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_occurrences_x_vocabulary_terms">
+      <types>
+        <type code="describes" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="subject" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has subject</typename>
+              <typename_reverse>is subject</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_places_x_collections">
+      <types>
+        <type code="location" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is location of</typename>
+              <typename_reverse>is located in</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_places_x_occurrences">
+      <types>
+        <type code="site" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>was site of</typename>
+              <typename_reverse>occurred at</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_places_x_places">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_places_x_vocabulary_terms">
+      <types>
+        <type code="describes" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_representations_x_entities">
+      <types>
+        <type code="creator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>was created by</typename>
+              <typename_reverse>is creator</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="rights_holder" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>rights held by</typename>
+              <typename_reverse>is rights holder</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_representations_x_occurrences">
+      <types>
+        <type code="depicts" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>depicts</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_representations_x_places">
+      <types>
+        <type code="depicts" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>depicts</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_vocabulary_terms">
+      <types>
+        <type code="subject" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has subject</typename>
+              <typename_reverse>is subject</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_representations_x_vocabulary_terms">
+      <types>
+        <type code="subject" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has subject</typename>
+              <typename_reverse>is subject</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_storage_locations">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is located at</typename>
+              <typename_reverse>is location of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_storage_locations">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is located at</typename>
+              <typename_reverse>is location of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_objects">
+      <types>
+        <type code="loan" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has as part of</typename>
+              <typename_reverse>is part of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_entities">
+      <types>
+        <type code="lender" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is lent from (lender)</typename>
+              <typename_reverse>is lender of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="borrower" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is borrowed from (borrower)</typename>
+              <typename_reverse>is borrower of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="authorizer" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is authorized by</typename>
+              <typename_reverse>is authorizer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_objects">
+      <types>
+        <type code="part" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has as part of</typename>
+              <typename_reverse>is part of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_object_lots">
+      <types>
+        <type code="part" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has as part of</typename>
+              <typename_reverse>is part of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_entities">
+      <types>
+        <type code="authorizer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>was authorized by</typename>
+              <typename_reverse>was authorizer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="mover" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>was moved by</typename>
+              <typename_reverse>was mover</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_movements">
+      <types>
+        <type code="location" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is located at</typename>
+              <typename_reverse>is location of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_tour_stops_x_objects">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_tour_stops_x_entities">
+      <types>
+        <type code="subject" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has subject</typename>
+              <typename_reverse>is subject</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_tour_stops_x_places">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is located at</typename>
+              <typename_reverse>is location of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_tour_stops_x_occurrences">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_tour_stops_x_collections">
+      <types>
+        <type code="part" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has as part of</typename>
+              <typename_reverse>is part of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_tour_stops_x_vocabulary_terms">
+      <types>
+        <type code="subject" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has subject</typename>
+              <typename_reverse>is subject</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_tour_stops_x_tour_stops">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_representations_x_collections">
+      <types>
+        <type code="depicts" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>part of</typename>
+              <typename_reverse>part of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_representations_x_storage_locations">
+      <types>
+        <type code="depicts" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>current location</typename>
+              <typename_reverse>current location</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_representations_x_object_representations">
+      <types>
+        <type code="depicts" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>related</typename>
+              <typename_reverse>related</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_collections">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_object_lots">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_occurrences">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_places">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_storage_locations">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_vocabulary_terms">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_loans">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_collections">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_occurrences">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_places">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_storage_locations">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_vocabulary_terms">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_movements">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_places_x_storage_locations">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_occurrences_x_storage_locations">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_storage_locations_x_vocabulary_terms">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_storage_locations_x_storage_locations">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_object_representations">
+      <types>
+        <type code="part" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has as part of</typename>
+              <typename_reverse>is part of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_object_representations">
+      <types>
+        <type code="part_of" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>contains</typename>
+              <typename_reverse>part of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_object_representations">
+      <types>
+        <type code="part" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has as part of</typename>
+              <typename_reverse>is part of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_object_lots">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+  </relationshipTypes>
+  <roles>
+    <role code="admin">
+      <name>Administrators</name>
+      <description>Confers actions needed by those administering the system</description>
+      <actions>
+        <action>is_administrator</action>
+        <action>can_set_access_control</action>
+        <action>can_view_logs</action>
+        <action>can_set_access_control</action>
+        <action>can_configure_user_interfaces</action>
+        <action>can_configure_metadata_elements</action>
+        <action>can_configure_relationship_types</action>
+        <action>can_configure_locales</action>
+        <action>can_view_configuration_check</action>
+        <action>can_manage_system_search_forms</action>
+        <action>can_manage_system_bundle_displays</action>
+      </actions>
+    </role>
+    <role code="cataloguer">
+      <name>Cataloguers</name>
+      <description>Confers actions needed by those editing catalogue entries</description>
+      <actions>
+        <action>can_search</action>
+        <action>can_quicksearch</action>
+        <action>can_browse</action>
+        <action>can_set_preferences</action>
+        <action>can_create_adv_search_forms</action>
+        <action>can_edit_adv_search_forms</action>
+        <action>can_delete_adv_search_forms</action>
+        <action>can_use_adv_search_forms</action>
+        <action>can_use_adv_search_forms</action>
+        <action>can_create_ca_bundle_displays</action>
+        <action>can_edit_ca_bundle_displays</action>
+        <action>can_delete_ca_bundle_displays</action>
+        <action>can_use_ca_bundle_displays</action>
+        <action>can_create_user_groups</action>
+        <action>can_create_sets</action>
+        <action>can_edit_sets</action>
+        <action>can_delete_sets</action>
+        <action>can_view_sets</action>
+        <action>can_create_ca_objects</action>
+        <action>can_edit_ca_objects</action>
+        <action>can_delete_ca_objects</action>
+        <action>can_search_ca_objects</action>
+        <action>can_browse_ca_objects</action>
+        <action>can_create_ca_object_lots</action>
+        <action>can_edit_ca_object_lots</action>
+        <action>can_delete_ca_object_lots</action>
+        <action>can_search_ca_object_lots</action>
+        <action>can_browse_ca_object_lots</action>
+        <action>can_create_ca_entities</action>
+        <action>can_edit_ca_entities</action>
+        <action>can_delete_ca_entities</action>
+        <action>can_search_ca_entities</action>
+        <action>can_browse_ca_entities</action>
+        <action>can_create_ca_places</action>
+        <action>can_edit_ca_places</action>
+        <action>can_delete_ca_places</action>
+        <action>can_search_ca_places</action>
+        <action>can_browse_ca_places</action>
+        <action>can_create_ca_occurrences</action>
+        <action>can_edit_ca_occurrences</action>
+        <action>can_delete_ca_occurrences</action>
+        <action>can_search_ca_occurrences</action>
+        <action>can_browse_ca_occurrences</action>
+        <action>can_create_ca_collections</action>
+        <action>can_edit_ca_collections</action>
+        <action>can_delete_ca_collections</action>
+        <action>can_search_ca_collections</action>
+        <action>can_browse_ca_collections</action>
+        <action>can_create_ca_storage_locations</action>
+        <action>can_edit_ca_storage_locations</action>
+        <action>can_delete_ca_storage_locations</action>
+        <action>can_search_ca_storage_locations</action>
+        <action>can_browse_ca_storage_locations</action>
+        <action>can_create_ca_lists</action>
+        <action>can_edit_ca_lists</action>
+        <action>can_delete_ca_lists</action>
+      </actions>
+    </role>
+    <role code="researcher">
+      <name>Researcher</name>
+      <description>Allows users to only search and view - but not edit - catalogue entries</description>
+      <actions>
+        <action>can_search</action>
+        <action>can_quicksearch</action>
+        <action>can_browse</action>
+        <action>can_set_preferences</action>
+        <action>can_use_adv_search_forms</action>
+        <action>can_create_user_groups</action>
+        <action>can_create_sets</action>
+        <action>can_edit_sets</action>
+        <action>can_delete_sets</action>
+        <action>can_view_sets</action>
+        <action>can_search_ca_object_lots</action>
+        <action>can_browse_ca_object_lots</action>
+        <action>can_search_ca_objects</action>
+        <action>can_browse_ca_objects</action>
+        <action>can_search_ca_entities</action>
+        <action>can_browse_ca_entities</action>
+        <action>can_search_ca_places</action>
+        <action>can_browse_ca_places</action>
+        <action>can_search_ca_occurrences</action>
+        <action>can_browse_ca_occurrences</action>
+        <action>can_search_ca_collections</action>
+        <action>can_browse_ca_collections</action>
+        <action>can_search_ca_storage_locations</action>
+        <action>can_browse_ca_storage_locations</action>
+      </actions>
+    </role>
+    <role code="moderator">
+      <name>User content moderator</name>
+      <description>Allows users to moderate user generated tags and comments</description>
+      <actions>
+        <action>can_manage_user_comments</action>
+        <action>can_manage_user_tags</action>
+      </actions>
+    </role>
+  </roles>
+  <groups>
+    <group code="admin">
+      <name>Administrators</name>
+      <description>System administrators</description>
+      <roles>
+        <role>admin</role>
+        <role>cataloguer</role>
+        <role>researcher</role>
+        <role>moderator</role>
+      </roles>
+    </group>
+    <group code="cataloguer">
+      <name>Cataloguers</name>
+      <description>Users who can add and edit catalogue entries</description>
+      <roles>
+        <role>cataloguer</role>
+      </roles>
+    </group>
+  </groups>
+  <displays>
+</displays>
+  <searchForms>
+    <searchForm code="ca_objects_adv_search" type="ca_objects" system="1">
+      <labels>
+        <label locale="en_US">
+          <name>Extended search</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="form_width">3</setting>
+      </settings>
+      <groupAccess>
+        <permission group="admin" access="edit" />
+      </groupAccess>
+      <bundlePlacements>
+        <placement code="p1">
+          <bundle>ca_object_labels.name</bundle>
+          <settings>
+            <setting name="label" locale="en_US">Title</setting>
+          </settings>
+        </placement>
+        <placement code="p2">
+          <bundle>ca_objects.idno</bundle>
+        </placement>
+        <placement code="p3">
+          <bundle>ca_objects.type_id</bundle>
+        </placement>
+        <placement code="p4">
+          <bundle>ca_entity_labels.displayname</bundle>
+        </placement>
+        <placement code="p5">
+          <bundle>ca_objects.access</bundle>
+        </placement>
+        <placement code="p6">
+          <bundle>ca_objects.status</bundle>
+        </placement>
+      </bundlePlacements>
+    </searchForm>
+    <searchForm code="ca_entities_adv_search" type="ca_entities" system="1">
+      <labels>
+        <label locale="en_US">
+          <name>Extended search</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="form_width">3</setting>
+      </settings>
+      <groupAccess>
+        <permission group="admin" access="edit" />
+      </groupAccess>
+      <bundlePlacements>
+        <placement code="p7">
+          <bundle>ca_entity_labels.forename</bundle>
+        </placement>
+        <placement code="p8">
+          <bundle>ca_entity_labels.middlename</bundle>
+        </placement>
+        <placement code="p9">
+          <bundle>ca_entity_labels.surname</bundle>
+        </placement>
+        <placement code="p10">
+          <bundle>ca_entities.idno</bundle>
+        </placement>
+        <placement code="p11">
+          <bundle>ca_entities.type_id</bundle>
+        </placement>
+        <placement code="p12">
+          <bundle>ca_entities.access</bundle>
+        </placement>
+        <placement code="p13">
+          <bundle>ca_entities.status</bundle>
+        </placement>
+      </bundlePlacements>
+    </searchForm>
+    <searchForm code="ca_places_adv_search" type="ca_places" system="1">
+      <labels>
+        <label locale="en_US">
+          <name>Extended search</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="form_width">3</setting>
+      </settings>
+      <groupAccess>
+        <permission group="admin" access="edit" />
+      </groupAccess>
+      <bundlePlacements>
+        <placement code="p14">
+          <bundle>ca_place_labels.name</bundle>
+        </placement>
+        <placement code="p15">
+          <bundle>ca_places.idno</bundle>
+        </placement>
+        <placement code="p16">
+          <bundle>ca_places.type_id</bundle>
+        </placement>
+        <placement code="p17">
+          <bundle>ca_places.access</bundle>
+        </placement>
+        <placement code="p18">
+          <bundle>ca_places.status</bundle>
+        </placement>
+      </bundlePlacements>
+    </searchForm>
+    <searchForm code="ca_occurrences_adv_search" type="ca_occurrences" system="1">
+      <labels>
+        <label locale="en_US">
+          <name>Extended search</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="form_width">3</setting>
+      </settings>
+      <groupAccess>
+        <permission group="admin" access="edit" />
+      </groupAccess>
+      <bundlePlacements>
+        <placement code="p19">
+          <bundle>ca_occurrence_labels.name</bundle>
+          <settings>
+            <setting name="label" locale="en_US">Title</setting>
+          </settings>
+        </placement>
+        <placement code="p20">
+          <bundle>ca_occurrences.idno</bundle>
+        </placement>
+      </bundlePlacements>
+    </searchForm>
+    <searchForm code="ca_collections_adv_search" type="ca_collections" system="1">
+      <labels>
+        <label locale="en_US">
+          <name>Extended search</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="form_width">3</setting>
+      </settings>
+      <groupAccess>
+        <permission group="admin" access="edit" />
+      </groupAccess>
+      <bundlePlacements>
+        <placement code="p23">
+          <bundle>ca_collection_labels.name</bundle>
+        </placement>
+        <placement code="p24">
+          <bundle>ca_collections.idno</bundle>
+        </placement>
+        <placement code="p25">
+          <bundle>ca_collections.type_id</bundle>
+        </placement>
+        <placement code="p26">
+          <bundle>ca_collections.access</bundle>
+        </placement>
+        <placement code="p27">
+          <bundle>ca_collections.status</bundle>
+        </placement>
+      </bundlePlacements>
+    </searchForm>
+    <searchForm code="ca_storage_locations_adv_search" type="ca_storage_locations" system="1">
+      <labels>
+        <label locale="en_US">
+          <name>Extended search</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="form_width">3</setting>
+      </settings>
+      <groupAccess>
+        <permission group="admin" access="edit" />
+      </groupAccess>
+      <bundlePlacements>
+        <placement code="p28">
+          <bundle>ca_storage_location_labels.name</bundle>
+        </placement>
+        <placement code="p29">
+          <bundle>ca_storage_locations.type_id</bundle>
+        </placement>
+      </bundlePlacements>
+    </searchForm>
+    <searchForm code="ca_loans_adv_search" type="ca_loans" system="1">
+      <labels>
+        <label locale="en_US">
+          <name>Extended search</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="form_width">3</setting>
+      </settings>
+      <groupAccess>
+        <permission group="admin" access="edit" />
+      </groupAccess>
+      <bundlePlacements>
+        <placement code="p30">
+          <bundle>ca_loan_labels.name</bundle>
+        </placement>
+        <placement code="p31">
+          <bundle>ca_loans.type_id</bundle>
+        </placement>
+        <placement code="p32">
+          <bundle>ca_loans.idno</bundle>
+        </placement>
+      </bundlePlacements>
+    </searchForm>
+    <searchForm code="acq_advanced_search" type="ca_object_lots" system="1">
+      <labels>
+        <label locale="en_US">
+          <name>Acquisitions Advanced Search</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="form_width">3</setting>
+      </settings>
+      <userAccess>
+        <permission user="thelmaross" access="edit" />
+      </userAccess>
+      <bundlePlacements>
+        <placement code="p33">
+          <bundle>created</bundle>
+        </placement>
+        <placement code="p34">
+          <bundle>_fulltext</bundle>
+        </placement>
+        <placement code="p35">
+          <bundle>_generic</bundle>
+        </placement>
+        <placement code="p36">
+          <bundle>modified</bundle>
+        </placement>
+        <placement code="p37">
+          <bundle>ca_object_lots.lot_status_id</bundle>
+        </placement>
+        <placement code="p38">
+          <bundle>ca_objects.idno</bundle>
+        </placement>
+        <placement code="p39">
+          <bundle>ca_object_lots.acquisition_date</bundle>
+        </placement>
+        <placement code="p40">
+          <bundle>ca_object_lots.idno_stub</bundle>
+        </placement>
+      </bundlePlacements>
+    </searchForm>
+  </searchForms>
+</profile>

--- a/ucla_providence/install/profiles/xml/ucla_ftva.xml
+++ b/ucla_providence/install/profiles/xml/ucla_ftva.xml
@@ -1,0 +1,18811 @@
+<?xml version="1.0" encoding="utf-8"?>
+<profile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="profile.xsd" useForConfiguration="1" infoUrl="">
+  <profileName>UCLA FTVA</profileName>
+  <profileDescription>CollectiveAccess Providence installation profile for UCLA Film and Television Archive. Based on PBCore 2.1.</profileDescription>
+  <locales>
+    <locale lang="en" country="US">English</locale>
+    <locale lang="en" country="CA" dontUseForCataloguing="1">English (Canadian)</locale>
+    <locale lang="en" country="AU" dontUseForCataloguing="1">English (Australian)</locale>
+    <locale lang="en" country="UK" dontUseForCataloguing="1">English (UK)</locale>
+    <locale lang="de" country="DE" dontUseForCataloguing="1">Deutsch (Deutschland)</locale>
+    <locale lang="de" country="AT" dontUseForCataloguing="1">Deutsch (Österreich)</locale>
+    <locale lang="fr" country="FR" dontUseForCataloguing="1">Français</locale>
+    <locale lang="fr" country="CA" dontUseForCataloguing="1">Français (Canadien)</locale>
+    <locale lang="cs" country="CZ" dontUseForCataloguing="1">Czech</locale>
+    <locale lang="es" country="ES" dontUseForCataloguing="1">Español</locale>
+    <locale lang="it" country="IT" dontUseForCataloguing="1">Italiano</locale>
+    <locale lang="nl" country="NL" dontUseForCataloguing="1">Nederlands</locale>
+    <locale lang="sv" country="SE" dontUseForCataloguing="1">Svenska</locale>
+  </locales>
+  <lists>
+    <list code="list_item_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>List item types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="concept" enabled="1" default="1" access="0" value="concept" rank="2">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>concept</name_singular>
+              <name_plural>concepts</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="facet" enabled="1" default="0" access="0" value="facet" rank="3">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>facet</name_singular>
+              <name_plural>facets</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="guide_term" enabled="1" default="0" access="0" value="guide_term" rank="4">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>guide term</name_singular>
+              <name_plural>guide terms</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="hierarchy_name" enabled="1" default="0" access="0" value="hierarchy_name"
+          rank="5">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>hierarchy name</name_singular>
+              <name_plural>hierarchy names</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="list_item_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>List item sources</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="local" enabled="1" default="0" access="0" value="local" rank="7">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Local</name_singular>
+              <name_plural>Local</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="list_item_label_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>List item label types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="uf" enabled="1" default="1" access="0" value="uf" rank="9">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Use for</name_singular>
+              <name_plural>Use for</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="alt" enabled="1" default="0" access="0" value="alt" rank="10">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Alternate</name_singular>
+              <name_plural>Alternate</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="set_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Set types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="user" enabled="1" default="0" access="0" value="user" rank="12">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>User set</name_singular>
+              <name_plural>User sets</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="public_presentation" enabled="1" default="1" access="0"
+          value="public_presentation" rank="13">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Public presentation</name_singular>
+              <name_plural>Public presentations</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="set_presentation_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Set presentation types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="slideshow" enabled="1" default="1" access="0" value="slideshow" rank="15">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Slideshow</name_singular>
+              <name_plural>Slideshows</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="thumbnail_image_list" enabled="1" default="0" access="0"
+          value="thumbnail_image_list" rank="16">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Thumbnail image list</name_singular>
+              <name_plural>Thumbnail image lists</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="title_list" enabled="1" default="0" access="0" value="title_list" rank="17">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Title list</name_singular>
+              <name_plural>Title lists</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="chronology" enabled="1" default="0" access="0" value="chronology" rank="18">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Chronology</name_singular>
+              <name_plural>Chronologies</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="set_item_is_primary" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Set item primary status types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="is_primary" enabled="1" default="0" access="0" value="is_primary" rank="20">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Is primary</name_singular>
+              <name_plural>Is primary</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="is_not_primary" enabled="1" default="1" access="0" value="is_not_primary"
+          rank="21">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Is not primary</name_singular>
+              <name_plural>Is not primary</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_types" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Object Types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="audio" enabled="0" default="0" access="0" value="audio" rank="23">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio</name_singular>
+              <name_plural>Audio</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="audio_analog" enabled="1" default="0" access="0" value="audio_analog"
+              rank="24">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Analog Audio</name_singular>
+                  <name_plural>Analog Audio</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="audio_digital" enabled="1" default="0" access="0" value="audio_digital"
+              rank="25">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Digital Audio</name_singular>
+                  <name_plural>Digital Audio</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="moving_image" enabled="0" default="0" access="0" value="moving_image" rank="26">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Moving Image</name_singular>
+              <name_plural>Moving Images</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="moving_analog" enabled="1" default="0" access="0" value="moving_analog"
+              rank="27">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Analog Moving Image</name_singular>
+                  <name_plural>Analog Moving Images</name_plural>
+                  <description />
+                </label>
+              </labels>
+              <items>
+                <item idno="moving_component" enabled="1" default="0" access="0" rank="448"
+                  type="concept">
+                  <labels>
+                    <label locale="en_US" preferred="1">
+                      <name_singular>AMI component</name_singular>
+                      <name_plural>AMI components</name_plural>
+                      <description>Analog Moving Image component</description>
+                    </label>
+                  </labels>
+                </item>
+              </items>
+            </item>
+            <item idno="moving_digital" enabled="1" default="0" access="0" value="moving_digital"
+              rank="28">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Digital Moving Image</name_singular>
+                  <name_plural>Digital Moving Images</name_plural>
+                  <description />
+                </label>
+              </labels>
+              <settings>
+                <setting name="show_source_for_preferred_labels">0</setting>
+                <setting name="show_source_for_nonpreferred_labels">0</setting>
+                <setting name="render_in_new_menu">1</setting>
+              </settings>
+              <items>
+                <item idno="moving_component_2" enabled="1" default="0" access="0" rank="449"
+                  type="concept">
+                  <labels>
+                    <label locale="en_US" preferred="1">
+                      <name_singular>DMI component</name_singular>
+                      <name_plural>DMI components</name_plural>
+                      <description>Digital Moving Image component</description>
+                    </label>
+                  </labels>
+                </item>
+              </items>
+            </item>
+          </items>
+        </item>
+      </items>
+    </list>
+    <list code="object_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object Source</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="internal" enabled="1" default="1" access="0" value="internal" rank="30">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Our collection</name_singular>
+              <name_plural>Our collections</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="external" enabled="1" default="0" access="0" value="external" rank="31">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>External collection</name_singular>
+              <name_plural>External collections</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_statuses" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object statuses</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="pending_accession" enabled="1" default="1" access="0" value="pending_accession"
+          rank="33">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>pending accession</name_singular>
+              <name_plural>pending accession</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="accessioned" enabled="1" default="0" access="0" value="accessioned" rank="34">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>accessioned</name_singular>
+              <name_plural>accessioned</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="non_accessioned" enabled="1" default="0" access="0" value="non_accessioned"
+          rank="35">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>non-accessioned</name_singular>
+              <name_plural>non-accessioned</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="potential_acquisition" enabled="1" default="0" access="0"
+          value="potential_acquisition" rank="36">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>potential acquisition</name_singular>
+              <name_plural>potential acquisitions</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_deaccession_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object deaccession types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="disposed" enabled="1" default="1" access="0" value="disposed" rank="38">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>disposed</name_singular>
+              <name_plural>disposed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_acq_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object acquisition types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="gift" enabled="1" default="1" access="0" value="gift" rank="40">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>gift</name_singular>
+              <name_plural>gifts</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="bequest" enabled="1" default="0" access="0" value="bequest" rank="41">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>bequest</name_singular>
+              <name_plural>bequests</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="purchase" enabled="1" default="0" access="0" value="purchase" rank="42">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>purchase</name_singular>
+              <name_plural>purchases</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="loan" enabled="1" default="0" access="0" value="loan" rank="43">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>loan</name_singular>
+              <name_plural>loans</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="long_term_loan" enabled="1" default="0" access="0" value="long_term_loan"
+          rank="44">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>long-term loan</name_singular>
+              <name_plural>long-term loans</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_label_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object label types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="uf" enabled="1" default="0" access="0" value="uf" rank="46">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>use for</name_singular>
+              <name_plural>use for</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="alt" enabled="1" default="1" access="0" value="alt" rank="47">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>alternate</name_singular>
+              <name_plural>alternates</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="workflow_statuses" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object workflow statuses</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="new" enabled="1" default="1" access="0" value="0" rank="49">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>new</name_singular>
+              <name_plural>new</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="editing_in_progress" enabled="1" default="0" access="0" value="1" rank="50">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>editing in progress</name_singular>
+              <name_plural>editing in progress</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="editing_complete" enabled="1" default="0" access="0" value="2" rank="51">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>editing complete</name_singular>
+              <name_plural>editing complete</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="review_in_progress" enabled="1" default="0" access="0" value="3" rank="52">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>review in progress</name_singular>
+              <name_plural>review in progress</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="completed" enabled="1" default="0" access="0" value="4" rank="53">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>completed</name_singular>
+              <name_plural>completed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="access_statuses" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object access statuses</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="internal_only" enabled="1" default="1" access="0" value="0" rank="55">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>not accessible to public</name_singular>
+              <name_plural>not accessible to public</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="restricted_public_access" enabled="1" default="0" access="0" value="2" rank="56">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>restricted public access</name_singular>
+              <name_plural>restricted public access</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="public_access" enabled="1" default="0" access="0" value="1" rank="57">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>accessible to public</name_singular>
+              <name_plural>accessible to public</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="not_available_for_projection" enabled="1" default="0" access="0"
+          value="not_available_for_projection" rank="454" type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>not available for projection</name_singular>
+              <name_plural>not available for projection</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="projection_only" enabled="1" default="0" access="0" value="projection_only"
+          rank="455" type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>projection only</name_singular>
+              <name_plural>projection only</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="viewing_only" enabled="1" default="0" access="0" value="viewing_only" rank="456"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>viewing only</name_singular>
+              <name_plural>viewing only</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_circulation_statuses" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object circulation statuses</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="available" enabled="1" default="1" access="0" value="available" rank="59">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Available</name_singular>
+              <name_plural>Available</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="in_library" enabled="1" default="0" access="0" value="in_library" rank="60">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>In-library use only</name_singular>
+              <name_plural>In-library use only</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="unavailable" enabled="1" default="0" access="0" value="unavailable" rank="61">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Unavailable</name_singular>
+              <name_plural>Unavailable</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_lot_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object lot types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="gift" enabled="1" default="1" access="0" value="gift" rank="63">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>gift</name_singular>
+              <name_plural>gifts</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="restricted_gift" enabled="1" default="0" access="0" value="restricted_gift"
+          rank="64">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>restricted gift</name_singular>
+              <name_plural>restricted gift</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="bequest" enabled="1" default="0" access="0" value="bequest" rank="65">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>bequest</name_singular>
+              <name_plural>bequests</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="purchase" enabled="1" default="0" access="0" value="purchase" rank="66">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>purchase</name_singular>
+              <name_plural>purchases</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="loan" enabled="1" default="0" access="0" value="loan" rank="67">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>loan</name_singular>
+              <name_plural>loans</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="long_term_loan" enabled="1" default="0" access="0" value="long_term_loan"
+          rank="68">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>long-term loan</name_singular>
+              <name_plural>long-term loans</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_lot_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object lot sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="object_lot_statuses" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object lot statuses</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="pending_accession" enabled="1" default="1" access="0" value="pending_accession"
+          rank="71">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>pending accession</name_singular>
+              <name_plural>pending accession</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="accessioned" enabled="1" default="0" access="0" value="accessioned" rank="72">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>accessioned</name_singular>
+              <name_plural>accessioned</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="non_accessioned" enabled="1" default="0" access="0" value="non_accessioned"
+          rank="73">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>non-accessioned</name_singular>
+              <name_plural>non-accessioned</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="potential_acquisition" enabled="1" default="0" access="0"
+          value="potential_acquisition" rank="74">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>potential acquisition</name_singular>
+              <name_plural>potential acquisitions</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_lot_label_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object lot label type values</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="uf" enabled="1" default="0" access="0" value="uf" rank="76">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>use for</name_singular>
+              <name_plural>use for</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="alt" enabled="1" default="1" access="0" value="alt" rank="77">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>alternate</name_singular>
+              <name_plural>alternates</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="loan_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Loan types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="in" enabled="1" default="0" access="0" value="in" rank="79">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>loan in</name_singular>
+              <name_plural>loans in</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="out" enabled="1" default="1" access="0" value="out" rank="80">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>loan out</name_singular>
+              <name_plural>loans out</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="loan_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Loan sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="movement_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Movement type values</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="movement" enabled="1" default="1" access="0" value="movement" rank="83">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Movement</name_singular>
+              <name_plural>Movements</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="movement_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Movement sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="entity_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Entity types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="individual" enabled="1" default="1" access="0" value="individual" rank="86">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>individual</name_singular>
+              <name_plural>individuals</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="organization" enabled="1" default="0" access="0" value="organization" rank="87">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>organization</name_singular>
+              <name_plural>organizations</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="family" enabled="1" default="0" access="0" value="family" rank="88">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>family</name_singular>
+              <name_plural>families</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="entity_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Entity sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="entity_label_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Entity label types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="uf" enabled="1" default="0" access="0" value="uf" rank="91">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>use for</name_singular>
+              <name_plural>use for</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="alt" enabled="1" default="1" access="0" value="alt" rank="92">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>alternate</name_singular>
+              <name_plural>alternates</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="place_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Place types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="continent" enabled="1" default="0" access="0" value="continent" rank="94">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>continent</name_singular>
+              <name_plural>continents</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="country" enabled="1" default="1" access="0" value="country" rank="95">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>country</name_singular>
+              <name_plural>countries</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="state" enabled="1" default="0" access="0" value="state" rank="96">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>state/province</name_singular>
+              <name_plural>state/province</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="city" enabled="1" default="0" access="0" value="city" rank="97">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>city</name_singular>
+              <name_plural>cities</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="county" enabled="1" default="0" access="0" value="county" rank="98">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>county</name_singular>
+              <name_plural>counties</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="neighborhood" enabled="1" default="0" access="0" value="neighborhood" rank="99">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>neighborhood</name_singular>
+              <name_plural>neighborhoods</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="location" enabled="1" default="0" access="0" value="location" rank="100">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>location</name_singular>
+              <name_plural>locations</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="river" enabled="1" default="0" access="0" value="river" rank="101">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>river</name_singular>
+              <name_plural>rivers</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="socken" enabled="1" default="0" access="0" value="socken" rank="102">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>parish</name_singular>
+              <name_plural>parishes</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="other" enabled="1" default="0" access="0" value="other" rank="103">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>other feature</name_singular>
+              <name_plural>other features</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="place_label_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Place label type values</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="uf" enabled="1" default="0" access="0" value="uf" rank="105">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>use for</name_singular>
+              <name_plural>use for</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="alt" enabled="1" default="1" access="0" value="alt" rank="106">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>alternate</name_singular>
+              <name_plural>alternates</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="place_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Place sources</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="pbcore" enabled="1" default="1" access="0" value="pbcore" rank="108">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Coverage</name_singular>
+              <name_plural>Coverage</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="occurrence_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Occurrence Types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="intellectual_content" enabled="1" default="1" access="0"
+          value="intellectual_content" rank="110">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Intellectual Content</name_singular>
+              <name_plural>Intellectual Content</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="occurrence_label_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Occurrence label types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="uf" enabled="1" default="0" access="0" value="uf" rank="112">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>use for</name_singular>
+              <name_plural>use for</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="alt" enabled="1" default="1" access="0" value="alt" rank="113">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>alternate</name_singular>
+              <name_plural>alternates</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="occurrence_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Occurrence sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="collection_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Collection types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="local" enabled="1" default="1" access="0" value="local" rank="116">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Local collection</name_singular>
+              <name_plural>Local collections</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="external" enabled="1" default="0" access="0" value="external" rank="117">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>External collection</name_singular>
+              <name_plural>External collections</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="collection_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Collection sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="collection_label_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Collection label types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="uf" enabled="1" default="0" access="0" value="uf" rank="120">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>use for</name_singular>
+              <name_plural>use for</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="alt" enabled="1" default="1" access="0" value="alt" rank="121">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>alternate</name_singular>
+              <name_plural>alternates</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="storage_location_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Storage location types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="campus" enabled="1" default="1" access="0" value="campus" rank="123">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>campus</name_singular>
+              <name_plural>campuses</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="building" enabled="1" default="0" access="0" value="building" rank="124">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>building</name_singular>
+              <name_plural>buildings</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="floor" enabled="1" default="0" access="0" value="floor" rank="125">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>floor</name_singular>
+              <name_plural>floors</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="room" enabled="1" default="0" access="0" value="room" rank="126">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>room</name_singular>
+              <name_plural>rooms</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="cabinet" enabled="1" default="0" access="0" value="cabinet" rank="127">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>cabinet</name_singular>
+              <name_plural>cabinets</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="drawer" enabled="1" default="0" access="0" value="drawer" rank="128">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>drawer</name_singular>
+              <name_plural>drawers</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="shelf" enabled="1" default="0" access="0" value="shelf" rank="129">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>shelf</name_singular>
+              <name_plural>shelves</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="vault" enabled="1" default="0" access="0" rank="463" type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>vault</name_singular>
+              <name_plural>vaults</name_plural>
+              <description />
+            </label>
+          </labels>
+          <settings>
+            <setting name="show_source_for_preferred_labels">0</setting>
+            <setting name="show_source_for_nonpreferred_labels">0</setting>
+            <setting name="render_in_new_menu">1</setting>
+          </settings>
+        </item>
+        <item idno="column" enabled="1" default="0" access="0" rank="464" type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>column</name_singular>
+              <name_plural>columns</name_plural>
+              <description />
+            </label>
+          </labels>
+          <settings>
+            <setting name="show_source_for_preferred_labels">0</setting>
+            <setting name="show_source_for_nonpreferred_labels">0</setting>
+            <setting name="render_in_new_menu">1</setting>
+          </settings>
+        </item>
+      </items>
+    </list>
+    <list code="storage_location_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Storage location sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="storage_location_label_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Storage location label type values</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="uf" enabled="1" default="0" access="0" value="uf" rank="132">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>use for</name_singular>
+              <name_plural>use for</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="alt" enabled="1" default="1" access="0" value="alt" rank="133">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>alternate</name_singular>
+              <name_plural>alternates</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_representation_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object representation types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="front" enabled="1" default="1" access="0" value="front" rank="135">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>front</name_singular>
+              <name_plural>front</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="back" enabled="1" default="0" access="0" value="back" rank="136">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>back</name_singular>
+              <name_plural>back</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_representation_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Object representation sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="tour_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Tour types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="full_length" enabled="1" default="0" access="0" value="full_length" rank="139">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>full tour</name_singular>
+              <name_plural>full tours</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="short" enabled="1" default="0" access="0" value="short" rank="140">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>short tour</name_singular>
+              <name_plural>short tours</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="tour_sources" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Tour sources</name>
+        </label>
+      </labels>
+    </list>
+    <list code="tour_stop_types" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Tour stop types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="primary" enabled="1" default="0" access="0" value="primary" rank="143">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>primary stop</name_singular>
+              <name_plural>primary stops</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="secondary" enabled="1" default="0" access="0" value="secondary" rank="144">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>optional stop</name_singular>
+              <name_plural>optional stops</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="subjects_list" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Subject list</name>
+        </label>
+      </labels>
+    </list>
+    <list code="place_hierarchies" hierarchical="1" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Place hierarchies</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="pbcore" enabled="1" default="1" access="0" value="pbcore" rank="147">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>PBCore Coverage Authority</name_singular>
+              <name_plural>PBCore Coverage Authority</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="pbcore_title_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Title Types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1" access="0" value="option0" rank="149">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="150">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Album</name_singular>
+              <name_plural>Albums</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="151">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Collection</name_singular>
+              <name_plural>Collection</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="152">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Series</name_singular>
+              <name_plural>Series</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="153">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Episode</name_singular>
+              <name_plural>Episode</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="154">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Program</name_singular>
+              <name_plural>Program</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="155">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Segment</name_singular>
+              <name_plural>Segment</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option7" enabled="1" default="0" access="0" value="option7" rank="156">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Clip</name_singular>
+              <name_plural>Clip</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option8" enabled="1" default="0" access="0" value="option8" rank="157">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Miniseries</name_singular>
+              <name_plural>Miniseries</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option9" enabled="1" default="0" access="0" value="option9" rank="158">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Subseries</name_singular>
+              <name_plural>Subseries</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="pbcore_coverage_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Coverage Type</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="spatial" enabled="1" default="0" access="0" value="spatial" rank="160">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Spatial</name_singular>
+              <name_plural>Spatial</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="temporal" enabled="1" default="1" access="0" value="temporal" rank="161">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Temporal</name_singular>
+              <name_plural>Temporal</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="pbcore_description_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Description Type</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="none" enabled="1" default="1" access="0" value="none" rank="163">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="abstract" enabled="1" default="0" access="0" value="abstract" rank="164">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Abstract</name_singular>
+              <name_plural>Abstract</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="awards" enabled="1" default="0" access="0" value="awards" rank="165">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Awards</name_singular>
+              <name_plural>Awards</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="chapter" enabled="1" default="0" access="0" value="chapter" rank="166">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Chapter</name_singular>
+              <name_plural>Chapter</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="collection" enabled="1" default="0" access="0" value="collection" rank="167">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Collection</name_singular>
+              <name_plural>Collection</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="comments" enabled="1" default="0" access="0" value="comments" rank="168">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Comments</name_singular>
+              <name_plural>Comments</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="description" enabled="1" default="0" access="0" value="description" rank="169">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Description</name_singular>
+              <name_plural>Description</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="episode" enabled="1" default="0" access="0" value="episode" rank="170">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Episode Description</name_singular>
+              <name_plural>Episode Description</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="event" enabled="1" default="0" access="0" value="event" rank="171">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Event</name_singular>
+              <name_plural>Event</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="excerpt" enabled="1" default="0" access="0" value="excerpt" rank="172">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Excerpt</name_singular>
+              <name_plural>Excerpt</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="item" enabled="1" default="0" access="0" value="item" rank="173">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Item</name_singular>
+              <name_plural>Item</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="movement" enabled="1" default="0" access="0" value="movement" rank="174">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Movement</name_singular>
+              <name_plural>Movement</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="number" enabled="1" default="0" access="0" value="number" rank="175">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Number</name_singular>
+              <name_plural>Number</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="playlist" enabled="1" default="0" access="0" value="playlist" rank="176">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Playlist</name_singular>
+              <name_plural>Playlist</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="program" enabled="1" default="0" access="0" value="program" rank="177">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Program</name_singular>
+              <name_plural>Program</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="reviews" enabled="1" default="0" access="0" value="reviews" rank="178">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Reviews</name_singular>
+              <name_plural>Reviews</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="rundown" enabled="1" default="0" access="0" value="rundown" rank="179">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Rundown</name_singular>
+              <name_plural>Rundown</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="script" enabled="1" default="0" access="0" value="script" rank="180">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Script</name_singular>
+              <name_plural>Script</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="segment" enabled="1" default="0" access="0" value="segment" rank="181">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Segment</name_singular>
+              <name_plural>Segment</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="series" enabled="1" default="0" access="0" value="series" rank="182">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Series</name_singular>
+              <name_plural>Series</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="shotlist" enabled="1" default="0" access="0" value="shotlist" rank="183">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Shot List</name_singular>
+              <name_plural>Shot List</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="song" enabled="1" default="0" access="0" value="song" rank="184">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Song</name_singular>
+              <name_plural>Song</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="story" enabled="1" default="0" access="0" value="story" rank="185">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Story</name_singular>
+              <name_plural>Story</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="summary" enabled="1" default="0" access="0" value="summary" rank="186">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Summary</name_singular>
+              <name_plural>Summary</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="transcript" enabled="1" default="0" access="0" value="transcript" rank="187">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Transcript</name_singular>
+              <name_plural>Transcript</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="pbcore_relation_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Relation Type</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="189">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="1" access="0" value="option1" rank="190">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Has Format</name_singular>
+              <name_plural>Has Format</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="191">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Is Format Of</name_singular>
+              <name_plural>Is Format Of</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="192">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Has Part</name_singular>
+              <name_plural>Has Part</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="193">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Is Part Of</name_singular>
+              <name_plural>Is Part Of</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="194">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Has Version</name_singular>
+              <name_plural>Has Version</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="195">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Is Version Of</name_singular>
+              <name_plural>Is Version Of</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option7" enabled="1" default="0" access="0" value="option7" rank="196">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>References</name_singular>
+              <name_plural>References</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option8" enabled="1" default="0" access="0" value="option8" rank="197">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Is Referenced By</name_singular>
+              <name_plural>Is Referenced By</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option9" enabled="1" default="0" access="0" value="option9" rank="198">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Has Derivative</name_singular>
+              <name_plural>Derived From</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="instantiation_physical_types_moving" hierarchical="0" system="0" vocabulary="0"
+      defaultSort="1">
+      <labels>
+        <label locale="en_US">
+          <name>Physical Formats For Moving Images</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1" access="0" value="option0" rank="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="film_types" enabled="0" default="0" access="0" value="film_types" rank="2">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>FILM</name_singular>
+              <name_plural>FILM</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="3">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Film</name_singular>
+                  <name_plural>Film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="4">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>8mm film</name_singular>
+                  <name_plural>8mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="5">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>9.5mm film</name_singular>
+                  <name_plural>9.5mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="6">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Super 8mm film</name_singular>
+                  <name_plural>Super 8mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="7">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>16mm film</name_singular>
+                  <name_plural>16mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option7" enabled="1" default="0" access="0" value="option7" rank="8">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Super 16mm film</name_singular>
+                  <name_plural>Super 16mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option8" enabled="1" default="0" access="0" value="option8" rank="9">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>22mm film</name_singular>
+                  <name_plural>22mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option9" enabled="1" default="0" access="0" value="option9" rank="10">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>28mm film</name_singular>
+                  <name_plural>28mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option10" enabled="1" default="0" access="0" value="option10" rank="11">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>35mm film</name_singular>
+                  <name_plural>35mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option11" enabled="1" default="0" access="0" value="option11" rank="12">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>70mm film</name_singular>
+                  <name_plural>70mm film</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="video_types" enabled="0" default="0" access="0" value="video_types" rank="13">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>VIDEO</name_singular>
+              <name_plural>VIDEO</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="videocassette" enabled="1" default="0" access="0" value="videocassette"
+              rank="14">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Videocassette</name_singular>
+                  <name_plural>Videocassette</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="open_reel_videotape" enabled="1" default="0" access="0"
+              value="open_reel_videotape" rank="15">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Open reel videotape</name_singular>
+                  <name_plural>Open reel videotape</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="optical_video_disc" enabled="1" default="0" access="0"
+              value="optical_video_disc" rank="16">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Optical video disc</name_singular>
+                  <name_plural>Optical video disc</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape" enabled="1" default="0" access="0"
+              value="one_inch_videotape" rank="17">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape</name_singular>
+                  <name_plural>1 inch videotape</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_1" enabled="1" default="0" access="0"
+              value="one_inch_videotape_1" rank="18">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: MVC-10</name_singular>
+                  <name_plural>1 inch videotape: MVC-10</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_2" enabled="1" default="0" access="0"
+              value="one_inch_videotape_2" rank="19">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: PI-3V</name_singular>
+                  <name_plural>1 inch videotape: PI-3V</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_3" enabled="1" default="0" access="0"
+              value="one_inch_videotape_3" rank="20">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: EV-200</name_singular>
+                  <name_plural>1 inch videotape: EV-200</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_4" enabled="1" default="0" access="0"
+              value="one_inch_videotape_4" rank="21">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: EL-3400</name_singular>
+                  <name_plural>1 inch videotape: EL-3400</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_5" enabled="1" default="0" access="0"
+              value="one_inch_videotape_5" rank="22">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: IVC-700</name_singular>
+                  <name_plural>1 inch videotape: IVC-700</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_6" enabled="1" default="0" access="0"
+              value="one_inch_videotape_6" rank="23">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: IVC-800</name_singular>
+                  <name_plural>1 inch videotape: IVC-800</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_7" enabled="1" default="0" access="0"
+              value="one_inch_videotape_7" rank="24">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: IVC-900</name_singular>
+                  <name_plural>1 inch videotape: IVC-900</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_8" enabled="1" default="0" access="0"
+              value="one_inch_videotape_8" rank="25">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: UV-340</name_singular>
+                  <name_plural>1 inch videotape: UV-340</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_9" enabled="1" default="0" access="0"
+              value="one_inch_videotape_9" rank="26">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: EV-210</name_singular>
+                  <name_plural>1 inch videotape: EV-210</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_10" enabled="1" default="0" access="0"
+              value="one_inch_videotape_10" rank="27">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: SMPTE Type A</name_singular>
+                  <name_plural>1 inch videotape: SMPTE Type A</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_11" enabled="1" default="0" access="0"
+              value="one_inch_videotape_11" rank="28">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: SMPTE Type B</name_singular>
+                  <name_plural>1 inch videotape: SMPTE Type B</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_12" enabled="1" default="0" access="0"
+              value="one_inch_videotape_12" rank="29">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: SMPTE Type C</name_singular>
+                  <name_plural>1 inch videotape: SMPTE Type C</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_13" enabled="1" default="0" access="0"
+              value="one_inch_videotape_13" rank="30">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: BVH-1000</name_singular>
+                  <name_plural>1 inch videotape: BVH-100</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_14" enabled="1" default="0" access="0"
+              value="one_inch_videotape_14" rank="31">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: HDV-1000</name_singular>
+                  <name_plural>1 inch videotape: HDV-1000</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="one_inch_videotape_15" enabled="1" default="0" access="0"
+              value="one_inch_videotape_15" rank="32">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1 inch videotape: HDD-1000</name_singular>
+                  <name_plural>2 inch videotape: HDD-1000</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape" enabled="1" default="0" access="0"
+              value="half_inch_videotape" rank="33">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape</name_singular>
+                  <name_plural>1/2 inch videotape</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_1" enabled="1" default="0" access="0"
+              value="half_inch_videotape_1" rank="34">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: CV</name_singular>
+                  <name_plural>1/2 inch videotape: CV</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_2" enabled="1" default="0" access="0"
+              value="half_inch_videotape_2" rank="35">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: EIAJ Type 1</name_singular>
+                  <name_plural>1/2 inch videotape: EIAJ Type 1</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_3" enabled="1" default="0" access="0"
+              value="half_inch_videotape_3" rank="11">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: Hawkeye</name_singular>
+                  <name_plural>1/2 inch videotape: Hawkeye</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_4" enabled="1" default="0" access="0"
+              value="half_inch_videotape_4" rank="36">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: Recam</name_singular>
+                  <name_plural>1/2 inch videotape: Recam</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_5" enabled="1" default="0" access="0"
+              value="half_inch_videotape_5" rank="37">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: V200</name_singular>
+                  <name_plural>1/2 inch videotape: V200</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="half_inch_videotape_6" enabled="1" default="0" access="0"
+              value="half_inch_videotape_6" rank="38">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/2 inch videotape: VCR</name_singular>
+                  <name_plural>1/2 inch videotape: VCR</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="quarter_inch_videotape" enabled="1" default="0" access="0"
+              value="quarter_inch_videotape" rank="39">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1/4 inch videotape</name_singular>
+                  <name_plural>1/4 inch videotape</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape" enabled="1" default="0" access="0"
+              value="two_inch_videotape" rank="40">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape</name_singular>
+                  <name_plural>2 inch videotape</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_1" enabled="1" default="0" access="0"
+              value="two_inch_videotape_1" rank="41">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: Quadruplex</name_singular>
+                  <name_plural>2 inch videotape: Quadruplex</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_2" enabled="1" default="0" access="0"
+              value="two_inch_videotape_2" rank="42">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: Octaplex</name_singular>
+                  <name_plural>2 inch videotape: Octaplex</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_3" enabled="1" default="0" access="0"
+              value="two_inch_videotape_3" rank="43">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: VR-1500</name_singular>
+                  <name_plural>2 inch videotape: VR-1500</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_4" enabled="1" default="0" access="0"
+              value="two_inch_videotape_4" rank="44">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: VR-1600</name_singular>
+                  <name_plural>2 inch videotape: VR-1600</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_5" enabled="1" default="0" access="0"
+              value="two_inch_videotape_5" rank="45">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: IVC-9000</name_singular>
+                  <name_plural>2 inch videotape: IVC-9000</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_6" enabled="1" default="0" access="0"
+              value="two_inch_videotape_6" rank="46">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: Helical SV-201</name_singular>
+                  <name_plural>2 inch videotape: Helical SV-201</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="two_inch_videotape_7" enabled="1" default="0" access="0"
+              value="two_inch_videotape_7" rank="47">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>2 inch videotape: ACR 25</name_singular>
+                  <name_plural>2 inch videotape: ACR 25</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="betacam" enabled="1" default="0" access="0" value="betacam" rank="48">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betacam</name_singular>
+                  <name_plural>Betacam</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="betacam_1" enabled="1" default="0" access="0" value="betacam_1" rank="49">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betacam: SP</name_singular>
+                  <name_plural>Betacam: SP</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="betamax" enabled="1" default="0" access="0" value="betamax" rank="50">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betamax</name_singular>
+                  <name_plural>Betamax</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="betamax_1" enabled="1" default="0" access="0" value="betamax_1" rank="51">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betamax: Hi-Fi</name_singular>
+                  <name_plural>Betamax: Hi-Fi</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="betamax_2" enabled="1" default="0" access="0" value="betamax_2" rank="52">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betamax: ED</name_singular>
+                  <name_plural>Betamax: ED</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="betamax_3" enabled="1" default="0" access="0" value="betamax_3" rank="53">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Betamax: Super</name_singular>
+                  <name_plural>Betamax: Super</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="blu_ray_disc" enabled="1" default="0" access="0" value="blu_ray_disc"
+              rank="54">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Blu-ray disc</name_singular>
+                  <name_plural>Blu-ray disc</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="catrivision" enabled="1" default="0" access="0" value="catrivision"
+              rank="12">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Catrivision</name_singular>
+                  <name_plural>Catrivision</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="d1" enabled="1" default="0" access="0" value="d1" rank="55">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D1</name_singular>
+                  <name_plural>D1</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="d2" enabled="1" default="0" access="0" value="d2" rank="56">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D2</name_singular>
+                  <name_plural>D2</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="d3" enabled="1" default="0" access="0" value="d3" rank="57">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D3</name_singular>
+                  <name_plural>D3</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="d5" enabled="1" default="0" access="0" value="d5" rank="58">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D5</name_singular>
+                  <name_plural>D5</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="d5_1" enabled="1" default="0" access="0" value="d5_1" rank="59">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D5: HD</name_singular>
+                  <name_plural>D5: HD</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="d6" enabled="1" default="0" access="0" value="d6" rank="60">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D6</name_singular>
+                  <name_plural>D6</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="d9" enabled="1" default="0" access="0" value="d9" rank="61">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D9</name_singular>
+                  <name_plural>D9</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="d9_1" enabled="1" default="0" access="0" value="d9_1" rank="62">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>D9: HD</name_singular>
+                  <name_plural>D9: HD</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dct" enabled="1" default="0" access="0" value="dct" rank="63">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DCT</name_singular>
+                  <name_plural>DCT</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="digital_betacam" enabled="1" default="0" access="0" value="digital_betacam"
+              rank="64">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Digital Betacam</name_singular>
+                  <name_plural>Digital Betacam</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="digital8" enabled="1" default="0" access="0" value="digital8" rank="65">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Digital8</name_singular>
+                  <name_plural>Digital8</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dv" enabled="1" default="0" access="0" value="dv" rank="66">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DV</name_singular>
+                  <name_plural>DV</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcam" enabled="1" default="0" access="0" value="dvcam" rank="67">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCAM</name_singular>
+                  <name_plural>DVCAM</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcpro" enabled="1" default="0" access="0" value="dvcpro" rank="68">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCPRO</name_singular>
+                  <name_plural>DVCPRO</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcpro_1" enabled="1" default="0" access="0" value="dvcpro_1" rank="69">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCPRO: 25</name_singular>
+                  <name_plural>DVCPRO: 25</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcpro_2" enabled="1" default="0" access="0" value="dvcpro_2" rank="70">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCPRO: 50</name_singular>
+                  <name_plural>DVCPRO: 50</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcpro_3" enabled="1" default="0" access="0" value="dvcpro_3" rank="71">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCPRO: Progressive</name_singular>
+                  <name_plural>DVCPRO: Progressive</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvcpro_4" enabled="1" default="0" access="0" value="dvcpro_4" rank="72">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVCPRO: HD</name_singular>
+                  <name_plural>DVCPRO: HD</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd" enabled="1" default="0" access="0" value="dvd" rank="73">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD</name_singular>
+                  <name_plural>DVD</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd_1" enabled="1" default="0" access="0" value="dvd_1" rank="74">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD: DVD+R</name_singular>
+                  <name_plural>DVD: DVD+R</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd_2" enabled="1" default="0" access="0" value="dvd_2" rank="75">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD: DVD+R DL</name_singular>
+                  <name_plural>DVD: DVD+R DL</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd_3" enabled="1" default="0" access="0" value="dvd_3" rank="76">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD: DVD-R</name_singular>
+                  <name_plural>DVD: DVD-R</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd_4" enabled="1" default="0" access="0" value="dvd_4" rank="77">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD: DVD-RW</name_singular>
+                  <name_plural>DVD: DVD-RW</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="dvd_5" enabled="1" default="0" access="0" value="dvd_5" rank="78">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>DVD: DVD+RW</name_singular>
+                  <name_plural>DVD: DVD+RW</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="eiaj" enabled="1" default="0" access="0" value="eiaj" rank="79">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>EIAJ</name_singular>
+                  <name_plural>EIAJ</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="evd" enabled="1" default="0" access="0" value="evd" rank="80">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>EVD</name_singular>
+                  <name_plural>EVD</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="hdcam" enabled="1" default="0" access="0" value="hdcam" rank="81">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>HDCAM</name_singular>
+                  <name_plural>HDCAM</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="hdcam_1" enabled="1" default="0" access="0" value="hdcam_1" rank="82">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>HDCAM: SR</name_singular>
+                  <name_plural>HDCAM: SR</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="hdv" enabled="1" default="0" access="0" value="hdv" rank="83">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>HDV</name_singular>
+                  <name_plural>HDV</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="hi8" enabled="1" default="0" access="0" value="hi8" rank="84">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Hi8</name_singular>
+                  <name_plural>Hi8</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="laserdisc" enabled="1" default="0" access="0" value="laserdisc" rank="85">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>LaserDisc</name_singular>
+                  <name_plural>LaserDisc</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="laserdisc_1" enabled="1" default="0" access="0" value="laserdisc_1"
+              rank="86">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>LaserDisc: CAV</name_singular>
+                  <name_plural>LaserDisc: CAV</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="laserdisc_2" enabled="1" default="0" access="0" value="laserdisc_2"
+              rank="87">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>LaserDisc: CLV</name_singular>
+                  <name_plural>LaserDisc: CLV</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="laserdisc_3" enabled="1" default="0" access="0" value="laserdisc_3"
+              rank="88">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>LaserDisc: CAA</name_singular>
+                  <name_plural>LaserDisc: CAA</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="mii" enabled="1" default="0" access="0" value="mii" rank="89">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>MII</name_singular>
+                  <name_plural>MII</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="minidv" enabled="1" default="0" access="0" value="minidv" rank="90">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>MiniDV</name_singular>
+                  <name_plural>MiniDV</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="super_video_cd" enabled="1" default="0" access="0" value="super_video_cd"
+              rank="91">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Super Video CD</name_singular>
+                  <name_plural>Super Video CD</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="u_matic" enabled="1" default="0" access="0" value="u_matic" rank="92">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>U-matic</name_singular>
+                  <name_plural>U-matic</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="u_matic_1" enabled="1" default="0" access="0" value="u_matic_1" rank="93">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>U-matic: S</name_singular>
+                  <name_plural>U-matic: S</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="u_matic_2" enabled="1" default="0" access="0" value="u_matic_2" rank="94">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>U-matic: SP</name_singular>
+                  <name_plural>U-matic: SP</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="universal_media_disc" enabled="1" default="0" access="0"
+              value="universal_media_disc" rank="95">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Universal Media Disc</name_singular>
+                  <name_plural>Universal Media Disc</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="v_cord" enabled="1" default="0" access="0" value="v_cord" rank="96">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>V-Cord</name_singular>
+                  <name_plural>V-Cord</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="v_cord_1" enabled="1" default="0" access="0" value="v_cord_1" rank="97">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>V-Cord: I</name_singular>
+                  <name_plural>V-Cord: I</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="v_cord_2" enabled="1" default="0" access="0" value="v_cord_2" rank="98">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>V-Cord: II</name_singular>
+                  <name_plural>V-Cord: II</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="vhs" enabled="1" default="0" access="0" value="vhs" rank="99">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>VHS</name_singular>
+                  <name_plural>VHS</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="vhs_1" enabled="1" default="0" access="0" value="vhs_1" rank="100">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>VHS: S-VHS</name_singular>
+                  <name_plural>VHS: S-VHS</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="vhs_2" enabled="1" default="0" access="0" value="vhs_2" rank="101">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>VHS: W-VHS</name_singular>
+                  <name_plural>VHS: W-VHS</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="vhs_3" enabled="1" default="0" access="0" value="vhs_3" rank="102">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>VHS: VHS-C</name_singular>
+                  <name_plural>VHS: VHS-C</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="video8" enabled="1" default="0" access="0" value="video8" rank="103">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Video8</name_singular>
+                  <name_plural>Video8</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="vx" enabled="1" default="0" access="0" value="vx" rank="104">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>VX</name_singular>
+                  <name_plural>VX</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+      </items>
+    </list>
+    <list code="instantiation_physical_types_audio" hierarchical="0" system="0" vocabulary="0"
+      defaultSort="1">
+      <labels>
+        <label locale="en_US">
+          <name>Physical Formats For Audio</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1" access="0" value="option0" rank="1">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="open_reel_audiotape" enabled="1" default="0" access="0"
+          value="open_reel_audiotape" rank="2">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Open reel audiotape</name_singular>
+              <name_plural>Open reel audiotape</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="grooved_analog_disc" enabled="1" default="0" access="0"
+          value="grooved_analog_disc" rank="3">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Grooved analog disc</name_singular>
+              <name_plural>Grooved analog disc</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="one_inch_audio_tape" enabled="1" default="0" access="0"
+          value="one_inch_audio_tape" rank="4">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1 inch audio tape</name_singular>
+              <name_plural>1 inch audio tape</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="half_inch_audio_tape" enabled="1" default="0" access="0"
+          value="half_inch_audio_tape" rank="5">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1/2 inch audio tape</name_singular>
+              <name_plural>1/2 inch audio tape</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="quarter_inch_audio_cassette" enabled="1" default="0" access="0"
+          value="quarter_inch_audio_cassette" rank="6">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1/4 inch audio cassette</name_singular>
+              <name_plural>1/4 inch audio cassette</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="quarter_inch_audio_tape" enabled="1" default="0" access="0"
+          value="quarter_inch_audio_tape" rank="7">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1/4 inch audio tape</name_singular>
+              <name_plural>1/4 inch audio tape</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="two_inch_audio_tape" enabled="1" default="0" access="0"
+          value="two_inch_audio_tape" rank="8">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>2 inch audio tape</name_singular>
+              <name_plural>2 inch audio tape</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="8_track" enabled="1" default="0" access="0" value="8_track" rank="9">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>8-track</name_singular>
+              <name_plural>8-track</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="aluminum_disc" enabled="1" default="0" access="0" value="aluminum_disc"
+          rank="10">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Aluminum disc</name_singular>
+              <name_plural>Aluminum disc</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cassette" enabled="1" default="0" access="0" value="audio_cassette"
+          rank="11">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio cassette</name_singular>
+              <name_plural>Audio cassette</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cassette_1" enabled="1" default="0" access="0" value="audio_cassette_1"
+          rank="12">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio cassette: Type I</name_singular>
+              <name_plural>Audio cassette: Type I</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cassette_2" enabled="1" default="0" access="0" value="audio_cassette_2"
+          rank="13">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio cassette: Type II</name_singular>
+              <name_plural>Audio cassette: Type II</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cassette_3" enabled="1" default="0" access="0" value="audio_cassette_3"
+          rank="14">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio cassette: Type III</name_singular>
+              <name_plural>Audio cassette: Type III</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cassette_4" enabled="1" default="0" access="0" value="audio_cassette_4"
+          rank="15">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio cassette: Type IV</name_singular>
+              <name_plural>Audio cassette: Type IV</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="audio_cd" enabled="1" default="0" access="0" value="audio_cd" rank="16">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Audio CD</name_singular>
+              <name_plural>Audio CD</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="dat" enabled="1" default="0" access="0" value="dat" rank="17">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DAT</name_singular>
+              <name_plural>DAT</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="dds" enabled="1" default="0" access="0" value="dds" rank="18">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DDS</name_singular>
+              <name_plural>DDS</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="dtrs" enabled="1" default="0" access="0" value="dtrs" rank="19">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DTRS</name_singular>
+              <name_plural>DTRS</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="dtrs_1" enabled="1" default="0" access="0" value="dtrs_1" rank="20">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DTRS: DA-88</name_singular>
+              <name_plural>DTRS: DA-88</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="film_audio" enabled="1" default="0" access="0" value="film_audio" rank="21">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Film</name_singular>
+              <name_plural>Film</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="flexi_disc" enabled="1" default="0" access="0" value="flexi_disc" rank="21">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Flexi Disc</name_singular>
+              <name_plural>Flexi Disc</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="grooved_dictabelt" enabled="1" default="0" access="0" value="grooved_dictabelt"
+          rank="22">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Grooved Dictabelt</name_singular>
+              <name_plural>Grooved Dictabelt</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="lacquer_disc" enabled="1" default="0" access="0" value="lacquer_disc" rank="23">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Lacquer disc</name_singular>
+              <name_plural>Lacquer disc</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="magnetic_dictabelt" enabled="1" default="0" access="0"
+          value="magnetic_dictabelt" rank="24">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Magnetic Dictabelt</name_singular>
+              <name_plural>Magnetic Dictabelt</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="mini_cassette" enabled="1" default="0" access="0" value="mini_cassette"
+          rank="25">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mini-cassette</name_singular>
+              <name_plural>Mini-cassette</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="pcm_betamax" enabled="1" default="0" access="0" value="pcm_betamax" rank="26">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>PCM Betamax</name_singular>
+              <name_plural>PCM Betamax</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="pcm_u_matic" enabled="1" default="0" access="0" value="pcm_u_matic" rank="27">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>PCM U-matic</name_singular>
+              <name_plural>PCM U-matic</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="pcm_vhs" enabled="1" default="0" access="0" value="pcm_vhs" rank="28">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>PCM VHS</name_singular>
+              <name_plural>PCM VHS</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="piano_roll" enabled="1" default="0" access="0" value="piano_roll" rank="29">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Piano roll</name_singular>
+              <name_plural>Piano roll</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="plastic_cylinder" enabled="1" default="0" access="0" value="plastic_cylinder"
+          rank="30">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Plastic cylinder</name_singular>
+              <name_plural>Plastic cylinder</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="shellac_disc" enabled="1" default="0" access="0" value="shellac_disc" rank="31">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Shellac disc</name_singular>
+              <name_plural>Shellac disc</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="super_audio_cd" enabled="1" default="0" access="0" value="super_audio_cd"
+          rank="32">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Super Audio CD</name_singular>
+              <name_plural>Super Audio CD</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="vinyl_recording" enabled="1" default="0" access="0" value="vinyl_recording"
+          rank="33">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Vinyl recording</name_singular>
+              <name_plural>Vinyl recording</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="vinyl_recording_1" enabled="1" default="0" access="0" value="vinyl_recording_1"
+          rank="34">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Vinyl recording: EP</name_singular>
+              <name_plural>Vinyl recording: EP</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="vinyl_recording_2" enabled="1" default="0" access="0" value="vinyl_recording_2"
+          rank="35">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Vinyl recording: LP</name_singular>
+              <name_plural>Vinyl recording: LP</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="vinyl_recording_3" enabled="1" default="0" access="0" value="vinyl_recording_3"
+          rank="36">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Vinyl recording: 45</name_singular>
+              <name_plural>Vinyl recording: 45</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="vinyl_recording_4" enabled="1" default="0" access="0" value="vinyl_recording_4"
+          rank="37">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Vinyl recording: 78</name_singular>
+              <name_plural>Vinyl recording: 78</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="wax_cylinder" enabled="1" default="0" access="0" value="wax_cylinder" rank="38">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Wax cylinder</name_singular>
+              <name_plural>Wax cylinder</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="wire_recording" enabled="1" default="0" access="0" value="wire_recording"
+          rank="39">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Wire recording</name_singular>
+              <name_plural>Wire recording</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="instantiation_generations_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Generations Types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="348">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="a_b_rolls" enabled="1" default="0" access="0" value="a_b_rolls" rank="349">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>A-B rolls</name_singular>
+              <name_plural>A-B rolls</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="answer_print" enabled="1" default="0" access="0" value="answer_print" rank="350">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Answer print</name_singular>
+              <name_plural>Answer print</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="composite" enabled="1" default="0" access="0" value="composite" rank="351">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Composite</name_singular>
+              <name_plural>Composite</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="copy" enabled="1" default="0" access="0" value="copy" rank="352">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Copy</name_singular>
+              <name_plural>Copy</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="copy_access" enabled="1" default="0" access="0" value="copy_access" rank="353">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Copy: Access</name_singular>
+              <name_plural>Copy: Access</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="dub" enabled="1" default="0" access="0" value="dub" rank="354">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Dub</name_singular>
+              <name_plural>Dub</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="duplicate" enabled="1" default="0" access="0" value="duplicate" rank="355">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Duplicate</name_singular>
+              <name_plural>Duplicate</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="fine_cut" enabled="1" default="0" access="0" value="fine_cut" rank="356">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Fine cut</name_singular>
+              <name_plural>Fine cut</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="intermediate" enabled="1" default="0" access="0" value="intermediate" rank="357">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Intermediate</name_singular>
+              <name_plural>Intermediate</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="interpositive" enabled="1" default="0" access="0" value="interpositive"
+          rank="358">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Interpositive</name_singular>
+              <name_plural>Interpositive</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="internegative" enabled="1" default="0" access="0" value="internegative"
+          rank="359">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Internegative</name_singular>
+              <name_plural>Internegative</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="color_reversal_intermediate" enabled="1" default="0" access="0"
+          value="color_reversal_intermediate" rank="360">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Color reversal intermediate</name_singular>
+              <name_plural>Color reversal intermediate</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="kinescope" enabled="1" default="0" access="0" value="kinescope" rank="361">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Kinescope</name_singular>
+              <name_plural>Kinescope</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="line_cut" enabled="1" default="0" access="0" value="line_cut" rank="362">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Line cut</name_singular>
+              <name_plural>Line cut</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="magnetic_track" enabled="1" default="0" access="0" value="magnetic_track"
+          rank="363">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Magnetic Track</name_singular>
+              <name_plural>Magnetic Track</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="master" enabled="1" default="0" access="0" value="master" rank="364">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Master</name_singular>
+              <name_plural>Master</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="master_distribution" enabled="1" default="0" access="0"
+          value="master_distribution" rank="365">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Master: distribution</name_singular>
+              <name_plural>Master: distribution</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="master_production" enabled="1" default="0" access="0" value="master_production"
+          rank="366">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Master: production</name_singular>
+              <name_plural>Master: production</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="mezzanine" enabled="1" default="0" access="0" value="mezzanine" rank="367">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mezzanine</name_singular>
+              <name_plural>Mezzanine</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="negative" enabled="1" default="0" access="0" value="negative" rank="368">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Negative</name_singular>
+              <name_plural>Negative</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="optical_track" enabled="1" default="0" access="0" value="optical_track"
+          rank="369">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Optical Track</name_singular>
+              <name_plural>Optical Track</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="original" enabled="1" default="0" access="0" value="original" rank="370">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Original</name_singular>
+              <name_plural>Original</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="original_footage" enabled="1" default="0" access="0" value="original_footage"
+          rank="371">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Original footage</name_singular>
+              <name_plural>Original footage</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="original_recording" enabled="1" default="0" access="0"
+          value="original_recording" rank="372">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Original recording</name_singular>
+              <name_plural>Original recording</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="outs_and_trims" enabled="1" default="0" access="0" value="outs_and_trims"
+          rank="373">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Outs and trims</name_singular>
+              <name_plural>Outs and trims</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="picture_lock" enabled="1" default="0" access="0" value="picture_lock" rank="374">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Picture lock</name_singular>
+              <name_plural>Picture lock</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="positive" enabled="1" default="0" access="0" value="positive" rank="375">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Positive</name_singular>
+              <name_plural>Positive</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="preservation" enabled="1" default="0" access="0" value="preservation" rank="376">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Preservation</name_singular>
+              <name_plural>Preservation</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="print" enabled="1" default="0" access="0" value="print" rank="377">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Print</name_singular>
+              <name_plural>Print</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="proxy_file" enabled="1" default="0" access="0" value="proxy_file" rank="378">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Proxy file</name_singular>
+              <name_plural>Proxy file</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="reversal" enabled="1" default="0" access="0" value="reversal" rank="379">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Reversal</name_singular>
+              <name_plural>Reversal</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="rough_cut" enabled="1" default="0" access="0" value="rough_cut" rank="380">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Rough cut</name_singular>
+              <name_plural>Rough cut</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="separation_master" enabled="1" default="0" access="0" value="separation_master"
+          rank="381">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Separation master</name_singular>
+              <name_plural>Separation master</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="stock_footage" enabled="1" default="0" access="0" value="stock_footage"
+          rank="382">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Stock footage</name_singular>
+              <name_plural>Stock footage</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="submaster" enabled="1" default="0" access="0" value="submaster" rank="383">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Submaster</name_singular>
+              <name_plural>Submaster</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="transcription_disc" enabled="1" default="0" access="0"
+          value="transcription_disc" rank="384">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Transcription disc</name_singular>
+              <name_plural>Transcription disc</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="work_print" enabled="1" default="0" access="0" value="work_print" rank="385">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Work print</name_singular>
+              <name_plural>Work print</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="work_tapes" enabled="1" default="0" access="0" value="work_tapes" rank="386">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Work tapes</name_singular>
+              <name_plural>Work tapes</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="work_track" enabled="1" default="0" access="0" value="work_track" rank="387">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Work track</name_singular>
+              <name_plural>Work track</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="pbcore_dates_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>PBCore Date types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1" access="0" value="option0" rank="389">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="accepted" enabled="1" default="0" access="0" value="accepted" rank="390">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>accepted</name_singular>
+              <name_plural>accepted</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="available" enabled="1" default="0" access="0" value="available" rank="391">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>available</name_singular>
+              <name_plural>available</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="available_end" enabled="1" default="0" access="0" value="available_end"
+          rank="392">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>available end</name_singular>
+              <name_plural>available end</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="available_start" enabled="1" default="0" access="0" value="available_start"
+          rank="393">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>available start</name_singular>
+              <name_plural>available start</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="broadcast" enabled="1" default="0" access="0" value="broadcast" rank="394">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>broadcast</name_singular>
+              <name_plural>broadcast</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="captured" enabled="1" default="0" access="0" value="captured" rank="395">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>captured</name_singular>
+              <name_plural>captured</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="created" enabled="1" default="0" access="0" value="created" rank="396">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>created</name_singular>
+              <name_plural>created</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="copyright" enabled="1" default="0" access="0" value="copyright" rank="397">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>copyright</name_singular>
+              <name_plural>copyright</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="distributed" enabled="1" default="0" access="0" value="distributed" rank="398">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>distributed</name_singular>
+              <name_plural>distributed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="dubbed" enabled="1" default="0" access="0" value="dubbed" rank="399">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>dubbed</name_singular>
+              <name_plural>dubbed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="edited" enabled="1" default="0" access="0" value="edited" rank="400">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>edited</name_singular>
+              <name_plural>edited</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="encoded" enabled="1" default="0" access="0" value="encoded" rank="401">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>encoded</name_singular>
+              <name_plural>encoded</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="encrypted" enabled="1" default="0" access="0" value="encrypted" rank="402">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>encrypted</name_singular>
+              <name_plural>encrypted</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="event" enabled="1" default="0" access="0" value="event" rank="403">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>event</name_singular>
+              <name_plural>event</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="ingested" enabled="1" default="0" access="0" value="ingested" rank="404">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>ingested</name_singular>
+              <name_plural>ingested</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="issued" enabled="1" default="0" access="0" value="issued" rank="405">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>issued</name_singular>
+              <name_plural>issued</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="licensed" enabled="1" default="0" access="0" value="licensed" rank="406">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>licensed</name_singular>
+              <name_plural>licensed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="mastered" enabled="1" default="0" access="0" value="mastered" rank="407">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>mastered</name_singular>
+              <name_plural>mastered</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="migrated" enabled="1" default="0" access="0" value="migrated" rank="408">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>migrated</name_singular>
+              <name_plural>migrated</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="mixed" enabled="1" default="0" access="0" value="mixed" rank="409">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>mixed</name_singular>
+              <name_plural>mixed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="modified" enabled="1" default="0" access="0" value="modified" rank="410">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>modified</name_singular>
+              <name_plural>modified</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="normalized" enabled="1" default="0" access="0" value="normalized" rank="411">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>normalized</name_singular>
+              <name_plural>normalized</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="performed" enabled="1" default="0" access="0" value="performed" rank="412">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>performed</name_singular>
+              <name_plural>performed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="podcast" enabled="1" default="0" access="0" value="podcast" rank="413">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>podcast</name_singular>
+              <name_plural>podcast</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="published" enabled="1" default="0" access="0" value="published" rank="414">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>published</name_singular>
+              <name_plural>published</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="released" enabled="1" default="0" access="0" value="released" rank="415">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>released</name_singular>
+              <name_plural>released</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="restored" enabled="1" default="0" access="0" value="restored" rank="416">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>restored</name_singular>
+              <name_plural>restored</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="revised" enabled="1" default="0" access="0" value="revised" rank="417">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>revised</name_singular>
+              <name_plural>revised</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="tranferred" enabled="1" default="0" access="0" value="tranferred" rank="418">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>transferred</name_singular>
+              <name_plural>transferred</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="valid" enabled="1" default="0" access="0" value="valid" rank="419">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>valid</name_singular>
+              <name_plural>valid</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="validated" enabled="1" default="0" access="0" value="validated" rank="420">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>validated</name_singular>
+              <name_plural>validated</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="webcast" enabled="1" default="0" access="0" value="webcast" rank="421">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>webcast</name_singular>
+              <name_plural>webcast</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="instantiation_media_types" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Media Types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="film" enabled="1" default="0" access="0" value="film" rank="423">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> Film</name_singular>
+              <name_plural> Film</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="video_tape" enabled="1" default="0" access="0" value="Video Tape" rank="424">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Video Tape</name_singular>
+              <name_plural>Video Tape</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="video_disc" enabled="1" default="0" access="0" value="video_disc" rank="425">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Video Disc</name_singular>
+              <name_plural>Video Disc</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="digital_tape" enabled="1" default="0" access="0" value="digital_tape" rank="426"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Digital Tape</name_singular>
+              <name_plural>Digital Tape</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="digital_disc" enabled="1" default="0" access="0" value="digital_disc" rank="427"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Digital Disc</name_singular>
+              <name_plural>Digital Disc</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="digital_file" enabled="1" default="0" access="0" value="digital_file" rank="428"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Digital File</name_singular>
+              <name_plural>Digital File</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="asset_types" hierarchical="0" system="1" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Asset Type</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1" access="0" value="option0" rank="427">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular> </name_singular>
+              <name_plural> </name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="clip_type" enabled="1" default="0" access="0" value="clip_type" rank="430">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Clip</name_singular>
+              <name_plural>Clip</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="collection_type" enabled="1" default="0" access="0" value="collection_type"
+          rank="431">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Collection</name_singular>
+              <name_plural>Collection</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="compilation_type" enabled="1" default="0" access="0" value="compilation_type"
+          rank="432">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Compilation</name_singular>
+              <name_plural>Compilation</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="episode_type" enabled="1" default="0" access="0" value="episode_type" rank="433">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Episode</name_singular>
+              <name_plural>Episode</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="miniseries_type" enabled="1" default="0" access="0" value="miniseries_type"
+          rank="434">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Miniseries</name_singular>
+              <name_plural>Miniseries</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="program_type" enabled="1" default="0" access="0" value="program_type" rank="435">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Program</name_singular>
+              <name_plural>Program</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="segment_clip" enabled="1" default="0" access="0" value="segment_clip" rank="438">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Segment</name_singular>
+              <name_plural>Segment</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="series" enabled="1" default="0" access="0" value="series" rank="439">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Series</name_singular>
+              <name_plural>Series</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="season" enabled="1" default="0" access="0" value="season" rank="440">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Season</name_singular>
+              <name_plural>Season</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="subseries" enabled="1" default="0" access="0" value="subseries" rank="441">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Subseries</name_singular>
+              <name_plural>Subseries</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="monographic" enabled="1" default="0" access="0" value="monographic" rank="461"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Monographic</name_singular>
+              <name_plural>Monographic</name_plural>
+              <description>Complete content in one part or intended to be completed in a finite number of parts.</description>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="digital_file_format" hierarchical="0" system="1" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Digital File Format</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="DPX" enabled="1" default="0" access="0" rank="447" type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DPX</name_singular>
+              <name_plural>DPX</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="genre" hierarchical="0" system="1" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Genre</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="western" enabled="1" default="0" access="0" value="western" rank="458"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Western</name_singular>
+              <name_plural>Western</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="form" hierarchical="0" system="1" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Form</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="album" enabled="1" default="0" access="0" value="album" rank="428">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Album</name_singular>
+              <name_plural>Album</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="animation" enabled="1" default="0" access="0" value="animation" rank="429">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Animation</name_singular>
+              <name_plural>Animation</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="promo" enabled="1" default="0" access="0" value="promo" rank="436">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Promo</name_singular>
+              <name_plural>Promo</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="raw_footage" enabled="1" default="0" access="0" value="raw_footage" rank="437">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Raw Footage</name_singular>
+              <name_plural>Raw Footage</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="documentary" enabled="1" default="0" access="0" value="documentary" rank="460"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Documentary</name_singular>
+              <name_plural>Documentary</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="loan_status" hierarchical="0" system="1" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Loan Status</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="requested" enabled="1" default="0" access="0" value="requested" rank="466"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>requested</name_singular>
+              <name_plural>requested</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="approved" enabled="1" default="0" access="0" value="approved" rank="467"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>approved</name_singular>
+              <name_plural>approved</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="returned" enabled="1" default="0" access="0" value="returned" rank="468"
+          type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>returned</name_singular>
+              <name_plural>returned</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="object_purposes" hierarchical="0" system="1" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Object purposes</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1" access="0" value="option0" rank="470">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Archival copy</name_singular>
+              <name_plural>Archival copy</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="471">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Research copy</name_singular>
+              <name_plural>Research copy</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="472">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Conservation copy</name_singular>
+              <name_plural>Conservation copy</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="aspect_ratios" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Aspect ratios</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="474">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1.66:1</name_singular>
+              <name_plural>1.66:1</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="475">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1.85:1</name_singular>
+              <name_plural>1.85:1</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="476">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>16:10</name_singular>
+              <name_plural>16:10</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="477">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>16:9</name_singular>
+              <name_plural>16:9</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="478">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>16:9 (14:9 letterbox)</name_singular>
+              <name_plural>16:9 (14:9 letterbox)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="479">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1:1</name_singular>
+              <name_plural>1:1</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="480">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>2.35:1</name_singular>
+              <name_plural>2.35:1</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option7" enabled="1" default="0" access="0" value="option7" rank="481">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>2.39:1</name_singular>
+              <name_plural>2.39:1</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option8" enabled="1" default="0" access="0" value="option8" rank="482">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>2.75:1</name_singular>
+              <name_plural>2.75:1</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option9" enabled="1" default="0" access="0" value="option9" rank="483">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>3:2</name_singular>
+              <name_plural>3:2</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option10" enabled="1" default="0" access="0" value="option10" rank="484">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>4:3</name_singular>
+              <name_plural>4:3</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option11" enabled="1" default="0" access="0" value="option11" rank="485">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>4:3 (14:9 letterbox)</name_singular>
+              <name_plural>4:3 (14:9 letterbox)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option12" enabled="1" default="0" access="0" value="option12" rank="486">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>4:3 (16:9 anamorphic)</name_singular>
+              <name_plural>4:3 (16:9 anamorphic)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option13" enabled="1" default="0" access="0" value="option13" rank="487">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>4:3 (16:9 letterbox)</name_singular>
+              <name_plural>4:3 (16:9 letterbox)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option14" enabled="1" default="0" access="0" value="option14" rank="488">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>5:3</name_singular>
+              <name_plural>5:3</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option15" enabled="1" default="0" access="0" value="option15" rank="489">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>5:4</name_singular>
+              <name_plural>5:4</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option16" enabled="1" default="0" access="0" value="option16" rank="490">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>6:7</name_singular>
+              <name_plural>6:7</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option17" enabled="1" default="0" access="0" value="option17" rank="491">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>7:3 (Panavision or CinemaScope)</name_singular>
+              <name_plural>7:3 (Panavision or CinemaScope)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="apertures" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Apertures</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="493">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Academy 1.33:1</name_singular>
+              <name_plural>Academy 1.33:1</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="494">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Full Height</name_singular>
+              <name_plural>Full Height</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="495">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Full Screen</name_singular>
+              <name_plural>Full Screen</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="496">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Flat</name_singular>
+              <name_plural>Flat</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="497">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Anamorphic</name_singular>
+              <name_plural>Anamorphic</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="498">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>3D</name_singular>
+              <name_plural>3D</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="499">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Pan and scan</name_singular>
+              <name_plural>Pan and scan</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option7" enabled="1" default="0" access="0" value="option7" rank="500">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Pillarbox</name_singular>
+              <name_plural>Pillarbox</name_plural>
+              <description>Bars added at the sides</description>
+            </label>
+          </labels>
+        </item>
+        <item idno="option8" enabled="1" default="0" access="0" value="option8" rank="501">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Letterbox</name_singular>
+              <name_plural>Letterbox</name_plural>
+              <description>Bars added at the top and bottom.</description>
+            </label>
+          </labels>
+        </item>
+        <item idno="option9" enabled="1" default="0" access="0" value="option9" rank="502">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Windowbox</name_singular>
+              <name_plural>Windowbox</name_plural>
+              <description>Bars added at the side and the top and bottom.</description>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="bases" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Bases</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="504">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Acetate</name_singular>
+              <name_plural>Acetate</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="505">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Diacetate</name_singular>
+              <name_plural>Diacetate</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="506">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mainly safety</name_singular>
+              <name_plural>Mainly safety</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="507">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mainly nitrate</name_singular>
+              <name_plural>Mainly nitrate</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="508">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mixed</name_singular>
+              <name_plural>Mixed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="509">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mylar</name_singular>
+              <name_plural>Mylar</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="510">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Nitrate</name_singular>
+              <name_plural>Nitrate</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option7" enabled="1" default="0" access="0" value="option7" rank="511">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Polyester</name_singular>
+              <name_plural>Polyester</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option8" enabled="1" default="0" access="0" value="option8" rank="512">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>PVC</name_singular>
+              <name_plural>PVC</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option9" enabled="1" default="0" access="0" value="option9" rank="513">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Safety</name_singular>
+              <name_plural>Safety</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option10" enabled="1" default="0" access="0" value="option10" rank="514">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Vinyl</name_singular>
+              <name_plural>Vinyl</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="stock_types" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Stock types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="0" default="0" access="0" value="option0" rank="516">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>FILM</name_singular>
+              <name_plural>FILM</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option0_0" enabled="1" default="0" access="0" value="option0_0" rank="517">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Eastman Kodak</name_singular>
+                  <name_plural>Eastman Kodak</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option0_1" enabled="1" default="0" access="0" value="option0_1" rank="518">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Fuji</name_singular>
+                  <name_plural>Fuji</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option0_2" enabled="1" default="0" access="0" value="option0_2" rank="519">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Agfa</name_singular>
+                  <name_plural>Agfa</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="option1" enabled="0" default="0" access="0" value="option1" rank="520">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>VIDEO</name_singular>
+              <name_plural>VIDEO</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option1_0" enabled="1" default="0" access="0" value="option1_0" rank="521">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>3M</name_singular>
+                  <name_plural>3M</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option1_1" enabled="1" default="0" access="0" value="option1_1" rank="522">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Fuji</name_singular>
+                  <name_plural>Fuji</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option1_2" enabled="1" default="0" access="0" value="option1_2" rank="523">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Sony</name_singular>
+                  <name_plural>Sony</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="option2" enabled="0" default="0" access="0" value="option2" rank="524">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>AUDIO</name_singular>
+              <name_plural>AUDIO</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option2_0" enabled="1" default="0" access="0" value="option2_0" rank="525">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Ampex</name_singular>
+                  <name_plural>Ampex</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option2_1" enabled="1" default="0" access="0" value="option2_1" rank="526">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Scotch</name_singular>
+                  <name_plural>Scotch</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option2_2" enabled="1" default="0" access="0" value="option2_2" rank="527">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>3M</name_singular>
+                  <name_plural>3M</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="option3" enabled="0" default="0" access="0" value="option3" rank="528">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>OPTICAL</name_singular>
+              <name_plural>OPTICAL</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option3_0" enabled="1" default="0" access="0" value="option3_0" rank="529">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Maxell</name_singular>
+                  <name_plural>Maxell</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option3_1" enabled="1" default="0" access="0" value="option3_1" rank="530">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Memorex</name_singular>
+                  <name_plural>Memorex</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option3_2" enabled="1" default="0" access="0" value="option3_2" rank="531">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Philips</name_singular>
+                  <name_plural>Philips</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="option4" enabled="0" default="0" access="0" value="option4" rank="532">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DIGITAL TAPE</name_singular>
+              <name_plural>DIGITAL TAPE</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option4_0" enabled="1" default="0" access="0" value="option4_0" rank="533">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>HP</name_singular>
+                  <name_plural>HP</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option4_1" enabled="1" default="0" access="0" value="option4_1" rank="534">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Oracle</name_singular>
+                  <name_plural>Oracle</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="option5" enabled="0" default="0" access="0" value="option5" rank="535">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>HARD DRIVES</name_singular>
+              <name_plural>HARD DRIVES</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option5_0" enabled="1" default="0" access="0" value="option5_0" rank="536">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Hitachi</name_singular>
+                  <name_plural>Hitachi</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option5_1" enabled="1" default="0" access="0" value="option5_1" rank="537">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Seagate</name_singular>
+                  <name_plural>Seagate</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option5_2" enabled="1" default="0" access="0" value="option5_2" rank="538">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Toshiba</name_singular>
+                  <name_plural>Toshiba</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option5_3" enabled="1" default="0" access="0" value="option5_3" rank="539">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Western Digital</name_singular>
+                  <name_plural>Western Digital</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+      </items>
+    </list>
+    <list code="sound_fixation_types" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Sound fixation types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="541">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Needle sound</name_singular>
+              <name_plural>Needle sound</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="542">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Optical</name_singular>
+              <name_plural>Optical</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="543">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Magnetic</name_singular>
+              <name_plural>Magnetic</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="544">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Analog sound</name_singular>
+              <name_plural>Analog sound</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="545">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Digital</name_singular>
+              <name_plural>Digital</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="sound_types" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Sound types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="547">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Sound</name_singular>
+              <name_plural>Sound</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="548">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Silent</name_singular>
+              <name_plural>Silent</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="549">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mute</name_singular>
+              <name_plural>Mute</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="550">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Combined</name_singular>
+              <name_plural>Combined</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="551">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Combined as mute</name_singular>
+              <name_plural>Combined as mute</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="552">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Combined as sound</name_singular>
+              <name_plural>Combined as sound</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="553">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mixed</name_singular>
+              <name_plural>Mixed</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option7" enabled="1" default="0" access="0" value="option7" rank="554">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Temporary</name_singular>
+              <name_plural>Temporary</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="sound_systems" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Sound systems</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="556">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Dolby SR</name_singular>
+              <name_plural>Dolby SR</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="557">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Dolby Digital</name_singular>
+              <name_plural>Dolby Digital</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="558">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mute</name_singular>
+              <name_plural>Mute</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="559">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Combined magnetic sound</name_singular>
+              <name_plural>Combined magnetic sound</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="560">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Combined optical sound</name_singular>
+              <name_plural>Combined optical sound</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="561">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>VA RCA Duplex</name_singular>
+              <name_plural>VA RCA Duplex</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="sound_channel_configurations" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Sound channel configurations</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="563">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Mono</name_singular>
+              <name_plural>Mono</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="564">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Stereo</name_singular>
+              <name_plural>Stereo</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="color_types" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Color types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="566">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Color</name_singular>
+              <name_plural>Color</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="567">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Black and white</name_singular>
+              <name_plural>Black and white</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="568">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Tinted</name_singular>
+              <name_plural>Tinted</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="569">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Toned</name_singular>
+              <name_plural>Toned</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="570">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Sepia</name_singular>
+              <name_plural>Sepia</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="color_standards" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Color standards</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="572">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Pathécolor</name_singular>
+              <name_plural>Pathécolor</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="573">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Technicolor</name_singular>
+              <name_plural>Technicolor</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="574">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Kinemacolor</name_singular>
+              <name_plural>Kinemacolor</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="575">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Anscocolor</name_singular>
+              <name_plural>Anscocolor</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="576">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Ferraniacolor</name_singular>
+              <name_plural>Ferraniacolor</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="577">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Fujicolor</name_singular>
+              <name_plural>Fujicolor</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option7" enabled="1" default="0" access="0" value="option7" rank="578">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Kodachrome</name_singular>
+              <name_plural>Kodachrome</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option8" enabled="1" default="0" access="0" value="option8" rank="579">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Eastmancolor</name_singular>
+              <name_plural>Eastmancolor</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option9" enabled="1" default="0" access="0" value="option9" rank="580">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>RGB</name_singular>
+              <name_plural>RGB</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option10" enabled="1" default="0" access="0" value="option10" rank="581">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>YUV</name_singular>
+              <name_plural>YUV</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="condition_types" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Condition types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="583">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Emulsion scratches</name_singular>
+              <name_plural>Emulsion scratches</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="584">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Base scratches</name_singular>
+              <name_plural>Base scratches</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="585">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Perforation damage</name_singular>
+              <name_plural>Perforation damage</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="586">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Projector oil and dirt</name_singular>
+              <name_plural>Projector oil and dirt</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="587">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Warpage</name_singular>
+              <name_plural>Warpage</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="588">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Shrinkage</name_singular>
+              <name_plural>Shrinkage</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="589">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Color fading</name_singular>
+              <name_plural>Color fading</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="condition_levels" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Condition levels</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="1" access="0" value="0" rank="591">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>0 (perfect)</name_singular>
+              <name_plural>0 (perfect)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="592">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>1</name_singular>
+              <name_plural>1</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="593">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>2</name_singular>
+              <name_plural>2</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="594">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>3</name_singular>
+              <name_plural>3</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="595">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>4</name_singular>
+              <name_plural>4</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="5" rank="596">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>5 (critical)</name_singular>
+              <name_plural>5 (critical)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="deterioration_types" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Deterioration types</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="598">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Acetate decomposition (vinegar syndrome)</name_singular>
+              <name_plural>Acetate decomposition (vinegar syndrome)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="599">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Polyurethane hydrolysis (sticky-shed syndrome)</name_singular>
+              <name_plural>Polyurethane hydrolysis (sticky-shed syndrome)</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="resolutions" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Resolutions</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="601">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Standard definition</name_singular>
+              <name_plural>Standard definition</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="602">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>High definition</name_singular>
+              <name_plural>High definition</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="603">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>2k</name_singular>
+              <name_plural>2k</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="604">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>4k</name_singular>
+              <name_plural>4k</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="605">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>6k</name_singular>
+              <name_plural>6k</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="606">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>8k</name_singular>
+              <name_plural>8k</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="broadcast_standards" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Broadcast standards</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="608">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>NTSC</name_singular>
+              <name_plural>NTSC</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="609">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>PAL</name_singular>
+              <name_plural>PAL</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="610">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>SECAM</name_singular>
+              <name_plural>SECAM</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="frame_rates" hierarchical="0" system="0" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Frame rates</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="option0" rank="612">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>16fps</name_singular>
+              <name_plural>16fps</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="option1" rank="613">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>23.98fps</name_singular>
+              <name_plural>23.98fps</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="option2" rank="614">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>24fps</name_singular>
+              <name_plural>24fps</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="option3" rank="615">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>25fps</name_singular>
+              <name_plural>25fps</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option4" enabled="1" default="0" access="0" value="option4" rank="616">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>30fps</name_singular>
+              <name_plural>30fps</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option5" enabled="1" default="0" access="0" value="option5" rank="617">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>48fps</name_singular>
+              <name_plural>48fps</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option6" enabled="1" default="0" access="0" value="option6" rank="618">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Variable</name_singular>
+              <name_plural>Variable</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="languages" hierarchical="0" system="1" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Languages</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="1" default="0" access="0" value="eng" rank="620">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>English</name_singular>
+              <name_plural>English</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option1" enabled="1" default="0" access="0" value="fre" rank="621">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>French</name_singular>
+              <name_plural>French</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option2" enabled="1" default="0" access="0" value="ger" rank="622">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>German</name_singular>
+              <name_plural>German</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+        <item idno="option3" enabled="1" default="0" access="0" value="spa" rank="623">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>Spanish</name_singular>
+              <name_plural>Spanish</name_plural>
+              <description />
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+    <list code="storage_formats" hierarchical="0" system="1" vocabulary="1">
+      <labels>
+        <label locale="en_US">
+          <name>Storage formats</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option0" enabled="0" default="0" access="0" value="option0" rank="625">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>ANALOG</name_singular>
+              <name_plural>ANALOG</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option0_0" enabled="1" default="0" access="0" value="option0_0" rank="626">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>1000ft can</name_singular>
+                  <name_plural>1000ft can</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+        <item idno="option1" enabled="0" default="0" access="0" value="option1" rank="627">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>DIGITAL</name_singular>
+              <name_plural>DIGITAL</name_plural>
+              <description />
+            </label>
+          </labels>
+          <items>
+            <item idno="option1_0" enabled="1" default="0" access="0" value="option1_0" rank="628">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>Hard Drive</name_singular>
+                  <name_plural>Hard Drive</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+            <item idno="option1_1" enabled="1" default="0" access="0" value="option1_1" rank="629">
+              <labels>
+                <label locale="en_US" preferred="1">
+                  <name_singular>LTO</name_singular>
+                  <name_plural>LTO</name_plural>
+                  <description />
+                </label>
+              </labels>
+            </item>
+          </items>
+        </item>
+      </items>
+    </list>
+    <list code="units_dimensions" hierarchical="0" system="0" vocabulary="0">
+      <labels>
+        <label locale="en_US">
+          <name>Units of measure (dimensions)</name>
+        </label>
+      </labels>
+      <items>
+        <item idno="option1" enabled="1" default="0" access="0" rank="631" type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>ft</name_singular>
+              <name_plural>ft</name_plural>
+              <description>Feet</description>
+            </label>
+          </labels>
+        </item>
+        <item idno="option0" enabled="1" default="0" access="0" rank="632" type="concept">
+          <labels>
+            <label locale="en_US" preferred="1">
+              <name_singular>in</name_singular>
+              <name_plural>in</name_plural>
+              <description>Inches</description>
+            </label>
+          </labels>
+        </item>
+      </items>
+    </list>
+  </lists>
+  <elementSets>
+    <metadataElement code="set_description" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Introduction</name>
+          <description>Narrative description for set. This is the primary text used when publicly presenting the set.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_sets</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">3</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="set_item_description" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Item description</name>
+          <description>Narrative description for item in this set. This is the primary text used when publicly presenting the item in the context of this set.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_set_items</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">3</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="set_presentation_type" datatype="List" list="set_presentation_types">
+      <labels>
+        <label locale="en_US">
+          <name>Presentation type</name>
+          <description>Determines how set is rendered when displayed to the public in the Pawtucket/Pawtucket2 front-end.</description>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_sets</table>
+          <type>public_presentation</type>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="set_item_is_primary" datatype="List" list="set_item_is_primary">
+      <labels>
+        <label locale="en_US">
+          <name>Is primary item for set?</name>
+          <description>The item marked as primary will be used to represent the set as a whole when included in a list of sets.</description>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_set_items</table>
+          <type>public_presentation</type>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="set_chron_date_element_code" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Chronology element code</name>
+          <description>Element code of date range element to be used when placing set items into chronological order.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_sets</table>
+          <type>public_presentation</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_authorization_date" datatype="DateRange">
+      <labels>
+        <label locale="en_US">
+          <name>Authorization date</name>
+          <description>The date when the loan was authorized.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">40</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_in_date" datatype="DateRange">
+      <labels>
+        <label locale="en_US">
+          <name>Loan in date</name>
+          <description>The date a loan will enter the institution.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">40</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <type>in</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_out_date" datatype="DateRange">
+      <labels>
+        <label locale="en_US">
+          <name>Loan out date</name>
+          <description>The date a loan will enter the institution.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">40</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <type>out</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_return_date" datatype="DateRange">
+      <labels>
+        <label locale="en_US">
+          <name>Loan return date</name>
+          <description>The date a loan is due back to the lending institution.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">40</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_renewal_date" datatype="DateRange">
+      <labels>
+        <label locale="en_US">
+          <name>Loan renewal application date</name>
+          <description>The date to apply for a renewal to the loan.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">40</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_conditions" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Loan conditions</name>
+          <description>A statement of the conditions on a loan.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">3</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_note" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Loan note</name>
+          <description>General information about the loan.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">3</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_purpose" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Loan purpose</name>
+          <description>General information about the purpose of loan.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">3</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="movement_method" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Movement method</name>
+          <description>The method used in the movement of an object.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_movements</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="movement_note" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Movement note</name>
+          <description>Additional information about the movement of an object or group of objects.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_movements</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="planned_removal_date" datatype="DateRange">
+      <labels>
+        <label locale="en_US">
+          <name>Planned removal date</name>
+          <description>The date an object is to be removed from its current location.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">40</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_movements</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="removal_date" datatype="DateRange">
+      <labels>
+        <label locale="en_US">
+          <name>Planned removal date</name>
+          <description>The date an object was actually removed from its current location.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">40</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_movements</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="movement_reason" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Reason for move</name>
+          <description>The purpose or reason for the movement of the object or group of objects.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_movements</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="tour_description" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Introduction</name>
+          <description>Narrative description for tour. This is the primary text used when publicly presenting the tour.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_tours</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">3</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="tour_stop_description" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Introduction</name>
+          <description>Narrative description for tour stop. This is the primary text used when publicly presenting the stop.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_tour_stops</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">3</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="tour_stop_georeference" datatype="Geocode">
+      <labels>
+        <label locale="en_US">
+          <name>Georeference</name>
+          <description>Location of this stop.</description>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_tour_stops</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="lcshFull" datatype="LCSH">
+      <labels>
+        <label locale="en_US">
+          <name>Library of Congress Subject Headings</name>
+          <description>Library of Congress Subject headings describing this object. To add a new heading simply type the first few letters of the heading and choose the desired one from the displayed list of possible matches.</description>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_object_representations</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_collections</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="geonames" datatype="GeoNames">
+      <labels>
+        <label locale="en_US">
+          <name>GeoNames</name>
+          <description>A Geographic lookup that takes search text, passes it to the GeoNames search service and provides a dropdown with search results (ordered by score). Selected geoname is stored as both text (name, country, continent and ID) and the service URL identifier.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_collections</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="georeference" datatype="Geocode">
+      <labels>
+        <label locale="en_US">
+          <name>Georeference</name>
+          <description>Coordinates documenting the location of the item</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">80</setting>
+        <setting name="fieldHeight">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">100</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="description" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Description</name>
+          <description>Narrative description. This is the primary text used to document the item.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_collections</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_storage_locations</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_object_lots</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="caption" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Caption</name>
+          <description>Short descriptive caption for item.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">2</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_object_representations</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_representation_annotations</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_set_items</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="address" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Address</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <elements>
+        <metadataElement code="line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Address line 1</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="address1" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Address line 1</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">70</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Address line 1</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="address2" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Address line 2</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">70</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="line3" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Address line 3</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="city" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>City</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">20</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="stateprovince" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>State</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">15</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="postalcode" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Postal code</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">10</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="country" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Country</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">15</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="telephone" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Telephone/fax</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="maxChars">65535</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="email" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Email address</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="maxChars">65535</setting>
+        <setting name="doesNotTakeLocale">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="biography" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Description</name>
+          <description>Narrative biography for entity. This is the primary text used to document the entity.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">6</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="biography_source" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Source of description</name>
+          <description>Source of entity biography. This should be a formal citation if possible. For informal sources a narrative description is acceptable.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="fieldHeight">3</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="institution" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Institution</name>
+          <description>Name of the institution to which the collection belongs.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">70</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_collections</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreExtension" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Extension</name>
+          <description>pbcoreExtension is an extension element. Use this element as a wrapper containing a specific element from another standard.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="extension_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Extension element</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="extensionElement" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Extension element</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="extension_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Extension value</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="extensionValue" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Extension value</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="extension_line3" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Extension authority used</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="extensionAuthority" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Extension authority used</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreCoverage" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Coverage</name>
+          <description>coverage refers to either the geographic location or the time period covered by the asset’s intellectual content. For geographic locations (‘spatial’ descriptors), it is expressed by keywords such as place names (e.g. ‘Alaska’ or ‘Washington, DC’), numeric coordinates or geo-spatial data. For time-based events (‘temporal’ descriptors), it is expressed by using a date, period, era, or time-based event that is portrayed or covered in the intellectual content (e.g. ‘2007’ or ‘Victorian Era’). The PBCore metadata element coverage houses the actual spatial or temporal keywords. The companion element coverageType is used to identify the type of keywords that are being used.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pbCoverage_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Coverage</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pbCoverage_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Coverage</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="pbCoverage_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Coverage Details</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="coverageType" datatype="List" list="pbcore_coverage_types">
+              <labels>
+                <label locale="en_US">
+                  <name>Coverage Type</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="listWidth">40</setting>
+                <setting name="listHeight">200px</setting>
+                <setting name="doesNotTakeLocale">1</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="requireValue">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="implicitNullOption">0</setting>
+                <setting name="nullOptionText">Not set</setting>
+                <setting name="useDefaultWhenNull">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="render">1</setting>
+                <setting name="renderInSearchBuilder">1</setting>
+                <setting name="useSingular">0</setting>
+                <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+                <setting name="auto_shrink">0</setting>
+                <setting name="maxColumns">3</setting>
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="restrictToTypes" />
+                <setting name="currentSelectionDisplayFormat" />
+                <setting name="minimizeExistingValues">0</setting>
+                <setting name="deferHierarchyLoad">0</setting>
+                <setting name="separateDisabledValues">0</setting>
+                <setting name="hideDisabledValues">0</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="coverageSource" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Coverage Source</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="coverageRef" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Coverage Ref</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreIdentifier" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Additional PBCore Identifiers</name>
+          <description>pbcoreIdentifier is an identifier that can apply to the asset. This identifier should not be limited to a specific instantiation, but rather all instantiations of an asset. It can also hold a URL or URI that points to the asset. </description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pbcore_id" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Identifier</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="pbcore_id_source" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Identifier source</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationIdentifier" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Additional Instantiation Identifiers</name>
+          <description>instantiationIdentifier contains an unambiguous reference or identifier for a particular instantiation of an asset.</description>
+        </label>
+        <label locale="en_US">
+          <name>Additional identifiers</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="instantiation_id" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Identifier</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="instantiation_id_source" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Identifier source</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreTitle" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Additional Titles</name>
+          <description>pbcoreTitle is a name or label relevant to the asset. There may be many types of titles an asset may have, such as a series title, episode title, segment title, or project title, therefore the element is repeatable.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pbTitle_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Title</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pbTitle_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Title</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="pbTitle_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Title Details</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pbTitleType" datatype="List" list="pbcore_title_types">
+              <labels>
+                <label locale="en_US">
+                  <name>Title Type</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="listWidth">40</setting>
+                <setting name="listHeight">200px</setting>
+                <setting name="doesNotTakeLocale">1</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="requireValue">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="implicitNullOption">0</setting>
+                <setting name="nullOptionText">Not set</setting>
+                <setting name="useDefaultWhenNull">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="render">1</setting>
+                <setting name="renderInSearchBuilder">1</setting>
+                <setting name="useSingular">0</setting>
+                <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+                <setting name="auto_shrink">0</setting>
+                <setting name="maxColumns">3</setting>
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="restrictToTypes" />
+                <setting name="currentSelectionDisplayFormat" />
+                <setting name="minimizeExistingValues">0</setting>
+                <setting name="deferHierarchyLoad">0</setting>
+                <setting name="separateDisabledValues">0</setting>
+                <setting name="hideDisabledValues">0</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbTitleSource" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Title Source</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbTitleRef" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Title Ref</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreDescription" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Description</name>
+          <description>pbcoreDescription is an element that uses free-form text or a narrative to report general notes, abstracts, or summaries about the intellectual content of an asset. The information may be in the form of an individual program description, anecdotal interpretations, or brief content reviews. The description may also consist of outlines, lists, bullet points, rundowns, edit decision lists, indexes, or tables of content.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pBdescription_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Description</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pBdescription_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Description</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">5</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="pBdescription_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Description Details</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pbdescriptionType" datatype="List"
+              list="pbcore_description_types">
+              <labels>
+                <label locale="en_US">
+                  <name>Description Type</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="listWidth">40</setting>
+                <setting name="listHeight">200px</setting>
+                <setting name="doesNotTakeLocale">1</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="requireValue">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="implicitNullOption">0</setting>
+                <setting name="nullOptionText">Not set</setting>
+                <setting name="useDefaultWhenNull">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="render">1</setting>
+                <setting name="renderInSearchBuilder">1</setting>
+                <setting name="useSingular">0</setting>
+                <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+                <setting name="auto_shrink">0</setting>
+                <setting name="maxColumns">3</setting>
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="restrictToTypes" />
+                <setting name="currentSelectionDisplayFormat" />
+                <setting name="minimizeExistingValues">0</setting>
+                <setting name="deferHierarchyLoad">0</setting>
+                <setting name="separateDisabledValues">0</setting>
+                <setting name="hideDisabledValues">0</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbdescriptionSource" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Description Source</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbdescriptionRef" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Description Ref</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="primary_inst_id_source" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Primary Identifier Source</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="primary_pbcore_id_source" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Primary Identifier Source</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="primary_title_details" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Primary Title Details</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pbPrimaryTitleType" datatype="List" list="pbcore_title_types">
+          <labels>
+            <label locale="en_US">
+              <name>Title Type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="render">1</setting>
+            <setting name="renderInSearchBuilder">1</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="pbPrimaryTitleSource" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Title Source</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">255</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="pbPrimaryTitleRef" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Title Ref</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">255</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreAssetType" datatype="List" list="asset_types">
+      <labels>
+        <label locale="en_US">
+          <name>Asset Type</name>
+          <description>A broad definition of the type or description level of the intellectual content being described. </description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+        <setting name="restrictToTypes">concept</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreGenre" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Form/Genre</name>
+          <description>Describes the Form or Genre. Form describes the format and/or purpose of a Work, e.g., “non-fiction”, “short” and “animation”. Genre describes categories of Works, characterized by similar plots, themes, settings, situations, and characters. Examples of genres are “westerns” and “thrillers”.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pbGenre_line1" datatype="List" list="genre">
+          <labels>
+            <label locale="en_US">
+              <name>Genre</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes">concept</setting>
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="form" datatype="List" list="form">
+          <labels>
+            <label locale="en_US">
+              <name>Form</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes">concept</setting>
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreAudienceLevel" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Audience Level</name>
+          <description>Identifies a type of audience, viewer, or listener for whom the media item is primarily designed or educationally useful.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreAudienceRating" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Audience Rating</name>
+          <description>Designates the type of users for whom the intellectual content of a media item is intended or judged appropriate. This element differs from the element pbcoreAudienceLevel in that it utilizes standard ratings that have been crafted by the broadcast television and film industries and that are used as flags for audience or age-appropriate materials.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreRelation" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Relation</name>
+          <description>The descriptor relationType identifies the type of work bond between a media item you are cataloging and some other related media item.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="relationType" datatype="List" list="pbcore_relation_types">
+          <labels>
+            <label locale="en_US">
+              <name>Relation Type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="render">1</setting>
+            <setting name="renderInSearchBuilder">1</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="relation" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Relation</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">60</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">1</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_places</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="rightsSummary_asset" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Rights Summary</name>
+          <description>rightsSummary is used as a general free-text element to identify information about copyrights and property rights held in and over an asset or instantiation, whether they are open access or restricted in some way. If dates, times and availability periods are associated with a right, include them. End user permissions, constraints and obligations may also be identified as needed</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">5</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="rightsLink_asset" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Rights Link</name>
+          <description>rightsLink is a URI pointing to a declaration of rights.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="rightsSummary_instantiation" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Rights Summary</name>
+          <description>rightsSummary is used as a general free-text element to identify information about copyrights and property rights held in and over an asset or instantiation, whether they are open access or restricted in some way. If dates, times and availability periods are associated with a right, include them. End user permissions, constraints and obligations may also be identified as needed</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">5</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="rightsLink_instantiation" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Rights Link</name>
+          <description>rightsLink is a URI pointing to a declaration of rights.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationPhysAudio" datatype="List"
+      list="instantiation_physical_types_audio">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Physical for Audio</name>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio_analog</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationPhysMovingImages" datatype="List"
+      list="instantiation_physical_types_moving">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Physical for Moving Image</name>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_analog</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDigMovingImages" datatype="List" list="digital_file_format">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Digital for Moving Image</name>
+        </label>
+        <label locale="en_US">
+          <name>Digital file format</name>
+          <description>File format for digital moving images.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+        <setting name="restrictToTypes">concept</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDigAudio" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Digital for Audio</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">255</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationLocation" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Storage Path</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="fieldHeight">2</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationGenerations" datatype="List"
+      list="instantiation_generations_types">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Generations</name>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationTimeStart" datatype="TimeCode">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Time Start</name>
+          <description>instantiationTimeStart describes the point at which playback begins for a time-based instantiation. It is likely that the content on a tape may begin an arbitrary amount of time after the beginning of the instantiation.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">60</setting>
+        <setting name="fieldHeight">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_image</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDuration" datatype="TimeCode">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Duration</name>
+          <description>The element instantiationDuration provides a timestamp for the overall length or duration of a time-based media item. It represents the playback time. Best practice is to use a timestamp format such as HH:MM:SS[:|;]FF or HH:MM:SS.mmm or S.mmm.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">60</setting>
+        <setting name="fieldHeight">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_image</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDataRate" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Data Rate</name>
+          <description>The amount of data in a digital media file that is encoded, delivered or distributed, for every second of time.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="instantiationDataRate_text" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Instantiation Data Rate</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="instantiationDataRate_units" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Units of Measure</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationFileSize" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation File Size</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="instantiationFileSize_text" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Instantiation File Size</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="instantiationFileSize_units" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Units of Measure</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_digital</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationTracks" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Tracks</name>
+          <description>The element instantiationTracks is simply intended to indicate the number and type of tracks that are found in a media item, whether it is analog or digital. (e.g. 1 video track, 2 audio tracks, 1 text track, 1 sprite track, etc.) Other configuration information specific to these identified tracks should be described using instantiationChannelConfiguration.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_image</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationLanguage" datatype="List" list="languages">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Language</name>
+          <description>instantiationLanguage identifies the primary language of the tracks’ audio or text. Languages must be indicated using 3-letter codes standardized in ISO 639-2 or 639-3. If an instantiation includes more than one language, the element can be repeated. Alternately, both languages can be expressed in one element by separating two three-letter codes with a semicolon, i.e. eng;fre.</description>
+        </label>
+        <label locale="en_US">
+          <name>Language</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+        <setting name="restrictToTypes">concept</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationEssenceTrack" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Essence Track</name>
+          <description>instantiationEssenceTrack is an XML container element that allows for grouping of related essenceTrack elements and their repeated use. Use instantiationEssenceTrack element to describe the individual streams that comprise an instantiation, such as audio, video, timecode, etc.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="essence_line01" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Type</name>
+              <description>essenceTrackType refers to the media type of the decoded data. Tracks may possibly be of these types: video, audio, caption, metadata, image, etc.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackType" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Type</name>
+                  <description>essenceTrackType refers to the media type of the decoded data. Tracks may possibly be of these types: video, audio, caption, metadata, image, etc.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line02" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Identifier</name>
+              <description>essenceTrackIdentifier is an identifier of the track. Several audiovisual containers include such identifier schema to identify each track, such as MPEG2 PIDs or QuickTime Track ids</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackIdentifier" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Identifier</name>
+                  <description>essenceTrackIdentifier is an identifier of the track. Several audiovisual containers include such identifier schema to identify each track, such as MPEG2 PIDs or QuickTime Track ids</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line03" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Identifier Source</name>
+              <description>the name of the software or tool that provided the Track Identifier</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackIdentifierSource" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Identifier Source</name>
+                  <description>the name of the software or tool that provided the Track Identifier</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line04" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Standard</name>
+              <description>essenceTrackStandard should be be used with file-based instantiations to describe the broadcast standard of the video signal (e.g. NTSC, PAL) or to further clarify the standard of the essenceTrackEncoding format.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackStandard" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Standard</name>
+                  <description>essenceTrackStandard should be be used with file-based instantiations to describe the broadcast standard of the video signal (e.g. NTSC, PAL) or to further clarify the standard of the essenceTrackEncoding format.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line05" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Encoding</name>
+              <description>essenceTrackEncoding identifies how the actual information in an instantiation is compressed, interpreted, or formulated using a particular scheme. Identifying the encoding used is beneficial for a number of reasons, including as a way to achieve reversible compression; for the construction of document indices to facilitate searching and access; or for efficient distribution of the information across data networks with differing bandwidths or pipeline capacities. Human-readable encoding value should be placed here.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackEncoding" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Encoding</name>
+                  <description>essenceTrackEncoding identifies how the actual information in an instantiation is compressed, interpreted, or formulated using a particular scheme. Identifying the encoding used is beneficial for a number of reasons, including as a way to achieve reversible compression; for the construction of document indices to facilitate searching and access; or for efficient distribution of the information across data networks with differing bandwidths or pipeline capacities. Human-readable encoding value should be placed here.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line06" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Data Rate</name>
+              <description>essenceTrackDataRate measures the amount of data used per time interval for encoded data. The data rate can be calculated by dividing the total data size of the track's encoded data by a time unit.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackDataRate_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Data Rate</name>
+                  <description>essenceTrackDataRate measures the amount of data used per time interval for encoded data. The data rate can be calculated by dividing the total data size of the track's encoded data by a time unit.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackDataRate_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line07" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Time Start</name>
+              <description>essenceTrackTimeStart provides a time stamp for the beginning point of playback for a time-based essence track. It is likely that the content on a tape may begin an arbitrary amount of time after the beginning of the instantiation.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackTimeStart" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Time Start</name>
+                  <description>essenceTrackTimeStart provides a time stamp for the beginning point of playback for a time-based essence track. It is likely that the content on a tape may begin an arbitrary amount of time after the beginning of the instantiation.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line08" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Duration</name>
+              <description>essenceTrackDuration provides a timestamp for the overall length or duration of a track. It represents the track playback time</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackDuration" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Duration</name>
+                  <description>essenceTrackDuration provides a timestamp for the overall length or duration of a track. It represents the track playback time</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line09" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Bit Depth</name>
+              <description>essenceTrackBitDepth specifies how much data is sampled when information is digitized, encoded, or converted for an instantiation (specifically, audio, video, or image). Bit depth is measured in bits and generally implies an arbitrary perception of quality during playback of an instantiation (the higher the bit depth, the greater the fidelity).</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackBitDepth_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Bit Depth</name>
+                  <description>essenceTrackBitDepth specifies how much data is sampled when information is digitized, encoded, or converted for an instantiation (specifically, audio, video, or image). Bit depth is measured in bits and generally implies an arbitrary perception of quality during playback of an instantiation (the higher the bit depth, the greater the fidelity).</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackBitDepth_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line10" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Sampling Rate</name>
+              <description>essenceTrackSamplingRate measures how often data is sampled when information from the audio portion from an instantiation is digitized. For a digital audio signal, the sampling rate is measured in kilohertz and is an indicator of the perceived playback quality of the media item (the higher the sampling rate, the greater the fidelity).</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackSamplingRate_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Sampling Rate</name>
+                  <description>essenceTrackSamplingRate measures how often data is sampled when information from the audio portion from an instantiation is digitized. For a digital audio signal, the sampling rate is measured in kilohertz and is an indicator of the perceived playback quality of the media item (the higher the sampling rate, the greater the fidelity).</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackSamplingRate_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Sampling Rate</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line11" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Playback Speed</name>
+              <description>essenceTrackPlaybackSpeed specifies the rate of units against time at which the media track should be rendered for human consumption. e.g., 15ips (inches per second).</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackPlaybackSpeed_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Playback Speed</name>
+                  <description>essenceTrackPlaybackSpeed specifies the rate of units against time at which the media track should be rendered for human consumption. e.g., 15ips (inches per second).</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackPlaybackSpeed_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line12" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Frame Size</name>
+              <description>essenceTrackFrameSize measures the width and height of the encoded video or image track. The frame size refers to the size of the encoded pixels and not the size of the displayed image. It may be expressed as combination of pixels measured horizontally vs. the number of pixels of image/resolution data stacked vertically (interlaced and progressive scan).</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackFrameSize_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Frame Size</name>
+                  <description>essenceTrackFrameSize measures the width and height of the encoded video or image track. The frame size refers to the size of the encoded pixels and not the size of the displayed image. It may be expressed as combination of pixels measured horizontally vs. the number of pixels of image/resolution data stacked vertically (interlaced and progressive scan).</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackFrameSize_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line13" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Aspect Ratio</name>
+              <description>essenceTrackAspectRatio indicates the ratio of horizontal to vertical proportions in the display of a static image or moving image.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackAspectRatio_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Aspect Ratio</name>
+                  <description>essenceTrackAspectRatio indicates the ratio of horizontal to vertical proportions in the display of a static image or moving image.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackAspectRatio_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line14" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Frame Rate</name>
+              <description>essenceTrackFrameRate is relevant to tracks of video track type only. The frame rate is calculated by dividing the total number of frames by the duration of the video track. By default measure frame rate in frames per second expressed as fps as a unit of measure. e.g., 24 fps.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackFrameRate_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Frame Rate</name>
+                  <description>essenceTrackFrameRate is relevant to tracks of video track type only. The frame rate is calculated by dividing the total number of frames by the duration of the video track. By default measure frame rate in frames per second expressed as fps as a unit of measure. e.g., 24 fps.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackFrameRate_units" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Units of Measure</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line15" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Language</name>
+              <description>essenceTrackLanguage identifies the primary language of the tracks’ audio or text. Languages must be indicated using 3-letter codes standardized in ISO 639-2 or 639-3. If an instantiation includes more than one language, the element can be repeated. Alternately, both languages can be expressed in one element by separating two three-letter codes with a semicolon, i.e. eng;fre.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackLanguage" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Language</name>
+                  <description>essenceTrackLanguage identifies the primary language of the tracks’ audio or text. Languages must be indicated using 3-letter codes standardized in ISO 639-2 or 639-3. If an instantiation includes more than one language, the element can be repeated. Alternately, both languages can be expressed in one element by separating two three-letter codes with a semicolon, i.e. eng;fre.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="essence_line16" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Track Annotation</name>
+              <description>essenceTrackAnnotation can store any supplementary information about a track or the metadata used to describe it. It clarifies element values, terms, descriptors, and vocabularies that may not be otherwise sufficiently understood.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="trackAnnotation_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Track Annotation</name>
+                  <description>essenceTrackAnnotation can store any supplementary information about a track or the metadata used to describe it. It clarifies element values, terms, descriptors, and vocabularies that may not be otherwise sufficiently understood.</description>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">3</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="trackAnnotation_type" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Annotation Type</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">50</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">250</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_image</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">250</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreSubject" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Subject</name>
+          <description>pbcoreSubject is used to assign topic headings or keywords that portray the intellectual content of the asset. A subject is expressed by keywords, key phrases, or even specific classification codes. Controlled vocabularies, authorities, formal classification codes, as well as folksonomies and user-generated tags, may be employed when assigning descriptive subject terms.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pbSubject_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Subject</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pbSubject_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Subject</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="pbSubject_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Subject Details</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pbSubjectType" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Subject Type</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbSubjectSource" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Subject Source</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+            <metadataElement code="pbSubjectRef" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Subject Ref</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">30</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreAnnotation" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Annotation</name>
+          <description>pbcoreAnnotation allows the addition of any supplementary information about the metadata used to describe the PBCore record. pbcoreAnnotation clarifies element values, terms, descriptors, and vocabularies that may not be otherwise sufficiently understood.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pbAnnotation_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Annotation</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pbAnnotation_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Annotation</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">5</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="pbAnnotation_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Annotation Type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="pbAnnotationType" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Annotation Type</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationAnnotation" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Annotation</name>
+          <description>instantiationAnnotation is used to add any supplementary information about an instantiation of the instantiation or the metadata used to describe it. It clarifies element values, terms, descriptors, and vocabularies that may not be otherwise sufficiently understood.</description>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="instAnnotation_line1" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Annotation</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="instAnnotation_text" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Annotation</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">5</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">65535</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+        <metadataElement code="instAnnotation_line2" datatype="Container">
+          <labels>
+            <label locale="en_US">
+              <name>Annotation Type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="lineBreakAfterNumberOfElements">0</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="readonlyTemplate" />
+            <setting name="includeSourceData">0</setting>
+          </settings>
+          <elements>
+            <metadataElement code="instAnnotationType" datatype="Text">
+              <labels>
+                <label locale="en_US">
+                  <name>Annotation Type</name>
+                </label>
+              </labels>
+              <settings>
+                <setting name="fieldWidth">100</setting>
+                <setting name="fieldHeight">1</setting>
+                <setting name="minChars">0</setting>
+                <setting name="maxChars">255</setting>
+                <setting name="regex" />
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="doesNotTakeLocale">0</setting>
+                <setting name="singleValuePerLocale">0</setting>
+                <setting name="allowDuplicateValues">0</setting>
+                <setting name="raiseErrorOnDuplicateValue">0</setting>
+                <setting name="canBeUsedInSort">1</setting>
+                <setting name="suggestExistingValues">0</setting>
+                <setting name="suggestExistingValueSort">value</setting>
+                <setting name="default_text" />
+                <setting name="canBeUsedInSearchForm">1</setting>
+                <setting name="canBeUsedInDisplay">1</setting>
+                <setting name="canMakePDF">0</setting>
+                <setting name="canMakePDFForValue">0</setting>
+                <setting name="displayTemplate" />
+                <setting name="displayDelimiter">; </setting>
+                <setting name="isDependentValue">0</setting>
+                <setting name="dependentValueTemplate" />
+                <setting name="mustBeUnique">0</setting>
+                <setting name="referenceMediaIn" />
+                <setting name="moveArticles">1</setting>
+                <setting name="includeSourceData">0</setting>
+              </settings>
+            </metadataElement>
+          </elements>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">255</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="pbcoreDate" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Asset Date</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="pbcoreDates_value" datatype="DateRange">
+          <labels>
+            <label locale="en_US">
+              <name>Date</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="dateFormat" />
+            <setting name="dateRangeBoundaries" />
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="useDatePicker">0</setting>
+            <setting name="datePickerDateFormat">yy-mm-dd</setting>
+            <setting name="mustNotBeBlank">0</setting>
+            <setting name="isLifespan">0</setting>
+            <setting name="default_text" />
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">,</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="pbCoreDates_types" datatype="List" list="pbcore_dates_types">
+          <labels>
+            <label locale="en_US">
+              <name>Type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="render">1</setting>
+            <setting name="renderInSearchBuilder">1</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_occurrences</table>
+          <settings>
+            <setting name="minAttributesPerRow">1</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDate" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Date</name>
+        </label>
+        <label locale="en_US">
+          <name>Date</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="instantiationDates_value" datatype="DateRange">
+          <labels>
+            <label locale="en_US">
+              <name>Date</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="dateFormat" />
+            <setting name="dateRangeBoundaries" />
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="useDatePicker">0</setting>
+            <setting name="datePickerDateFormat">yy-mm-dd</setting>
+            <setting name="mustNotBeBlank">0</setting>
+            <setting name="isLifespan">0</setting>
+            <setting name="default_text" />
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">,</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="instantiationDates_types" datatype="List" list="pbcore_dates_types">
+          <labels>
+            <label locale="en_US">
+              <name>Type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="render">1</setting>
+            <setting name="renderInSearchBuilder">1</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationStandard" datatype="List" list="broadcast_standards">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Standard</name>
+          <description>If the instantiation is a physical item, instantiationStandard can be used to refer to the broadcast standard of the video signal (e.g. NTSC, PAL), or the audio encoding (e.g. Dolby A, vertical cut). If the instantiation is a digital item, instantiationStandard should be used to express the container format of the digital file (e.g. MXF).</description>
+        </label>
+        <label locale="en_US">
+          <name>Broadcast standard</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+        <setting name="restrictToTypes">concept</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationAlternativeModes" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Alternative Modes</name>
+          <description>instantiationAlternativeModes is a catch-all metadata element that identifies equivalent alternatives to the primary visual, sound or textual information that exists in an instantiation. These are modes that offer alternative ways to see, hear, and read the content of an instantiation. Examples include DVI (Descriptive Video Information), SAP (Supplementary Audio Program), ClosedCaptions, OpenCaptions, Subtitles, Language Dubs, and Transcripts. For each instance of available alternativeModes, the mode and its associated language should be identified together, if applicable. Examples include ‘SAP in English,’ ‘SAP in Spanish,’ ‘Subtitle in French,’ ‘OpenCaption in Arabic.’</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="fieldWidth">100</setting>
+        <setting name="maxChars">65535</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="instantiationDimensions" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Instantiation Dimensions</name>
+          <description>Specifies either the dimensions of a physical instantiation, or high-level visual dimensions.
+
+Best Practice: For physical dimensions, usage examples might be 7″ for an audio reel. When describing visual dimensions, use this for high-level descriptors such as 1080p.</description>
+        </label>
+        <label locale="en_US">
+          <name>Dimensions</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="instantiationDimensions_text" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Instantiation Dimensions</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="instantiationDimensions_units" datatype="List"
+          list="units_dimensions">
+          <labels>
+            <label locale="en_US">
+              <name>Units of measure</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">30</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="listWidth">10</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes">concept</setting>
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">10</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="entity_attributes" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Entity Attributes</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="entitySource" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Entity Source</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">50</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">255</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="entityRef" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Entity Ref</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">50</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">255</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_entities</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="acquisition_date" datatype="DateRange">
+      <labels>
+        <label locale="en_US">
+          <name>Acquisition Date</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="useDatePicker">1</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_object_lots</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">0</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="storage_format" datatype="List" list="storage_formats">
+      <labels>
+        <label locale="en_US">
+          <name>Storage Format</name>
+          <description>For Analog: 1000 ft can, etc. For Digital: Hard Drive, LTO, etc.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+        <setting name="restrictToTypes">concept</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="frame_rate" datatype="List" list="frame_rates">
+      <labels>
+        <label locale="en_US">
+          <name>Frame rate</name>
+          <description>The native frames per second rate. Information related to the frame rate used during a digitization process is added to Transfer Speed.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="resolution" datatype="List" list="resolutions">
+      <labels>
+        <label locale="en_US">
+          <name>Resolution</name>
+          <description>E.g., Standard Definition, High Definition, 2k, 4k, 6k, 8k</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="overall_condition" datatype="List" list="condition_levels">
+      <labels>
+        <label locale="en_US">
+          <name>Overall Condition</name>
+          <description>High-level description of the condition of the Object and its Components, where relevant. </description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+        <setting name="restrictToTypes">concept</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="object_purpose" datatype="List" list="object_purposes">
+      <labels>
+        <label locale="en_US">
+          <name>Object purpose</name>
+          <description>Describes purpose or function of the Object, e.g., Archival copy, Research copy, Conservation copy, etc.</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="barcode" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Barcode</name>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">0</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="deterioration" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Deterioration</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="lineBreakAfterNumberOfElements">2</setting>
+        <setting name="canBeUsedInSearchForm">0</setting>
+        <setting name="canBeUsedInDisplay">0</setting>
+      </settings>
+      <elements>
+        <metadataElement code="deterioration_level" datatype="List" list="condition_levels">
+          <labels>
+            <label locale="en_US">
+              <name>Deterioration level</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="deterioration_type" datatype="List" list="deterioration_types">
+          <labels>
+            <label locale="en_US">
+              <name>Deterioration type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="deterioration_notes" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Deterioration notes</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">90</setting>
+            <setting name="fieldHeight">5</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio_analog</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">0</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_analog</type>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">0</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="condition" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Condition</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="lineBreakAfterNumberOfElements">2</setting>
+        <setting name="canBeUsedInSearchForm">0</setting>
+        <setting name="canBeUsedInDisplay">0</setting>
+      </settings>
+      <elements>
+        <metadataElement code="condition_type" datatype="List" list="condition_types">
+          <labels>
+            <label locale="en_US">
+              <name>Condition type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="condition_level" datatype="List" list="condition_levels">
+          <labels>
+            <label locale="en_US">
+              <name>Condition level</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="condition_notes" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Condition notes</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">90</setting>
+            <setting name="fieldHeight">5</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">0</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="specific_component_number" datatype="Text">
+      <labels>
+        <label locale="en_US">
+          <name>Specific Component Number</name>
+          <description>Denotes the actual component number.</description>
+        </label>
+      </labels>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">0</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="loan_status" datatype="List" list="loan_status">
+      <labels>
+        <label locale="en_US">
+          <name>Loan Status</name>
+          <description>Indicates the status of the loan, e.g., "Requested", "Approved", "Returned"</description>
+        </label>
+      </labels>
+      <settings>
+        <setting name="doesNotTakeLocale">0</setting>
+        <setting name="render">select</setting>
+        <setting name="renderInSearchBuilder">select</setting>
+        <setting name="restrictToTypes">concept</setting>
+      </settings>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_loans</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">0</setting>
+            <setting name="minimumAttributeBundlesToDisplay">0</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="carrier_type" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Carrier type</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="instantiationMediaType" datatype="List"
+          list="instantiation_media_types">
+          <labels>
+            <label locale="en_US">
+              <name>Instantiation Media Type</name>
+            </label>
+            <label locale="en_US">
+              <name>General carrier type</name>
+              <description>The broad media type of the Object. Recording this high-level information will enable simple searching for only film, video, digital, etc. elements rather than searching by all possible formats and carriers.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes">concept</setting>
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="specific_carrier_type" datatype="List"
+          list="instantiation_physical_types_moving">
+          <labels>
+            <label locale="en_US">
+              <name>Specific carrier type</name>
+            </label>
+          </labels>
+          <settings>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="material_characteristics" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Material characteristics</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="base" datatype="List" list="bases">
+          <labels>
+            <label locale="en_US">
+              <name>Base</name>
+              <description>The physical material or video format, e.g., describing the flexible transparent material that supports a film object’s emulsion or a magnetic track, (e.g., acetate, nitrate, CTA, etc.). </description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="stock_type" datatype="List" list="stock_types">
+          <labels>
+            <label locale="en_US">
+              <name>Stock type</name>
+              <description>Describes the specific stock/brand on which the Item is captured, for example, Eastman Kodak, Fuji, 3M, etc. This element should be used for all media: film, video, audio, optical, digital tape, external hard drives.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="stock_batch" datatype="Text">
+          <labels>
+            <label locale="en_US">
+              <name>Stock batch</name>
+              <description>The stock batch number or edge code of the media the Item is captured on. This can be a video, audio, optical media, or digital tape stock. Identifying the batch number can assist in identifying problems related to specific manufactured batches</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_analog</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+        <restriction>
+          <table>ca_objects</table>
+          <type>audio_analog</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="projection_characteristics" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Projection characteristics</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="aspect_ratio" datatype="List" list="aspect_ratios">
+          <labels>
+            <label locale="en_US">
+              <name>Aspect ratio</name>
+              <description>The projected image area visible on screen, expressed as a value of width to height (the value of height always being “1”), e.g., 2.34:1, 2.39:1.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="aperture" datatype="List" list="apertures">
+          <labels>
+            <label locale="en_US">
+              <name>Aperture</name>
+              <description>The actual exposed image or picture area as it appears on the moving image itself, e.g., Academy, Full screen, Widescreen, etc. The image format does not necessarily bear any relation to the projection ratio (aspect ratio) of the moving image.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <type>moving_image</type>
+          <includeSubtypes>1</includeSubtypes>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="sound_characteristics" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Sound characteristics</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="lineBreakAfterNumberOfElements">2</setting>
+      </settings>
+      <elements>
+        <metadataElement code="instantiationChanConf" datatype="List"
+          list="sound_channel_configurations">
+          <labels>
+            <label locale="en_US">
+              <name>Sound channel configuration</name>
+              <description>The element instantiationChannelConfiguration is designed to indicate, at a general narrative level, the arrangement or configuration of specific channels or layers of information within an instantiation’s tracks. Examples are 2-track mono, 8- track stereo, or video track with alpha channel.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">100</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="sound_type" datatype="List" list="sound_types">
+          <labels>
+            <label locale="en_US">
+              <name>Sound type</name>
+              <description>Indicate the presence or absence of sound, e.g.,. “sound,” “silent,” “mute”. </description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="doesNotTakeLocale">1</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="restrictToTypes">concept</setting>
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+            <setting name="includeSourceData">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="sound_system" datatype="List" list="sound_systems">
+          <labels>
+            <label locale="en_US">
+              <name>Sound system</name>
+              <description>Describes the technical or proprietary system used to record the sound, e.g., Dolby SR, Dolby Digital, etc. </description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="sound_fixation_type" datatype="List" list="sound_fixation_types">
+          <labels>
+            <label locale="en_US">
+              <name>Sound fixation type</name>
+              <description>The name of the physical principle of sound recording, e.g., “Needle,”, “Optical,” “Magnetic,” etc. </description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+    <metadataElement code="color_characteristics" datatype="Container">
+      <labels>
+        <label locale="en_US">
+          <name>Color characteristics</name>
+        </label>
+      </labels>
+      <elements>
+        <metadataElement code="instantiationColors" datatype="List" list="color_types">
+          <labels>
+            <label locale="en_US">
+              <name>Color type</name>
+              <description>Indicates the overall color, grayscale, or black and white nature of the presentation of an instantiation, as a single occurrence or combination of occurrences in or throughout the instantiation.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="fieldWidth">100</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">65535</setting>
+            <setting name="regex" />
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+        <metadataElement code="color_standard" datatype="List" list="color_standards">
+          <labels>
+            <label locale="en_US">
+              <name>Color standard</name>
+              <description>The system or process by which color is fixed on the carrier or as part of the digital encoding, e.g., Pathécolor, Technicolor, etc.</description>
+            </label>
+          </labels>
+          <settings>
+            <setting name="minChars">0</setting>
+            <setting name="maxChars">16777216</setting>
+            <setting name="regex" />
+            <setting name="fieldWidth">40</setting>
+            <setting name="fieldHeight">1</setting>
+            <setting name="usewysiwygeditor">0</setting>
+            <setting name="doesNotTakeLocale">0</setting>
+            <setting name="singleValuePerLocale">0</setting>
+            <setting name="allowDuplicateValues">0</setting>
+            <setting name="raiseErrorOnDuplicateValue">0</setting>
+            <setting name="canBeUsedInSort">1</setting>
+            <setting name="suggestExistingValues">0</setting>
+            <setting name="suggestExistingValueSort">value</setting>
+            <setting name="default_text" />
+            <setting name="canBeUsedInSearchForm">1</setting>
+            <setting name="canBeUsedInDisplay">1</setting>
+            <setting name="canMakePDF">0</setting>
+            <setting name="canMakePDFForValue">0</setting>
+            <setting name="displayTemplate" />
+            <setting name="displayDelimiter">; </setting>
+            <setting name="isDependentValue">0</setting>
+            <setting name="dependentValueTemplate" />
+            <setting name="mustBeUnique">0</setting>
+            <setting name="referenceMediaIn" />
+            <setting name="moveArticles">1</setting>
+            <setting name="includeSourceData">0</setting>
+            <setting name="render">select</setting>
+            <setting name="renderInSearchBuilder">select</setting>
+            <setting name="listWidth">40</setting>
+            <setting name="listHeight">200px</setting>
+            <setting name="requireValue">0</setting>
+            <setting name="implicitNullOption">0</setting>
+            <setting name="nullOptionText">Not set</setting>
+            <setting name="useDefaultWhenNull">0</setting>
+            <setting name="useSingular">0</setting>
+            <setting name="useTextEntryInSearchBuilderWhenListLongerThan">500</setting>
+            <setting name="auto_shrink">0</setting>
+            <setting name="maxColumns">3</setting>
+            <setting name="restrictToTypes" />
+            <setting name="currentSelectionDisplayFormat" />
+            <setting name="minimizeExistingValues">0</setting>
+            <setting name="deferHierarchyLoad">0</setting>
+            <setting name="separateDisabledValues">0</setting>
+            <setting name="hideDisabledValues">0</setting>
+          </settings>
+        </metadataElement>
+      </elements>
+      <typeRestrictions>
+        <restriction>
+          <table>ca_objects</table>
+          <settings>
+            <setting name="minAttributesPerRow">0</setting>
+            <setting name="maxAttributesPerRow">1</setting>
+            <setting name="minimumAttributeBundlesToDisplay">1</setting>
+          </settings>
+        </restriction>
+      </typeRestrictions>
+    </metadataElement>
+  </elementSets>
+  <userInterfaces>
+    <userInterface code="loan_cataloguers_ui" type="ca_loans">
+      <labels>
+        <label locale="en_US">
+          <name>Loan editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="status4">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Record Status</setting>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_status2">
+              <bundle>ca_loans.loan_status</bundle>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Short description of loan</setting>
+                <setting name="add_label" locale="en_US">Add short description</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_authorization_date">
+              <bundle>ca_loans.loan_authorization_date</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_in_date">
+              <bundle>ca_loans.loan_in_date</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_out_date">
+              <bundle>ca_loans.loan_out_date</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_return_date">
+              <bundle>ca_loans.loan_return_date</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_renewal_date">
+              <bundle>ca_loans.loan_renewal_date</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_conditions">
+              <bundle>ca_loans.loan_conditions</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_note">
+              <bundle>ca_loans.loan_note</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_loan_purpose">
+              <bundle>ca_loans.loan_purpose</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="history_tracking_chronology13">
+              <bundle>history_tracking_chronology</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_movements">
+              <bundle>ca_movements</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_storage_locations5">
+              <bundle>ca_storage_locations</bundle>
+            </placement>
+            <placement code="ca_object_representations4">
+              <bundle>ca_object_representations</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="movement_cataloguers_ui" type="ca_movements">
+      <labels>
+        <label locale="en_US">
+          <name>Movement editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Short description of movement</setting>
+                <setting name="add_label" locale="en_US">Add short description</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_planned_removal_date">
+              <bundle>ca_movements.planned_removal_date</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_removal_date">
+              <bundle>ca_movements.removal_date</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_movement_method">
+              <bundle>ca_movements.movement_method</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_movement_reason">
+              <bundle>ca_movements.movement_reason</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_movement_note">
+              <bundle>ca_movements.movement_note</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_objects9">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="restrict_to_types">moving_analog</setting>
+                <setting name="restrict_to_types">moving_component</setting>
+                <setting name="restrict_to_types">moving_digital</setting>
+                <setting name="restrict_to_types">moving_component</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_storage_locations10">
+              <bundle>ca_storage_locations</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_object_lots">
+              <bundle>ca_object_lots</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="list_cataloguers_ui" type="ca_lists">
+      <labels>
+        <label locale="en_US">
+          <name>List editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="list_code">
+              <bundle>list_code</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="default_sort">
+              <bundle>default_sort</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="is_hierarchical">
+              <bundle>is_hierarchical</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="is_system_list">
+              <bundle>is_system_list</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="use_as_vocabulary">
+              <bundle>use_as_vocabulary</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="list_item_cataloguers_ui" type="ca_list_items">
+      <labels>
+        <label locale="en_US">
+          <name>List item editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hier_location">
+              <bundle>hierarchy_location</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse">dont_force</setting>
+                <setting name="open_hierarchy">1</setting>
+                <setting name="auto_shrink">0</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="item_value">
+              <bundle>item_value</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="is_enabled">
+              <bundle>is_enabled</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="is_default">
+              <bundle>is_default</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="rank">
+              <bundle>rank</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="color">
+              <bundle>color</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="icon">
+              <bundle>icon</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_settings">
+              <bundle>settings</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="related" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Related list items</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_list_items">
+              <bundle>ca_list_items</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="relationship_types_config_ui" type="ca_relationship_types">
+      <labels>
+        <label locale="en_US">
+          <name>Relationship types configuration editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Relationship names</setting>
+                <setting name="add_label" locale="en_US">Add relationship name</setting>
+              </settings>
+            </placement>
+            <placement code="type_code">
+              <bundle>type_code</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="is_default">
+              <bundle>is_default</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="sub_type_left_id">
+              <bundle>sub_type_left_id</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="include_subtypes_left">
+              <bundle>include_subtypes_left</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="sub_type_right_id">
+              <bundle>sub_type_right_id</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="include_subtypes_right">
+              <bundle>include_subtypes_right</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="rank">
+              <bundle>rank</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="hierarchy_location">
+              <bundle>hierarchy_location</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse">dont_force</setting>
+                <setting name="open_hierarchy">1</setting>
+                <setting name="auto_shrink">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="set_cataloguers_ui" type="ca_sets">
+      <labels>
+        <label locale="en_US">
+          <name>Set editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="set_info" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Set info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Set title</setting>
+                <setting name="add_label" locale="en_US">Add title</setting>
+              </settings>
+            </placement>
+            <placement code="set_code">
+              <bundle>set_code</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_set_description">
+              <bundle>ca_sets.set_description</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_users">
+              <bundle>ca_users</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_user_groups">
+              <bundle>ca_user_groups</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="items" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Items</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_set_items">
+              <bundle>ca_set_items</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="set_item_cataloguers_ui" type="ca_set_items">
+      <labels>
+        <label locale="en_US">
+          <name>Set item editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Caption</setting>
+                <setting name="add_label" locale="en_US">Add caption</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_set_item_is_primary">
+              <bundle>ca_set_items.set_item_is_primary</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_set_item_description">
+              <bundle>ca_set_items.set_item_description</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="search_forms_config_ui" type="ca_search_forms">
+      <labels>
+        <label locale="en_US">
+          <name>Search forms configuration editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Form name</setting>
+                <setting name="add_label" locale="en_US">Add form name</setting>
+              </settings>
+            </placement>
+            <placement code="form_code">
+              <bundle>form_code</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="is_system">
+              <bundle>is_system</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_search_form_placements">
+              <bundle>ca_search_form_placements</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_settings">
+              <bundle>settings</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_search_form_type_restrictions">
+              <bundle>ca_search_form_type_restrictions</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_users">
+              <bundle>ca_users</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_user_groups">
+              <bundle>ca_user_groups</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="bundle_display_config_ui" type="ca_bundle_displays">
+      <labels>
+        <label locale="en_US">
+          <name>Display list configuration editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Display list name</setting>
+                <setting name="add_label" locale="en_US">Add display list name</setting>
+              </settings>
+            </placement>
+            <placement code="display_code">
+              <bundle>display_code</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="is_system">
+              <bundle>is_system</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="settings">
+              <bundle>settings</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_bundle_display_type_restrictions">
+              <bundle>ca_bundle_display_type_restrictions</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_users">
+              <bundle>ca_users</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_user_groups">
+              <bundle>ca_user_groups</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="placements" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Display list</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_bundle_display_placements">
+              <bundle>ca_bundle_display_placements</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="metadata_alert_rule_config_ui" type="ca_metadata_alert_rules">
+      <labels>
+        <label locale="en_US">
+          <name>Metadata alert rule editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Metadata alert rule name</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+            <placement code="ca_metadata_alert_triggers">
+              <bundle>ca_metadata_alert_triggers</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_users">
+              <bundle>ca_users</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="label" locale="en_US">Recipient users</setting>
+                <setting name="add_label" locale="en_US">Add user</setting>
+              </settings>
+            </placement>
+            <placement code="ca_user_groups">
+              <bundle>ca_user_groups</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="label" locale="en_US">Recipient user groups</setting>
+                <setting name="add_label" locale="en_US">Add group</setting>
+              </settings>
+            </placement>
+            <placement code="ca_metadata_alert_rule_type_restrictions">
+              <bundle>ca_metadata_alert_rule_type_restrictions</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="code">
+              <bundle>code</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="tour_editor_ui" type="ca_tours">
+      <labels>
+        <label locale="en_US">
+          <name>Tour editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Tour title</setting>
+                <setting name="add_label" locale="en_US">Add title</setting>
+              </settings>
+            </placement>
+            <placement code="tour_code">
+              <bundle>tour_code</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_tour_description">
+              <bundle>ca_tours.tour_description</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="icon">
+              <bundle>icon</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="color">
+              <bundle>color</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="tour_stop_editor_ui" type="ca_tour_stops">
+      <labels>
+        <label locale="en_US">
+          <name>Tour stop editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Tour stop title</setting>
+                <setting name="add_label" locale="en_US">Add title</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_tour_stop_description">
+              <bundle>ca_tour_stops.tour_stop_description</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_tour_stop_georeference">
+              <bundle>ca_tour_stops.tour_stop_georeference</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="icon">
+              <bundle>icon</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="color">
+              <bundle>color</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+            <placement code="ca_occurrences">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_collections">
+              <bundle>ca_collections</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="useHierarchicalBrowser">0</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+            <placement code="ca_tour_stops">
+              <bundle>ca_tour_stops</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="keywords" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Keywords</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_list_items">
+              <bundle>ca_list_items</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="site_page_editor_ui" type="ca_site_pages">
+      <labels>
+        <label locale="en_US">
+          <name>Site page editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="title">
+              <bundle>title</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="path">
+              <bundle>path</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="description">
+              <bundle>ca_site_pages.description</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_site_pages_content">
+              <bundle>ca_site_pages_content</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="keywords">
+              <bundle>keywords</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_representation_ui" type="ca_object_representations">
+      <labels>
+        <label locale="en_US">
+          <name>Object representation editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Title</setting>
+                <setting name="add_label" locale="en_US">Add Title</setting>
+              </settings>
+            </placement>
+            <placement code="media">
+              <bundle>media</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_caption">
+              <bundle>ca_object_representations.caption</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="annotations" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Annotations</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_representation_annotations">
+              <bundle>ca_representation_annotations</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="data_dictionary" type="ca_metadata_dictionary_entries">
+      <labels>
+        <label locale="en_US">
+          <name>Data dictionary editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="0" color="000000">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels1">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="bundle_name4">
+              <bundle>bundle_name</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="table_num4">
+              <bundle>table_num</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_metadata_dictionary_rules6">
+              <bundle>ca_metadata_dictionary_rules</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="settings6">
+              <bundle>settings</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_object_ui" type="ca_objects">
+      <labels>
+        <label locale="en_US">
+          <name>Standard object editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic_pbcore" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+              </settings>
+            </placement>
+            <placement code="access" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Primary identifier</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationIdentifier">
+              <bundle>ca_objects.instantiationIdentifier</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_object_purpose7" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.object_purpose</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Title</setting>
+                <setting name="add_label" locale="en_US">Add Title</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationDate" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.instantiationDate</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationDigMovingImages">
+              <bundle>ca_objects.instantiationDigMovingImages</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationDigAudio" typeRestrictions="audio_digital">
+              <bundle>ca_objects.instantiationDigAudio</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="extent12">
+              <bundle>extent</bundle>
+            </placement>
+            <placement code="extent_units13" typeRestrictions="audio_analog,audio_digital,moving_analog,moving_component,moving_digital">
+              <bundle>extent_units</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationDimensions" typeRestrictions="audio_analog,audio_digital,moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.instantiationDimensions</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="description" locale="en_US">Specifies either the dimensions of a physical instantiation, or high-level visual dimensions.&#13;
+&#13;
+Best Practice: For physical dimensions, usage examples might be 7″ for an audio reel. When describing visual dimensions, use this for high-level descriptors such as 1080p.</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_carrier_type12">
+              <bundle>ca_objects.carrier_type</bundle>
+            </placement>
+            <placement code="ca_attribute_material_characteristics13">
+              <bundle>ca_objects.material_characteristics</bundle>
+            </placement>
+            <placement code="ca_attribute_specific_component_number20" typeRestrictions="moving_component">
+              <bundle>ca_objects.specific_component_number</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Actual Component Number</setting>
+                <setting name="add_label" locale="en_US">Actual Component Number</setting>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_storage_format9" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.storage_format</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_resolution19" typeRestrictions="moving_analog,moving_component">
+              <bundle>ca_objects.resolution</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_projection_characteristics18">
+              <bundle>ca_objects.projection_characteristics</bundle>
+            </placement>
+            <placement code="ca_attribute_sound_characteristics19">
+              <bundle>ca_objects.sound_characteristics</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationStandard" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.instantiationStandard</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationGenerations" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.instantiationGenerations</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="add_label" locale="en_US">Add instantiation generations</setting>
+                <setting name="label" locale="en_US">Element Type</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationFileSize" typeRestrictions="moving_digital,moving_component">
+              <bundle>ca_objects.instantiationFileSize</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="label" locale="en_US">File Size</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationDuration" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.instantiationDuration</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="label" locale="en_US">Duration</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_frame_rate16" typeRestrictions="moving_analog,moving_component">
+              <bundle>ca_objects.frame_rate</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationLanguage" typeRestrictions="audio_analog,audio_digital,moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.instantiationLanguage</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="add_label" locale="en_US">Add language</setting>
+                <setting name="label" locale="en_US">Language</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_overall_condition34" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.overall_condition</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="item_status_id38" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>item_status_id</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_deterioration39" typeRestrictions="moving_component">
+              <bundle>ca_objects.deterioration</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_condition40" typeRestrictions="moving_component">
+              <bundle>ca_objects.condition</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_objects_deaccession25" typeRestrictions="moving_component">
+              <bundle>ca_objects_deaccession</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationEssenceTrack" typeRestrictions="moving_digital,moving_component">
+              <bundle>ca_objects.instantiationEssenceTrack</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="add_label" locale="en_US">Add essence track</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_rightsSummary_instantiation" typeRestrictions="audio_analog,audio_digital,moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.rightsSummary_instantiation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="add_label" locale="en_US">Add instantiation rights summary</setting>
+                <setting name="label" locale="en_US">Rights Summary</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_rightsLink_instantiation" typeRestrictions="audio_analog,audio_digital,moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.rightsLink_instantiation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="add_label" locale="en_US">Add instantiation rights link</setting>
+                <setting name="label" locale="en_US">Rights Link</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationAnnotation" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_objects.instantiationAnnotation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="add_label" locale="en_US">Add Object Notes</setting>
+                <setting name="label" locale="en_US">Object Notes</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationAnnotation47" typeRestrictions="moving_component">
+              <bundle>ca_objects.instantiationAnnotation</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Component Notes</setting>
+                <setting name="add_label" locale="en_US">Add Component Notes</setting>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_barcode44" typeRestrictions="moving_component">
+              <bundle>ca_objects.barcode</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_storage_locations30" typeRestrictions="moving_component">
+              <bundle>ca_storage_locations</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+            <placement code="ca_object_lots31">
+              <bundle>ca_object_lots</bundle>
+            </placement>
+            <placement code="ca_movements32" typeRestrictions="moving_analog,moving_component,moving_digital">
+              <bundle>ca_movements</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="restrict_to_relationship_types">part</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="restrict_to_types">movement</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">0</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationLocation" typeRestrictions="audio_digital,moving_digital,moving_component">
+              <bundle>ca_objects.instantiationLocation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="history_tracking_chronology48">
+              <bundle>history_tracking_chronology</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="media" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Media</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_object_representations">
+              <bundle>ca_object_representations</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="dontAllowRelationshipsToExistingRepresentations">0</setting>
+                <setting name="dontAllowAccessToImportDirectory">0</setting>
+                <setting name="dontShowPreferredLabel">0</setting>
+                <setting name="dontShowIdno">0</setting>
+                <setting name="dontShowStatus">0</setting>
+                <setting name="dontShowAccess">0</setting>
+                <setting name="dontShowTranscribe">0</setting>
+                <setting name="uiStyle">NEW_UI</setting>
+                <setting name="showBundlesForEditing">idno</setting>
+                <setting name="showBundlesForEditing">access</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="works" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Intellectual Content</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="label" locale="en_US">Related Intellectual Content</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="assets" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Instantiations</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="restrict_to_types">audio_analog</setting>
+                <setting name="restrict_to_types">audio_digital</setting>
+                <setting name="restrict_to_types">moving_analog</setting>
+                <setting name="restrict_to_types">moving_digital</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="label" locale="en_US">Related Instantiations</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="extension" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Extensions</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_attribute_pbcoreExtension">
+              <bundle>ca_objects.pbcoreExtension</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="add_label" locale="en_US">Add extension</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="screen_16_5" default="0" color="000000">
+          <labels>
+            <label locale="en_US">
+              <name>Components</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects_components_list1">
+              <bundle>ca_objects_components_list</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_entity_ui" type="ca_entities">
+      <labels>
+        <label locale="en_US">
+          <name>Standard entity editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Name</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_entity_attributes">
+              <bundle>ca_entities.entity_attributes</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="contact" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Contact info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_attribute_address">
+              <bundle>ca_entities.address</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_telephone">
+              <bundle>ca_entities.telephone</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_email">
+              <bundle>ca_entities.email</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="label" locale="en_US">Related instantiation</setting>
+                <setting name="add_label" locale="en_US">Add instantiation</setting>
+              </settings>
+            </placement>
+            <placement code="ca_occurrences">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="label" locale="en_US">Related intellectual content</setting>
+                <setting name="add_label" locale="en_US">Add intellectual content</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+            <placement code="ca_collections">
+              <bundle>ca_collections</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="useHierarchicalBrowser">0</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="keywords" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Keywords</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_list_items">
+              <bundle>ca_list_items</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+                <setting name="add_label" locale="en_US">Add term</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_lcshFull">
+              <bundle>ca_entities.lcshFull</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_place_ui" type="ca_places">
+      <labels>
+        <label locale="en_US">
+          <name>Standard place editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="place" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Place</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="source_id">
+              <bundle>source_id</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Name</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="location" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Location</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_location">
+              <bundle>hierarchy_location</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse">dont_force</setting>
+                <setting name="open_hierarchy">1</setting>
+                <setting name="auto_shrink">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_georeference">
+              <bundle>ca_places.georeference</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_geonames">
+              <bundle>ca_places.geonames</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="label" locale="en_US">Related instantiation</setting>
+              </settings>
+            </placement>
+            <placement code="ca_assets">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="label" locale="en_US">Related intellectual content</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+            <placement code="ca_collections">
+              <bundle>ca_collections</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="useHierarchicalBrowser">0</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="keywords" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Keywords</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_list_items">
+              <bundle>ca_list_items</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+                <setting name="add_label" locale="en_US">Add term</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_lcshFull">
+              <bundle>ca_places.lcshFull</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_occurrences_ui" type="ca_occurrences">
+      <labels>
+        <label locale="en_US">
+          <name>Standard occurrences editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="content" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="idno4">
+              <bundle>idno</bundle>
+            </placement>
+            <placement code="ca_attribute_pbcoreAssetType">
+              <bundle>ca_occurrences.pbcoreAssetType</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="label" locale="en_US">Content Type</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_pbcoreDate">
+              <bundle>ca_occurrences.pbcoreDate</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="label" locale="en_US">Date</setting>
+                <setting name="add_label" locale="en_US">Add Date</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_pbcoreIdentifier">
+              <bundle>ca_occurrences.pbcoreIdentifier</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="label" locale="en_US">Additional Identifiers</setting>
+                <setting name="add_label" locale="en_US">Add Additional Identifiers</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Primary Title</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_primary_title_details">
+              <bundle>ca_occurrences.primary_title_details</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_pbcoreTitle">
+              <bundle>ca_occurrences.pbcoreTitle</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="add_label" locale="en_US">Add Title</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_pbcoreDescription">
+              <bundle>ca_occurrences.pbcoreDescription</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_pbcoreGenre">
+              <bundle>ca_occurrences.pbcoreGenre</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_pbcoreSubject">
+              <bundle>ca_occurrences.pbcoreSubject</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_pbcoreAnnotation">
+              <bundle>ca_occurrences.pbcoreAnnotation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="add_label" locale="en_US">Add Notes</setting>
+                <setting name="label" locale="en_US">Notes</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="intellectual" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Intellectual Property</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_contributors">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="restrict_to_relationship_types">actor</setting>
+                <setting name="restrict_to_relationship_types">artist</setting>
+                <setting name="restrict_to_relationship_types">artistic_director</setting>
+                <setting name="restrict_to_relationship_types">author</setting>
+                <setting name="restrict_to_relationship_types">broadcast_engineer</setting>
+                <setting name="restrict_to_relationship_types">camera_operator</setting>
+                <setting name="restrict_to_relationship_types">caption_writer</setting>
+                <setting name="restrict_to_relationship_types">casting_director</setting>
+                <setting name="restrict_to_relationship_types">choreographer</setting>
+                <setting name="restrict_to_relationship_types">cinematographer</setting>
+                <setting name="restrict_to_relationship_types">co_producer</setting>
+                <setting name="restrict_to_relationship_types">composer</setting>
+                <setting name="restrict_to_relationship_types">costume_designer</setting>
+                <setting name="restrict_to_relationship_types">creator</setting>
+                <setting name="restrict_to_relationship_types">describer</setting>
+                <setting name="restrict_to_relationship_types">director</setting>
+                <setting name="restrict_to_relationship_types">director_of_photography</setting>
+                <setting name="restrict_to_relationship_types">editor</setting>
+                <setting name="restrict_to_relationship_types">executive_producer</setting>
+                <setting name="restrict_to_relationship_types">filmmaker</setting>
+                <setting name="restrict_to_relationship_types">foley_artist</setting>
+                <setting name="restrict_to_relationship_types">graphic_designer</setting>
+                <setting name="restrict_to_relationship_types">graphic_editor</setting>
+                <setting name="restrict_to_relationship_types">guest</setting>
+                <setting name="restrict_to_relationship_types">host</setting>
+                <setting name="restrict_to_relationship_types">interviewee</setting>
+                <setting name="restrict_to_relationship_types">interviewer</setting>
+                <setting name="restrict_to_relationship_types">lighting_technician</setting>
+                <setting name="restrict_to_relationship_types">make_up_artist</setting>
+                <setting name="restrict_to_relationship_types">moderator</setting>
+                <setting name="restrict_to_relationship_types">music_supervisor</setting>
+                <setting name="restrict_to_relationship_types">musician</setting>
+                <setting name="restrict_to_relationship_types">narrator</setting>
+                <setting name="restrict_to_relationship_types">panelist</setting>
+                <setting name="restrict_to_relationship_types">performer</setting>
+                <setting name="restrict_to_relationship_types">performing_group</setting>
+                <setting name="restrict_to_relationship_types">photographer</setting>
+                <setting name="restrict_to_relationship_types">producer</setting>
+                <setting name="restrict_to_relationship_types">production_unit</setting>
+                <setting name="restrict_to_relationship_types">recording_engineer</setting>
+                <setting name="restrict_to_relationship_types">reporter</setting>
+                <setting name="restrict_to_relationship_types">set_designer</setting>
+                <setting name="restrict_to_relationship_types">sound_designer</setting>
+                <setting name="restrict_to_relationship_types">sound_editor</setting>
+                <setting name="restrict_to_relationship_types">speaker</setting>
+                <setting name="restrict_to_relationship_types">technical_director</setting>
+                <setting name="restrict_to_relationship_types">video_engineer</setting>
+                <setting name="restrict_to_relationship_types">vocalist</setting>
+                <setting name="restrict_to_relationship_types">voiceover_artist</setting>
+                <setting name="restrict_to_relationship_types">writer</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="label" locale="en_US">Creators and Contributors</setting>
+                <setting name="add_label" locale="en_US">Add creators</setting>
+              </settings>
+            </placement>
+            <placement code="ca_publishers">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="restrict_to_relationship_types">publisher</setting>
+                <setting name="restrict_to_relationship_types">distributor</setting>
+                <setting name="restrict_to_relationship_types">presenter</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="label" locale="en_US">Publishers</setting>
+                <setting name="add_label" locale="en_US">Add publishers</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_rightsSummary_asset">
+              <bundle>ca_occurrences.rightsSummary_asset</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_rightsLink_asset">
+              <bundle>ca_occurrences.rightsLink_asset</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="assets" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Instantiations</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="label" locale="en_US">Related Instantiations</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="extension" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Extensions</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_attribute_pbcoreExtension">
+              <bundle>ca_occurrences.pbcoreExtension</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="add_label" locale="en_US">Add extension</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="related_assets" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Intellectual Content</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_occurrences">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="label" locale="en_US">Related Intellectual Content</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_collection_ui" type="ca_collections">
+      <labels>
+        <label locale="en_US">
+          <name>Collection editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_location">
+              <bundle>hierarchy_location</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse">dont_force</setting>
+                <setting name="open_hierarchy">1</setting>
+                <setting name="auto_shrink">0</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Title</setting>
+                <setting name="add_label" locale="en_US">Add Title</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_institution">
+              <bundle>ca_collections.institution</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_description">
+              <bundle>ca_collections.description</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="label" locale="en_US">Related Instantiations</setting>
+              </settings>
+            </placement>
+            <placement code="ca_occurrences">
+              <bundle>ca_occurrences</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="label" locale="en_US">Related Intellectual Content</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+            <placement code="ca_collections">
+              <bundle>ca_collections</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+                <setting name="useHierarchicalBrowser">0</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="keywords" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Keywords</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_list_items">
+              <bundle>ca_list_items</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+                <setting name="add_label" locale="en_US">Add term</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_storage_locations_ui" type="ca_storage_locations">
+      <labels>
+        <label locale="en_US">
+          <name>Storage locations editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_navigation">
+              <bundle>hierarchy_navigation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse">dont_force</setting>
+                <setting name="open_hierarchy">1</setting>
+                <setting name="auto_shrink">0</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Name</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_description">
+              <bundle>ca_storage_locations.description</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_objects6">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="restrict_to_types">moving_component</setting>
+                <setting name="restrict_to_types">moving_component</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_movements7">
+              <bundle>ca_movements</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="location" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Location</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_location">
+              <bundle>hierarchy_navigation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse">dont_force</setting>
+                <setting name="open_hierarchy">1</setting>
+                <setting name="auto_shrink">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="contents" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Contents</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_navigation">
+              <bundle>hierarchy_navigation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse">dont_force</setting>
+                <setting name="open_hierarchy">1</setting>
+                <setting name="auto_shrink">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="hierarchy_navigation">
+              <bundle>hierarchy_navigation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse">dont_force</setting>
+                <setting name="open_hierarchy">1</setting>
+                <setting name="auto_shrink">0</setting>
+              </settings>
+            </placement>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_object_lots_ui" type="ca_object_lots">
+      <labels>
+        <label locale="en_US">
+          <name>Object lots editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Lot title</setting>
+                <setting name="add_label" locale="en_US">Add lot title</setting>
+              </settings>
+            </placement>
+            <placement code="idno_stub">
+              <bundle>idno_stub</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Lot number</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_acquisition_date3">
+              <bundle>ca_object_lots.acquisition_date</bundle>
+            </placement>
+            <placement code="lot_status_id">
+              <bundle>lot_status_id</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_description">
+              <bundle>ca_object_lots.description</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="extent">
+              <bundle>extent</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="extent_units">
+              <bundle>extent_units</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_objects2">
+              <bundle>ca_objects</bundle>
+            </placement>
+            <placement code="ca_object_representations4">
+              <bundle>ca_object_representations</bundle>
+            </placement>
+            <placement code="ca_object_lots4">
+              <bundle>ca_object_lots</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="contents" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Contents</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Alternate lot titles</setting>
+                <setting name="add_label" locale="en_US">Add lot title</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_representation_annotation_ui" type="ca_representation_annotations">
+      <labels>
+        <label locale="en_US">
+          <name>Representation annotation editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Title</setting>
+                <setting name="add_label" locale="en_US">Add Title</setting>
+              </settings>
+            </placement>
+            <placement code="ca_representation_annotation_properties">
+              <bundle>ca_representation_annotation_properties</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="access">
+              <bundle>access</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="status">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="keywords" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Keywords</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_list_items">
+              <bundle>ca_list_items</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="relationships" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Relationships</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="ca_objects">
+              <bundle>ca_objects</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_entities">
+              <bundle>ca_entities</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_places">
+              <bundle>ca_places</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+        <screen idno="altnames" default="0">
+          <labels>
+            <label locale="en_US">
+              <name>Alternate names</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="nonpreferred_labels">
+              <bundle>nonpreferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="label" locale="en_US">Alternate names</setting>
+                <setting name="add_label" locale="en_US">Add name</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="ui_editor" type="ca_editor_uis" color="000000">
+      <labels>
+        <label locale="en_US">
+          <name>UI Editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic_24" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="editor_code">
+              <bundle>editor_code</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="color">
+              <bundle>color</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_editor_ui_type_restrictions">
+              <bundle>ca_editor_ui_type_restrictions</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_editor_ui_screens">
+              <bundle>ca_editor_ui_screens</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="is_system_ui">
+              <bundle>is_system_ui</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_users">
+              <bundle>ca_users</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_user_groups">
+              <bundle>ca_user_groups</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_user_roles">
+              <bundle>ca_user_roles</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="ui_screen_editor" type="ca_editor_ui_screens" color="CC0000">
+      <labels>
+        <label locale="en_US">
+          <name>UI Screen Editor</name>
+        </label>
+      </labels>
+      <screens>
+        <screen idno="basic_25" default="1">
+          <labels>
+            <label locale="en_US">
+              <name>Basic</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="preferred_labels">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="idno">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="color">
+              <bundle>color</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="is_default">
+              <bundle>is_default</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_editor_ui_screen_type_restrictions">
+              <bundle>ca_editor_ui_screen_type_restrictions</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_editor_ui_bundle_placements">
+              <bundle>ca_editor_ui_bundle_placements</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_users">
+              <bundle>ca_users</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_user_groups">
+              <bundle>ca_user_groups</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+            <placement code="ca_user_roles">
+              <bundle>ca_user_roles</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">bubbles</setting>
+                <setting name="expand_collapse_no_value">bubbles</setting>
+              </settings>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+    <userInterface code="standard_object_component_ui" type="ca_objects"
+      typeRestrictions="moving_component,moving_component" includeSubtypes="0">
+      <labels>
+        <label locale="en_US">
+          <name>Standard object component editor</name>
+        </label>
+      </labels>
+      <userAccess>
+        <permission user="herosen" access="edit" />
+      </userAccess>
+      <screens>
+        <screen idno="screen_26_0" default="0" color="000000">
+          <labels>
+            <label locale="en_US">
+              <name>Basic info</name>
+            </label>
+          </labels>
+          <bundlePlacements>
+            <placement code="status1">
+              <bundle>status</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+              </settings>
+            </placement>
+            <placement code="idno2">
+              <bundle>idno</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="usewysiwygeditor">1</setting>
+                <setting name="label" locale="en_US">Primary Identifier</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationIdentifier3">
+              <bundle>ca_objects.instantiationIdentifier</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Additional Identifiers</setting>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="preferred_labels4">
+              <bundle>preferred_labels</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="usewysiwygeditor">0</setting>
+                <setting name="use_list_format">lookup</setting>
+                <setting name="label" locale="en_US">Title</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_material_characteristics5">
+              <bundle>ca_objects.material_characteristics</bundle>
+            </placement>
+            <placement code="extent8">
+              <bundle>extent</bundle>
+            </placement>
+            <placement code="extent_units9">
+              <bundle>extent_units</bundle>
+            </placement>
+            <placement code="ca_attribute_specific_component_number10">
+              <bundle>ca_objects.specific_component_number</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Actual Component Number</setting>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_deterioration11" typeRestrictions="moving_component">
+              <bundle>ca_objects.deterioration</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_condition12">
+              <bundle>ca_objects.condition</bundle>
+            </placement>
+            <placement code="ca_objects_deaccession13">
+              <bundle>ca_objects_deaccession</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationEssenceTrack14" typeRestrictions="moving_component">
+              <bundle>ca_objects.instantiationEssenceTrack</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_instantiationAnnotation14">
+              <bundle>ca_objects.instantiationAnnotation</bundle>
+              <settings>
+                <setting name="label" locale="en_US">Component Notes</setting>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_attribute_barcode15">
+              <bundle>ca_objects.barcode</bundle>
+            </placement>
+            <placement code="ca_storage_locations16">
+              <bundle>ca_storage_locations</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="showCurrentOnly">0</setting>
+                <setting name="policy">current_location</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="useHierarchicalBrowser">1</setting>
+                <setting name="hierarchicalBrowserHeight">200px</setting>
+              </settings>
+            </placement>
+            <placement code="ca_objects18">
+              <bundle>ca_objects</bundle>
+            </placement>
+            <placement code="ca_object_lots17">
+              <bundle>ca_object_lots</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="dontShowRelationshipTypes">0</setting>
+                <setting name="dont_include_subtypes_in_type_restriction">0</setting>
+                <setting name="list_format">bubbles</setting>
+                <setting name="dontShowAddButton">0</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+                <setting name="minRelationshipsPerRow">0</setting>
+                <setting name="maxRelationshipsPerRow">0</setting>
+                <setting name="disableQuickadd">0</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="disableSorts">0</setting>
+                <setting name="showCount">0</setting>
+                <setting name="numPerPage">100</setting>
+                <setting name="showBatchEditorButton">0</setting>
+                <setting name="showSetRepresentationButton">0</setting>
+                <setting name="showReturnToHomeLocations">0</setting>
+              </settings>
+            </placement>
+            <placement code="ca_movements18">
+              <bundle>ca_movements</bundle>
+            </placement>
+            <placement code="ca_attribute_instantiationLocation20" typeRestrictions="moving_component">
+              <bundle>ca_objects.instantiationLocation</bundle>
+              <settings>
+                <setting name="readonly">0</setting>
+                <setting name="expand_collapse_value">dont_force</setting>
+                <setting name="expand_collapse_no_value">dont_force</setting>
+                <setting name="sortDirection">ASC</setting>
+                <setting name="dontShowDeleteButton">0</setting>
+              </settings>
+            </placement>
+            <placement code="history_tracking_chronology19">
+              <bundle>history_tracking_chronology</bundle>
+            </placement>
+          </bundlePlacements>
+        </screen>
+      </screens>
+    </userInterface>
+  </userInterfaces>
+  <relationshipTypes>
+    <relationshipTable name="ca_representation_annotations_x_entities">
+      <types>
+        <type code="depicts" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="describes" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>describes</typename>
+              <typename_reverse>is described by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_representation_annotations_x_objects">
+      <types>
+        <type code="depicts" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="illustrated" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is illustrated by</typename>
+              <typename_reverse>illustrates</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_representation_annotations_x_occurrences">
+      <types>
+        <type code="depicts" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="describes" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>describes</typename>
+              <typename_reverse>is described by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_representation_annotations_x_places">
+      <types>
+        <type code="depicts" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="describes" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>describes</typename>
+              <typename_reverse>is described by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_representation_annotations_x_vocabulary_terms">
+      <types>
+        <type code="describes" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_collections_x_collections">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_collections_x_vocabulary_terms">
+      <types>
+        <type code="described" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_entities_x_collections">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_entities_x_occurrences">
+      <types>
+        <type code="actor" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is actor in</typename>
+              <typename_reverse>has as actor</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="artist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is artist of</typename>
+              <typename_reverse>has as artist</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="artistic_director" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is artistic director of</typename>
+              <typename_reverse>has as artistic director</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="assoicate_producer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is associate producer of</typename>
+              <typename_reverse>has as assoicate producer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="author" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is author of</typename>
+              <typename_reverse>has as author</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="broadcast_engineer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is broadcast engineer of</typename>
+              <typename_reverse>has as broadcast engineer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="camera_operator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is camera operator of</typename>
+              <typename_reverse>has as camera operator</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="caption_writer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is caption writer of</typename>
+              <typename_reverse>has as caption writer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="casting_director" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is casting director of</typename>
+              <typename_reverse>has as casting director</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="choreographer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is choreographer of</typename>
+              <typename_reverse>has as choreographer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="cinematographer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is cinematographer of</typename>
+              <typename_reverse>has as cinematographer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="co_producer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is co-producer of</typename>
+              <typename_reverse>has as co-producer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="commentator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is commentator of</typename>
+              <typename_reverse>has as commentator</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="composer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is composer of</typename>
+              <typename_reverse>has as composer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="concept_artist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is concept artist of</typename>
+              <typename_reverse>has as concept artist</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="conductor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is conductor of</typename>
+              <typename_reverse>has as conductor</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="costume_designer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is costume designer of</typename>
+              <typename_reverse>has as costume designer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="creator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is creator of</typename>
+              <typename_reverse>has as creator</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="describer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is describer of</typename>
+              <typename_reverse>has as describer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="director" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is director of</typename>
+              <typename_reverse>has as director</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="director_of_photography" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is director of photography of</typename>
+              <typename_reverse>has as director of photography</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="editor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is editor of</typename>
+              <typename_reverse>has as editor</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="executive_producer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is executive producer of</typename>
+              <typename_reverse>has as executive producer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="filmmaker" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is filmmaker of</typename>
+              <typename_reverse>has as filmmaker</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="foley_artist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is foley artist of</typename>
+              <typename_reverse>has as foley artist</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="graphic_designer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is graphic designer of</typename>
+              <typename_reverse>has as graphic designer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="graphic_editor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is graphic editor of</typename>
+              <typename_reverse>has as graphic editor</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="guest" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is guest of</typename>
+              <typename_reverse>has as guest</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="host" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is host of</typename>
+              <typename_reverse>has as host</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="interviewee" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is interviewee of</typename>
+              <typename_reverse>has as interviewee</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="interviewer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is interviewer of</typename>
+              <typename_reverse>has as interviewer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="lighting_technician" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is lighting technican of</typename>
+              <typename_reverse>has as lighting technician</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="make_up_artist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is make-up artist of</typename>
+              <typename_reverse>has as make-up artist</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="moderator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is moderator of</typename>
+              <typename_reverse>has as moderator</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="music_supervisor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is music supervisor of</typename>
+              <typename_reverse>has as music supervisor</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="musician" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is musician of</typename>
+              <typename_reverse>has as musician</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="narrator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is narrator of</typename>
+              <typename_reverse>has as narrator</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="panelist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is panelist of</typename>
+              <typename_reverse>has as panelist</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="performer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is performer of</typename>
+              <typename_reverse>has as performer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="performing_group" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is performing group of</typename>
+              <typename_reverse>has as performing group</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="photographer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is photographer of</typename>
+              <typename_reverse>has as photographer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="producer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is producer of</typename>
+              <typename_reverse>has as producer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="production_unit" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is production unit of</typename>
+              <typename_reverse>has as production unit</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="recording_engineer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is recording engineer of</typename>
+              <typename_reverse>has as recording engineer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="reporter" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is reporter of</typename>
+              <typename_reverse>has as reporter</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="set_designer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is set designer of</typename>
+              <typename_reverse>has as set designer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="sound_designer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is sound designer of</typename>
+              <typename_reverse>has as sound designer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="sound_editor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is sound editor of</typename>
+              <typename_reverse>has as sound editor</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="speaker" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is speaker of</typename>
+              <typename_reverse>has as speaker</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="technical_director" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is technical director of</typename>
+              <typename_reverse>has as technical director</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="video_engineer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is video engineer of</typename>
+              <typename_reverse>has as video engineer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="vocalist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is vocalist of</typename>
+              <typename_reverse>has as vocalist</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="voiceover_artist" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is voiceover artist of</typename>
+              <typename_reverse>has as voiceover artist</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="writer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is writer of</typename>
+              <typename_reverse>has as writer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="publisher" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is publisher of</typename>
+              <typename_reverse>has as publisher</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="distributor" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is distributor of</typename>
+              <typename_reverse>has as distributor</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="presenter" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is presenter of</typename>
+              <typename_reverse>has presenter by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_entities_x_places">
+      <types>
+        <type code="birthplace" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>was born at</typename>
+              <typename_reverse>was birthplace of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="residence" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>resided at</typename>
+              <typename_reverse>was residence of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="workplace" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>worked at</typename>
+              <typename_reverse>was workplace of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="ownership" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>owned</typename>
+              <typename_reverse>was owned by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="built_by" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>built</typename>
+              <typename_reverse>was built by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_entities_x_vocabulary_terms">
+      <types>
+        <type code="described" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_entities_x_entities">
+      <types>
+        <type code="related" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="child" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is child of</typename>
+              <typename_reverse>is parent of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="spouse" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is spouse of</typename>
+              <typename_reverse>is spouse of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_list_items_x_list_items">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_collections">
+      <types>
+        <type code="part_of" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is part of</typename>
+              <typename_reverse>contains</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_entities">
+      <types>
+        <type code="donor" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>was donated by</typename>
+              <typename_reverse>is donor of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="provider" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>was provided by</typename>
+              <typename_reverse>is provider of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_occurrences">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_places">
+      <types>
+        <type code="originates" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>originates from</typename>
+              <typename_reverse>is origination location of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_collections">
+      <types>
+        <type code="part_of" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is part of</typename>
+              <typename_reverse>contains</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_entities">
+      <types>
+        <type code="creator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>created by</typename>
+              <typename_reverse>is creator</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="publisher" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>published by</typename>
+              <typename_reverse>is publisher</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="contributor" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>contributed by</typename>
+              <typename_reverse>is contributor</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_objects">
+      <types>
+        <type code="clone" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Clone Of</typename>
+              <typename_reverse>Cloned To</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="dub" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Dub Of</typename>
+              <typename_reverse>Dubbed To</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="format" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Format Of</typename>
+              <typename_reverse>Has Format</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="part_of" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Part Of</typename>
+              <typename_reverse>Has Part</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="replaced" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Replaced By</typename>
+              <typename_reverse>Replaces</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="source" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Has Source</typename>
+              <typename_reverse>Is Source of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_occurrences">
+      <types>
+        <type code="manifestation" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has as intellectual content</typename>
+              <typename_reverse>is instantiation of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_places">
+      <types>
+        <type code="created" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>was created at</typename>
+              <typename_reverse>was creation location of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="located" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>was located at</typename>
+              <typename_reverse>was location of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="depicts" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="describes" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>describes</typename>
+              <typename_reverse>is described by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_vocabulary_terms">
+      <types>
+        <type code="described" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="depicts" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>is depicted by</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_occurrences_x_collections">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_occurrences_x_occurrences">
+      <types>
+        <type code="related" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Related To</typename>
+              <typename_reverse>Is Related To</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="derived" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Has Derivative</typename>
+              <typename_reverse>Derived From</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="reference" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>References</typename>
+              <typename_reverse>Is Referenced By</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="part_of" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>Is Part Of</typename>
+              <typename_reverse>Has Part</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="version" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>Has Version</typename>
+              <typename_reverse>Is Version Of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_occurrences_x_vocabulary_terms">
+      <types>
+        <type code="describes" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="subject" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has subject</typename>
+              <typename_reverse>is subject</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_places_x_collections">
+      <types>
+        <type code="location" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is location of</typename>
+              <typename_reverse>is located in</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_places_x_occurrences">
+      <types>
+        <type code="site" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>was site of</typename>
+              <typename_reverse>occurred at</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_places_x_places">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_places_x_vocabulary_terms">
+      <types>
+        <type code="describes" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is described by</typename>
+              <typename_reverse>describes</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_representations_x_entities">
+      <types>
+        <type code="creator" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>was created by</typename>
+              <typename_reverse>is creator</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="rights_holder" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>rights held by</typename>
+              <typename_reverse>is rights holder</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_representations_x_occurrences">
+      <types>
+        <type code="depicts" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>depicts</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_representations_x_places">
+      <types>
+        <type code="depicts" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>depicts</typename>
+              <typename_reverse>depicts</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_vocabulary_terms">
+      <types>
+        <type code="subject" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has subject</typename>
+              <typename_reverse>is subject</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_representations_x_vocabulary_terms">
+      <types>
+        <type code="subject" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has subject</typename>
+              <typename_reverse>is subject</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_objects_x_storage_locations">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is located at</typename>
+              <typename_reverse>is location of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_storage_locations">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is located at</typename>
+              <typename_reverse>is location of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_objects">
+      <types>
+        <type code="loan" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has as part of</typename>
+              <typename_reverse>is part of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_entities">
+      <types>
+        <type code="lender" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is lent from (lender)</typename>
+              <typename_reverse>is lender of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="borrower" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>is borrowed from (borrower)</typename>
+              <typename_reverse>is borrower of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="authorizer" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is authorized by</typename>
+              <typename_reverse>is authorizer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_objects">
+      <types>
+        <type code="part" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has as part of</typename>
+              <typename_reverse>is part of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_object_lots">
+      <types>
+        <type code="part" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has as part of</typename>
+              <typename_reverse>is part of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_entities">
+      <types>
+        <type code="authorizer" default="0">
+          <labels>
+            <label locale="en_US">
+              <typename>was authorized by</typename>
+              <typename_reverse>was authorizer</typename_reverse>
+            </label>
+          </labels>
+        </type>
+        <type code="mover" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>was moved by</typename>
+              <typename_reverse>was mover</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_movements">
+      <types>
+        <type code="location" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is located at</typename>
+              <typename_reverse>is location of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_tour_stops_x_objects">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_tour_stops_x_entities">
+      <types>
+        <type code="subject" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has subject</typename>
+              <typename_reverse>is subject</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_tour_stops_x_places">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is located at</typename>
+              <typename_reverse>is location of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_tour_stops_x_occurrences">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_tour_stops_x_collections">
+      <types>
+        <type code="part" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has as part of</typename>
+              <typename_reverse>is part of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_tour_stops_x_vocabulary_terms">
+      <types>
+        <type code="subject" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has subject</typename>
+              <typename_reverse>is subject</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_tour_stops_x_tour_stops">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_representations_x_collections">
+      <types>
+        <type code="depicts" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>part of</typename>
+              <typename_reverse>part of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_representations_x_storage_locations">
+      <types>
+        <type code="depicts" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>current location</typename>
+              <typename_reverse>current location</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_representations_x_object_representations">
+      <types>
+        <type code="depicts" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>related</typename>
+              <typename_reverse>related</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_collections">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_object_lots">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_occurrences">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_places">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_storage_locations">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_vocabulary_terms">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_loans">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_collections">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_occurrences">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_places">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_storage_locations">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_vocabulary_terms">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_movements">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_places_x_storage_locations">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_occurrences_x_storage_locations">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_storage_locations_x_vocabulary_terms">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_storage_locations_x_storage_locations">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_object_representations">
+      <types>
+        <type code="part" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has as part of</typename>
+              <typename_reverse>is part of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_loans_x_object_representations">
+      <types>
+        <type code="part_of" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>contains</typename>
+              <typename_reverse>part of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_movements_x_object_representations">
+      <types>
+        <type code="part" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>has as part of</typename>
+              <typename_reverse>is part of</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+    <relationshipTable name="ca_object_lots_x_object_lots">
+      <types>
+        <type code="related" default="1">
+          <labels>
+            <label locale="en_US">
+              <typename>is related to</typename>
+              <typename_reverse>is related to</typename_reverse>
+            </label>
+          </labels>
+        </type>
+      </types>
+    </relationshipTable>
+  </relationshipTypes>
+  <roles>
+    <role code="admin">
+      <name>Administrators</name>
+      <description>Confers actions needed by those administering the system</description>
+      <actions>
+        <action>is_administrator</action>
+        <action>can_set_access_control</action>
+        <action>can_view_logs</action>
+        <action>can_set_access_control</action>
+        <action>can_configure_user_interfaces</action>
+        <action>can_configure_metadata_elements</action>
+        <action>can_configure_relationship_types</action>
+        <action>can_configure_locales</action>
+        <action>can_view_configuration_check</action>
+        <action>can_manage_system_search_forms</action>
+        <action>can_manage_system_bundle_displays</action>
+      </actions>
+    </role>
+    <role code="cataloguer">
+      <name>Cataloguers</name>
+      <description>Confers actions needed by those editing catalogue entries</description>
+      <actions>
+        <action>can_search</action>
+        <action>can_quicksearch</action>
+        <action>can_browse</action>
+        <action>can_set_preferences</action>
+        <action>can_create_adv_search_forms</action>
+        <action>can_edit_adv_search_forms</action>
+        <action>can_delete_adv_search_forms</action>
+        <action>can_use_adv_search_forms</action>
+        <action>can_use_adv_search_forms</action>
+        <action>can_create_ca_bundle_displays</action>
+        <action>can_edit_ca_bundle_displays</action>
+        <action>can_delete_ca_bundle_displays</action>
+        <action>can_use_ca_bundle_displays</action>
+        <action>can_create_user_groups</action>
+        <action>can_create_sets</action>
+        <action>can_edit_sets</action>
+        <action>can_delete_sets</action>
+        <action>can_view_sets</action>
+        <action>can_create_ca_objects</action>
+        <action>can_edit_ca_objects</action>
+        <action>can_delete_ca_objects</action>
+        <action>can_search_ca_objects</action>
+        <action>can_browse_ca_objects</action>
+        <action>can_create_ca_object_lots</action>
+        <action>can_edit_ca_object_lots</action>
+        <action>can_delete_ca_object_lots</action>
+        <action>can_search_ca_object_lots</action>
+        <action>can_browse_ca_object_lots</action>
+        <action>can_create_ca_entities</action>
+        <action>can_edit_ca_entities</action>
+        <action>can_delete_ca_entities</action>
+        <action>can_search_ca_entities</action>
+        <action>can_browse_ca_entities</action>
+        <action>can_create_ca_places</action>
+        <action>can_edit_ca_places</action>
+        <action>can_delete_ca_places</action>
+        <action>can_search_ca_places</action>
+        <action>can_browse_ca_places</action>
+        <action>can_create_ca_occurrences</action>
+        <action>can_edit_ca_occurrences</action>
+        <action>can_delete_ca_occurrences</action>
+        <action>can_search_ca_occurrences</action>
+        <action>can_browse_ca_occurrences</action>
+        <action>can_create_ca_collections</action>
+        <action>can_edit_ca_collections</action>
+        <action>can_delete_ca_collections</action>
+        <action>can_search_ca_collections</action>
+        <action>can_browse_ca_collections</action>
+        <action>can_create_ca_storage_locations</action>
+        <action>can_edit_ca_storage_locations</action>
+        <action>can_delete_ca_storage_locations</action>
+        <action>can_search_ca_storage_locations</action>
+        <action>can_browse_ca_storage_locations</action>
+        <action>can_create_ca_lists</action>
+        <action>can_edit_ca_lists</action>
+        <action>can_delete_ca_lists</action>
+      </actions>
+    </role>
+    <role code="researcher">
+      <name>Researcher</name>
+      <description>Allows users to only search and view - but not edit - catalogue entries</description>
+      <actions>
+        <action>can_search</action>
+        <action>can_quicksearch</action>
+        <action>can_browse</action>
+        <action>can_set_preferences</action>
+        <action>can_use_adv_search_forms</action>
+        <action>can_create_user_groups</action>
+        <action>can_create_sets</action>
+        <action>can_edit_sets</action>
+        <action>can_delete_sets</action>
+        <action>can_view_sets</action>
+        <action>can_search_ca_object_lots</action>
+        <action>can_browse_ca_object_lots</action>
+        <action>can_search_ca_objects</action>
+        <action>can_browse_ca_objects</action>
+        <action>can_search_ca_entities</action>
+        <action>can_browse_ca_entities</action>
+        <action>can_search_ca_places</action>
+        <action>can_browse_ca_places</action>
+        <action>can_search_ca_occurrences</action>
+        <action>can_browse_ca_occurrences</action>
+        <action>can_search_ca_collections</action>
+        <action>can_browse_ca_collections</action>
+        <action>can_search_ca_storage_locations</action>
+        <action>can_browse_ca_storage_locations</action>
+      </actions>
+    </role>
+    <role code="moderator">
+      <name>User content moderator</name>
+      <description>Allows users to moderate user generated tags and comments</description>
+      <actions>
+        <action>can_manage_user_comments</action>
+        <action>can_manage_user_tags</action>
+      </actions>
+    </role>
+  </roles>
+  <groups>
+    <group code="admin">
+      <name>Administrators</name>
+      <description>System administrators</description>
+      <roles>
+        <role>admin</role>
+        <role>cataloguer</role>
+        <role>researcher</role>
+        <role>moderator</role>
+      </roles>
+    </group>
+    <group code="cataloguer">
+      <name>Cataloguers</name>
+      <description>Users who can add and edit catalogue entries</description>
+      <roles>
+        <role>cataloguer</role>
+      </roles>
+    </group>
+  </groups>
+  <displays>
+</displays>
+  <searchForms>
+    <searchForm code="ca_objects_adv_search" type="ca_objects" system="1">
+      <labels>
+        <label locale="en_US">
+          <name>Extended search</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="form_width">3</setting>
+      </settings>
+      <groupAccess>
+        <permission group="admin" access="edit" />
+      </groupAccess>
+      <bundlePlacements>
+        <placement code="p1">
+          <bundle>ca_object_labels.name</bundle>
+          <settings>
+            <setting name="label" locale="en_US">Title</setting>
+          </settings>
+        </placement>
+        <placement code="p2">
+          <bundle>ca_objects.idno</bundle>
+        </placement>
+        <placement code="p3">
+          <bundle>ca_objects.type_id</bundle>
+        </placement>
+        <placement code="p4">
+          <bundle>ca_entity_labels.displayname</bundle>
+        </placement>
+        <placement code="p5">
+          <bundle>ca_objects.access</bundle>
+        </placement>
+        <placement code="p6">
+          <bundle>ca_objects.status</bundle>
+        </placement>
+      </bundlePlacements>
+    </searchForm>
+    <searchForm code="ca_entities_adv_search" type="ca_entities" system="1">
+      <labels>
+        <label locale="en_US">
+          <name>Extended search</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="form_width">3</setting>
+      </settings>
+      <groupAccess>
+        <permission group="admin" access="edit" />
+      </groupAccess>
+      <bundlePlacements>
+        <placement code="p7">
+          <bundle>ca_entity_labels.forename</bundle>
+        </placement>
+        <placement code="p8">
+          <bundle>ca_entity_labels.middlename</bundle>
+        </placement>
+        <placement code="p9">
+          <bundle>ca_entity_labels.surname</bundle>
+        </placement>
+        <placement code="p10">
+          <bundle>ca_entities.idno</bundle>
+        </placement>
+        <placement code="p11">
+          <bundle>ca_entities.type_id</bundle>
+        </placement>
+        <placement code="p12">
+          <bundle>ca_entities.access</bundle>
+        </placement>
+        <placement code="p13">
+          <bundle>ca_entities.status</bundle>
+        </placement>
+      </bundlePlacements>
+    </searchForm>
+    <searchForm code="ca_places_adv_search" type="ca_places" system="1">
+      <labels>
+        <label locale="en_US">
+          <name>Extended search</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="form_width">3</setting>
+      </settings>
+      <groupAccess>
+        <permission group="admin" access="edit" />
+      </groupAccess>
+      <bundlePlacements>
+        <placement code="p14">
+          <bundle>ca_place_labels.name</bundle>
+        </placement>
+        <placement code="p15">
+          <bundle>ca_places.idno</bundle>
+        </placement>
+        <placement code="p16">
+          <bundle>ca_places.type_id</bundle>
+        </placement>
+        <placement code="p17">
+          <bundle>ca_places.access</bundle>
+        </placement>
+        <placement code="p18">
+          <bundle>ca_places.status</bundle>
+        </placement>
+      </bundlePlacements>
+    </searchForm>
+    <searchForm code="ca_occurrences_adv_search" type="ca_occurrences" system="1">
+      <labels>
+        <label locale="en_US">
+          <name>Extended search</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="form_width">3</setting>
+      </settings>
+      <groupAccess>
+        <permission group="admin" access="edit" />
+      </groupAccess>
+      <bundlePlacements>
+        <placement code="p19">
+          <bundle>ca_occurrence_labels.name</bundle>
+          <settings>
+            <setting name="label" locale="en_US">Title</setting>
+          </settings>
+        </placement>
+        <placement code="p20">
+          <bundle>ca_occurrences.idno</bundle>
+        </placement>
+      </bundlePlacements>
+    </searchForm>
+    <searchForm code="ca_collections_adv_search" type="ca_collections" system="1">
+      <labels>
+        <label locale="en_US">
+          <name>Extended search</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="form_width">3</setting>
+      </settings>
+      <groupAccess>
+        <permission group="admin" access="edit" />
+      </groupAccess>
+      <bundlePlacements>
+        <placement code="p23">
+          <bundle>ca_collection_labels.name</bundle>
+        </placement>
+        <placement code="p24">
+          <bundle>ca_collections.idno</bundle>
+        </placement>
+        <placement code="p25">
+          <bundle>ca_collections.type_id</bundle>
+        </placement>
+        <placement code="p26">
+          <bundle>ca_collections.access</bundle>
+        </placement>
+        <placement code="p27">
+          <bundle>ca_collections.status</bundle>
+        </placement>
+      </bundlePlacements>
+    </searchForm>
+    <searchForm code="ca_storage_locations_adv_search" type="ca_storage_locations" system="1">
+      <labels>
+        <label locale="en_US">
+          <name>Extended search</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="form_width">3</setting>
+      </settings>
+      <groupAccess>
+        <permission group="admin" access="edit" />
+      </groupAccess>
+      <bundlePlacements>
+        <placement code="p28">
+          <bundle>ca_storage_location_labels.name</bundle>
+        </placement>
+        <placement code="p29">
+          <bundle>ca_storage_locations.type_id</bundle>
+        </placement>
+      </bundlePlacements>
+    </searchForm>
+    <searchForm code="ca_loans_adv_search" type="ca_loans" system="1">
+      <labels>
+        <label locale="en_US">
+          <name>Extended search</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="form_width">3</setting>
+      </settings>
+      <groupAccess>
+        <permission group="admin" access="edit" />
+      </groupAccess>
+      <bundlePlacements>
+        <placement code="p30">
+          <bundle>ca_loan_labels.name</bundle>
+        </placement>
+        <placement code="p31">
+          <bundle>ca_loans.type_id</bundle>
+        </placement>
+        <placement code="p32">
+          <bundle>ca_loans.idno</bundle>
+        </placement>
+      </bundlePlacements>
+    </searchForm>
+    <searchForm code="acq_advanced_search" type="ca_object_lots" system="1">
+      <labels>
+        <label locale="en_US">
+          <name>Acquisitions Advanced Search</name>
+        </label>
+      </labels>
+      <settings>
+        <setting name="form_width">3</setting>
+      </settings>
+      <userAccess>
+        <permission user="thelmaross" access="edit" />
+      </userAccess>
+      <bundlePlacements>
+        <placement code="p33">
+          <bundle>created</bundle>
+        </placement>
+        <placement code="p34">
+          <bundle>_fulltext</bundle>
+        </placement>
+        <placement code="p35">
+          <bundle>_generic</bundle>
+        </placement>
+        <placement code="p36">
+          <bundle>modified</bundle>
+        </placement>
+        <placement code="p37">
+          <bundle>ca_object_lots.lot_status_id</bundle>
+        </placement>
+        <placement code="p38">
+          <bundle>ca_objects.idno</bundle>
+        </placement>
+        <placement code="p39">
+          <bundle>ca_object_lots.acquisition_date</bundle>
+        </placement>
+        <placement code="p40">
+          <bundle>ca_object_lots.idno_stub</bundle>
+        </placement>
+      </bundlePlacements>
+    </searchForm>
+  </searchForms>
+</profile>


### PR DESCRIPTION
Implements [SYS-1817](https://uclalibrary.atlassian.net/browse/SYS-1817)

This pull request adds a complete custom installation profile, extended from the PBCore 2.1 profile we used initially. The profile reflects configuration for metadata elements, lists, and UI placements that I created locally to match specifications from FTVA. I synced my local instance to the `ca_dump_latest.sql.gz` from yesterday (5/8), so the pilot instance should not be far ahead from the basis for this profile, if at all.

The profile can be applied using the steps Zoe documented [here](https://uclalibrary.atlassian.net/wiki/x/HoCRPw), also summarized below. Note that I saved the profile in our `ucla_customizations/install/profiles/xml` directory, to maintain the separation between our local material and what come from the upstream CA repo.

#### Applying the profile
First run `./apply_ucla_customizations.sh` to copy the profile from the `ucla_customizations` profile into the directory that's mounted in the running container.

Assuming Docker Compose, then run:
`support/bin/caUtils update-installation-profile -n ucla_ftva.xml`

In my local instance, the update script took about two minutes to apply the complete profile. The script may print the following warning repeatedly:

`Warning: Base directory /var/www/html/app/tmp/purifier does not exist, please create or change using %Cache.SerializerPath in /var/www/html/vendor/ezyang/htmlpurifier/library/HTMLPurifier/DefinitionCache/Serializer.php on line 232`

but it should complete successfully:

```Setting up hierarchies
Processing metadata alerts
Performing post install tasks
Installation complete
Update of installation profile successful
Installation took       142 seconds
```

### Expected result
Below is a screen capture showing an example Object editor UI in my local instance after applying the profile. The most notable changes vis-à-vis the pilot are the Container-type elements applied to Objects and Object Components which group other sub-elements (e.g. `Material characteristics`, which contains `Base`, `Stock type`, and `Stock batch`) and the drop-downs that connect many metadata elements to their respective Lists. If you do not see these features (the Containers and drop-downs), then something likely went wrong.

![ca_screencap](https://github.com/user-attachments/assets/76bb5f30-b508-4cd5-8916-b0b14f5a6f36)

### Tests
I tested these steps locally in the following ways: 
1. by creating a fresh installation with the base PBCore 2.1 profile, then applying the new UCLA FTVA profile; and
2. by creating an instance synced with the database dump from the pilot, then applying the new profile.

Both these tests yielded the same state in the UI, with all the same metadata elements, lists, and UI placements. The data differed of course, as the fresh installation has no records while the pilot does. Importantly, applying the profile caused no apparent issues with the existing records in the pilot-synced instance.

[SYS-1817]: https://uclalibrary.atlassian.net/browse/SYS-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ